### PR TITLE
support tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
   "babel": {
     "presets": [
       [
-        "es2015"
+        "es2015",
+        { "modules": false }
       ]
     ]
   },


### PR DESCRIPTION
webpack understands the native import syntax, and uses it for [tree shaking](https://webpack.js.org/guides/hmr-react/#babel-config)

#### Packing size has decreased

Don't use

![image](https://cloud.githubusercontent.com/assets/3281438/22011333/87778718-dcc9-11e6-9ab4-5275db344e20.png)

use

![image](https://cloud.githubusercontent.com/assets/3281438/22011339/9045a528-dcc9-11e6-96ce-3edb99cbdf1b.png)
