### PR TITLE
Fixed issue #58

### DIFF
--- a/components/alert.vue
+++ b/components/alert.vue
@@ -45,14 +45,6 @@
             alertState() {
                 return !this.state || this.state === `default` ? `alert-success` : `alert-${this.state}`
             },
-            show: {
-                get: function () {
-                    return this.localShow;
-                },
-                set: function (value) {
-                    this.localShow = value;
-                }
-            },
         },
         watch: {
             show: function (newValue, oldValue) {


### PR DESCRIPTION
According to #58, we have the same name `show` between props and computed parts.

I analysed your code and i decided to remove the `show` computed part because `localShow` already return the `show` value in `data` part.

The component works on 2.1.8 and 2.1.7 without any error code now ;)