### PR TITLE
Fixed issues on tabs/tab #34

### DIFF
--- a/components/tab.vue
+++ b/components/tab.vue
@@ -11,6 +11,7 @@ export default {
       return {
         fade: this.$parent.fade,
         animate: false,
+        active: false
       }
     },
     props: {
@@ -21,10 +22,6 @@ export default {
       title: {
         type: String,
         default: ''
-      },
-      active: {
-        type: Boolean,
-        default: false
       },
       disabled: {
         type: Boolean,

--- a/components/tabs.vue
+++ b/components/tabs.vue
@@ -71,16 +71,16 @@
         if (activeTab !== -1) {
           // setting animate to false will trigger fade out effect
           this.items[activeTab].active = false;
-          this.$children[activeTab].$set('animate', false);
-          this.$children[activeTab].$set('active', false)
+          this.$set(this.$children[activeTab], 'animate', false);
+          this.$set(this.$children[activeTab], 'active', false);
         }
 
         // set new active tab and animate (if fade flag is set to true)
-        this.$children[index].$set('active', true);
+        this.$set(this.$children[index], 'active', true);
         this._tabAnimation = setTimeout(() => {
           // setting animate to true will trigger fade in effect
           this.items[index].active = true;
-          this.$children[index].$set('animate', true);
+          this.$set(this.$children[index], 'animate', true);
           this.$root.$emit('changed::tab', this.items[index].id)
         }, this.fade ? TRANSITION_DURATION : 0)
       },


### PR DESCRIPTION
[https://vuejs.org/v2/guide/migration.html#vm-set-changed](https://vuejs.org/v2/guide/migration.html#vm-set-changed)

I also moved `active` from props to data because : 

> [Vue warn]: Avoid mutating a prop directly since the value will be overwritten whenever the parent component re-renders. Instead, use a data or computed property based on the prop's value. Prop being mutated: "active" (found in component <bTab>) 