### PR TITLE
Export individual components

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -95,4 +95,5 @@ if (typeof window !== 'undefined') {
   //require('../styles/style.css');
 }
 
-module.exports = plugin;
+module.exports = components;
+module.exports.default = plugin;


### PR DESCRIPTION
This would allow us to import individual components instead of "using" the plugin on the main `Vue` instance.

So, in addition of being able to use the whole plugin like before:

```js
// index.js
import Vue from 'vue'
import BootstrapVue from 'bootstrap-vue'

Vue.use('BootstrapVue')
```
We could also instead import and use components individually.

```js
// components/Hello.vue
<template>
  <b-button-group vertical>
    <b-button>Left</b-button>
    <b-button>Middle</b-button>
    <b-button>Right</b-button>
  </b-button-group>
</template>

<script>
import { bButtonGroup, bButton } from 'bootstrap-vue'

export default {
  components: {
    bButtonGroup,
    bButton
  }
}
</script>
```