### PR TITLE
modify breadcrumb for latest BootstrapV4 class

### DIFF
--- a/components/breadcrumb.vue
+++ b/components/breadcrumb.vue
@@ -1,11 +1,11 @@
 <template>
   <ol class="breadcrumb">
-    <li v-for="item in list" :class="{active:item.active}">
+    <li class="breadcrumb-item" v-for="item in list" :class="{active:item.active}">
       <a href="#"
          @click.stop.prevent="onclick(item)"
-         v-if="item.active"
+         v-if="!item.active"
       >{{item.text}}</a>
-      <span v-if="!item.active">{{item.text}}</span>
+      <span v-if="item.active">{{item.text}}</span>
     </li>
   </ol>
 </template>


### PR DESCRIPTION
I modify breadcrumb for latest Bootstrap v4 cssclass. 
[http://v4-alpha.getbootstrap.com/components/breadcrumb/](http://v4-alpha.getbootstrap.com/components/breadcrumb/)


followings are my changes.

 * add `breadcrumb-item` css class to `li` tag.
 * change to reverse  `active` css class condition.

