### PR TITLE
Popover re-design

### DIFF
--- a/components/popover.vue
+++ b/components/popover.vue
@@ -205,7 +205,7 @@
 
       // display popover if prop is set on load
       if (this.showState) {
-        this.showPopup();
+        this.showPopover();
       }
     },
 

--- a/components/popover.vue
+++ b/components/popover.vue
@@ -198,7 +198,7 @@
         this._trigger.addEventListener('mouseenter', (e) => _this._eventHandler(e));
         this._trigger.addEventListener('mouseleave', (e) => _this._eventHandler(e))
       }
-      if (this.triggers.indexOf('focus') !== -1 && this._trigger.tagName.toLowerCase() === 'input') {
+      if (this.triggers.indexOf('focus') !== -1) {
         this._trigger.addEventListener('focus', (e) => _this._eventHandler(e));
         this._trigger.addEventListener('blur', (e) => _this._eventHandler(e))
       }

--- a/components/popover.vue
+++ b/components/popover.vue
@@ -49,7 +49,7 @@
     },
     data() {
         return {
-            showState: this.state,
+            showState: this.show,
         }
     },
     computed: {
@@ -126,7 +126,7 @@
        */
       toggle(e, newState) {
         // change state
-        this.show = (typeof newState !== 'undefined') ? newState : !this.show;
+        this.showState = (typeof newState !== 'undefined') ? newState : !this.showState;
       },
 
       /**

--- a/components/popover.vue
+++ b/components/popover.vue
@@ -240,8 +240,6 @@
        * @param  {Object} e
        */
       eventHandler(e) {
-        console.log('Event: ' + e.type);
-
         // If this event is right after a previous successful event, ignore it
         if (this.useDebounce && this.lastEvent != null && e.timeStamp <= this.lastEvent + debounceMilliseconds) return;
 

--- a/components/popover.vue
+++ b/components/popover.vue
@@ -162,7 +162,7 @@
         // }
 
         // stop propagation to avoid accidental closing on ide::popover event
-        e.stopPropagation();
+        //e.stopPropagation();
 
         // hide popover
         if (e.type === 'click') {

--- a/components/popover.vue
+++ b/components/popover.vue
@@ -198,7 +198,7 @@
         this._trigger.addEventListener('mouseenter', (e) => _this._eventHandler(e));
         this._trigger.addEventListener('mouseleave', (e) => _this._eventHandler(e))
       }
-      if (this.triggers.indexOf('focus') !== -1) {
+      if (this.triggers.indexOf('focus') !== -1 && this._trigger.tagName.toLowerCase() === 'input') {
         this._trigger.addEventListener('focus', (e) => _this._eventHandler(e));
         this._trigger.addEventListener('blur', (e) => _this._eventHandler(e))
       }

--- a/components/popover.vue
+++ b/components/popover.vue
@@ -96,7 +96,7 @@
       show(newShow) {
         this.showState = newShow;
       },
-      
+
       /**
        * Affect 'show' state in response to status change
        * @param  {Boolean} newShowState
@@ -105,26 +105,7 @@
         this.$emit('showChange', newShowState);
 
         // Dispatch an event from the current vm that propagates all the way up to its $root
-        // element is shown
-        if (newShowState) {
-          // let tether do the magic, after element is shown
-          this._popover.style.display = 'block';
-          this._tether = new Tether({
-            element: this._popover,
-            target: this._trigger,
-            attachment: this.positionParameters.attachment,
-            targetAttachment: this.positionParameters.targetAttachment,
-          });
-          this.$root.$emit('shown::popover');
-
-          // element gets hidden
-        } else {
-          if (this._tether) {
-            this._popover.style.display = 'none';
-            this._tether.destroy()
-          }
-          this.$root.$emit('hidden::popover')
-        }
+        newShowState ? this.showPopover() : this.hidePopover();
       }
     },
 
@@ -137,6 +118,32 @@
       toggle(e, newState) {
         // change state
         this.showState = (typeof newState !== 'undefined') ? newState : !this.showState;
+      },
+
+      /**
+       * Display popover and fire event
+       */
+      showPopover() {
+        // let tether do the magic, after element is shown
+        this._popover.style.display = 'block';
+        this._tether = new Tether({
+          element: this._popover,
+          target: this._trigger,
+          attachment: this.positionParameters.attachment,
+          targetAttachment: this.positionParameters.targetAttachment,
+        });
+        this.$root.$emit('shown::popover');
+      },
+
+      /**
+       * Hide popover and fire event
+       */
+      hidePopover() {
+        if (this._tether) {
+          this._popover.style.display = 'none';
+          this._tether.destroy()
+        }
+        this.$root.$emit('hidden::popover');
       },
 
       /**
@@ -195,7 +202,13 @@
         this._trigger.addEventListener('focus', (e) => _this._eventHandler(e));
         this._trigger.addEventListener('blur', (e) => _this._eventHandler(e))
       }
+
+      // display popover if prop is set on load
+      if (this.showState) {
+        this.showPopup();
+      }
     },
+
     beforeDestroy() {
       // clean up listeners
       this._trigger.removeEventListener('click', () => _this._eventHandler());

--- a/components/popover.vue
+++ b/components/popover.vue
@@ -2,7 +2,7 @@
   <div>
     <span class="popover-trigger" ref="trigger"><slot></slot></span>
 
-    <div :class="['popover',popoverAlignment]" ref="popover">
+    <div tabindex="-1" :class="['popover',popoverAlignment]" ref="popover" @focus="$emit('focus')" @blur="$emit('blur')">
       <div class="popover-arrow"></div>
       <h3 class="popover-title" v-if="title">{{title}}</h3>
       <div class="popover-content">

--- a/components/popover.vue
+++ b/components/popover.vue
@@ -21,6 +21,12 @@
 <script>
   import Tether from 'tether'
 
+  const triggerListeners = {
+    click: {click: 'toggle'},
+    hover: {mouseenter: 'show', mouseleave: 'hide'},
+    focus: {focus: 'show', blur: 'hide'}
+  };
+
   export default {
     replace: true,
 
@@ -174,6 +180,14 @@
             this.toggle(e, false)
           }
         }
+      },
+
+      updateListeners() {
+
+      },
+
+      removeListeners() {
+
       }
     },
 
@@ -198,7 +212,7 @@
         this._trigger.addEventListener('mouseenter', (e) => _this._eventHandler(e));
         this._trigger.addEventListener('mouseleave', (e) => _this._eventHandler(e))
       }
-      if (this.triggers.indexOf('focus') !== -1 && this._trigger.tagName.toLowerCase() === 'input') {
+      if (this.triggers.indexOf('focus') !== -1) {
         this._trigger.addEventListener('focus', (e) => _this._eventHandler(e));
         this._trigger.addEventListener('blur', (e) => _this._eventHandler(e))
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-vue",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bootstrap 4 Components for Vue.js 2",
   "main": "build/bootstrap-vue.common.js",
   "license": "MIT",


### PR DESCRIPTION
This is a proposed major re-write for Popover. This makes breaking changes but given that it seems there has been little work on it since early on, it seemed worthwhile.

I tried to adopt as much of the official Bootstrap functionality as makes sense in a Vue framework context. This includes making changes to some of the property names to align with Bootstrap.

Previously, if both a property and a slot of the same name (either 'title' or 'content') is provided, then displaying the slot takes priority. This is more consistent with typical default VueJS behavior.

External control of the popover is provided, and appropriate events are provided parent code to respond to changes.

Determination of how to respond to events is simplified. When multiple event types are being monitored, a simple 'debounce' check is employed to make sure two quick switches don't occur in succession. In general, it's better to just rely on one trigger type except for 'click' and 'focus' which work pretty well together.