### PR TITLE
Added active status handling for collapse-trigger

### DIFF
--- a/components/collapse-toggle.vue
+++ b/components/collapse-toggle.vue
@@ -1,5 +1,5 @@
 <template>
-  <span @click.stop.prevent="toggle($event)">
+  <span @click.stop.prevent="toggle($event)" :class="{ active: isActive }">
     <slot></slot>
   </span>
 </template>
@@ -9,6 +9,11 @@
   export default {
     replace: true,
     computed: {},
+    data () {
+      return {
+        isActive: false
+      }
+    },
     props: {
       target: {
         type: String,
@@ -23,6 +28,9 @@
       toggle() {
         // if both attributes missing, ignore
         if (!this.target && !this.targetGroup) return;
+        
+        // switch active status
+        this.isActive = !this.isActive;
 
         // broadcast accordion toggle if both id and group are set otherwise broadcast collapse
         // we also use dispatch to tell other components about the change


### PR DESCRIPTION
Hi, I needed an "active" class toggle when the trigger for collapse is clicked.

Thought it may be helpful to keep track of open/close status there as well as in the actual collapsible item.