### PR TITLE
Fixed default export of plugin

### DIFF
--- a/components/components.js
+++ b/components/components.js
@@ -1,0 +1,74 @@
+import bAlert from './alert'
+import bBreadcrumb from './breadcrumb'
+import bButtonCheckbox from './button-checkbox'
+import bButtonGroup from './button-group'
+import bButtonRadio from './button-radio'
+import bButton from './button'
+import bCard from './card'
+import bCarousel from './carousel'
+import bCarouselSlide from './carousel'
+import bCollapse from './collapse'
+import bCollapseToggle from './collapse-toggle'
+import bDropdown from './dropdown'
+import bDropdownSelect from './dropdown-select'
+import bFormCheckbox from './form-checkbox'
+import bFormRadio from './form-radio'
+import bFormInput from './form-input'
+import bFormSelect from './form-select'
+import bFormTextarea from './form-textarea'
+import bJumbotron from './jumbotron'
+import bTags from './tags'
+import bListGroup from './list-group'
+import bListGroupItem from './list-group-item'
+import bMedia from './media'
+import bModal from './modal'
+import bNav from './nav'
+import bNavItem from './nav-item'
+import bNavItemDropdown from './nav-item-dropdown'
+import bNavbar from './navbar'
+import bPagination from './pagination'
+import bPopover from './popover'
+import bProgress from './progress'
+import bTables from './tables'
+import bTabs from './tabs'
+import bTab from './tab'
+import bTooltip from './tooltip'
+
+export {
+  bAlert,
+  bBreadcrumb,
+  bButtonCheckbox,
+  bButtonGroup,
+  bButtonRadio,
+  bButton as bButton,
+  bButton as bBtn,
+  bCard,
+  bDropdown,
+  bDropdownSelect,
+  bFormCheckbox,
+  bFormRadio,
+  bFormInput,
+  bFormSelect,
+  bFormTextarea,
+  bJumbotron,
+  bTags,
+  bMedia,
+  bModal,
+  bNavbar,
+  bPagination,
+  bPopover,
+  bProgress,
+  bTables,
+  bTooltip,
+  bTab,
+  bTabs,
+  bNav,
+  bNavItem,
+  bNavItemDropdown,
+  bListGroupItem,
+  bListGroup,
+  bCarouselSlide,
+  bCarousel,
+  bCollapse,
+  bCollapseToggle
+}

--- a/components/index.js
+++ b/components/index.js
@@ -1,84 +1,6 @@
-import bAlert from './alert'
-import bBreadcrumb from './breadcrumb'
-import bButtonCheckbox from './button-checkbox'
-import bButtonGroup from './button-group'
-import bButtonRadio from './button-radio'
-import bButton from './button'
-import bCard from './card'
-import carousel from './carousel'
-import carouselSlide from './carousel'
-import collapse from './collapse'
-import collapseToggle from './collapse-toggle'
-import bDropdown from './dropdown'
-import bDropdownSelect from './dropdown-select'
-import bFormCheckbox from './form-checkbox'
-import bFormRadio from './form-radio'
-import bFormInput from './form-input'
-import bFormSelect from './form-select'
-import bFormTextarea from './form-textarea'
-import bJumbotron from './jumbotron'
-import bTags from './tags'
-import listGroup from './list-group'
-import listGroupItem from './list-group-item'
-import bMedia from './media'
-import bModal from './modal'
-import nav from './nav'
-import navItem from './nav-item'
-import navItemDropdown from './nav-item-dropdown'
-import bNavbar from './navbar'
-import bPagination from './pagination'
-import bPopover from './popover'
-import bProgress from './progress'
-import bTables from './tables'
-import tabs from './tabs'
-import tab from './tab'
-import bTooltip from './tooltip'
-
-
-var components = {
-  bAlert,
-  bBreadcrumb,
-  bButtonCheckbox,
-  bButtonGroup,
-  bButtonRadio,
-  bButton,
-  bBtn: bButton,
-  bCard,
-  bDropdown,
-  bDropdownSelect,
-  bFormCheckbox,
-  bFormRadio,
-  bFormInput,
-  bFormSelect,
-  bFormTextarea,
-  bJumbotron,
-  bTags,
-  bMedia,
-  bModal,
-  bNavbar,
-  bPagination,
-  bPopover,
-  bProgress,
-  bTables,
-  bTooltip,
-  bTab: tab,
-  bTabs: tabs,
-  bNav: nav,
-  bNavItem: navItem,
-  bNavItemDropdown: navItemDropdown,
-
-  bListGroupItem: listGroupItem,
-  bListGroup: listGroup,
-
-  bCarouselSlide: carouselSlide,
-  bCarousel: carousel,
-
-  bCollapse: collapse,
-  bCollapseToggle: collapseToggle,
-};
+import * as components from './components';
 
 function plugin(Vue) {
-
   if (plugin.installed) {
     return;
   }
@@ -86,14 +8,13 @@ function plugin(Vue) {
   Object.keys(components).forEach(function (key) {
     Vue.component(key, components[key]);
   });
-
 }
 
 if (typeof window !== 'undefined') {
-  if (window.Vue)
+  if (window.Vue) {
     window.Vue.use(plugin);
-  //require('../styles/style.css');
+  }
 }
 
-module.exports = components;
-module.exports.default = plugin;
+export * from './components';
+export default plugin;

--- a/scripts/build
+++ b/scripts/build
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
-export node_env=production
+export NODE_ENV=production
 
 echo "Building commonjs version"
 webpack --colors --progress --config webpack.common.js --env production --display-error-details


### PR DESCRIPTION
Fixes the issues reported in https://github.com/bootstrap-vue/bootstrap-vue/pull/26#issuecomment-261690614.

Moved all components export into it's own `components.js` file because it was a lot of duplication otherwise, not the cleanest solution (having a file that just import/export) but it works.

@pi0 @sourcec0de this would result in `v0.3.9` if your good with these changes, or do you have another approach to suggest ?