### PR TITLE
Move production dependencies out of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,19 +73,21 @@
       ]
     ]
   },
+  "dependencies": {
+    "bootstrap": "^4.0.0-alpha.5",
+    "tether": "latest",
+    "vue": "2.1.7"
+  },
   "devDependencies": {
     "babel-core": "latest",
     "babel-loader": "latest",
     "babel-preset-es2015": "latest",
-    "bootstrap": "^4.0.0-alpha.5",
     "css-loader": "latest",
     "highlightjs": "latest",
     "node-sass": "latest",
     "nuxt": "latest",
     "postcss-loader": "latest",
     "sass-loader": "latest",
-    "tether": "latest",
-    "vue": "2.1.7",
     "vue-analytics": "latest",
     "vue-loader": "latest",
     "vue-style-loader": "latest",


### PR DESCRIPTION
As far as I understand, the Vue, Tether and Bootstrap dependencies should be in the "dependencies" group, not the "devDependencies" group. The dev group is meant for dependencies required only when developing on THIS package. When another package pulls this one in to extend it or use it in its own project, as far as this package is concerned that is a production environment. If these compilation-required dependencies are in the "dev" packages group then NPM or Yarn will not pull them down to the parent project as required and expected. In my particular experience, I found I had to add Tether as a dependency in my own packages.json, which shouldn't be required.

I may misunderstand your intention here, and I'm comparatively novice so feel to ignore this if you disagree.