### PR TITLE
Switch CSS class 'in' for 'show', fixes #63

### DIFF
--- a/components/modal.vue
+++ b/components/modal.vue
@@ -1,7 +1,7 @@
 <template>
   <div style="display: none">
     <div :id="id"
-         :class="{ modal:true,fade: fade, in: animateModal || !fade }"
+         :class="{ modal:true,fade: fade, show: animateModal || !fade }"
          style="display: block"
          @click="onClickOut($event)">
       <div :class="['modal-dialog','modal-'+size]" role="document" style="z-index: 9999">
@@ -18,7 +18,7 @@
         </div>
       </div>
     </div>
-    <div class="modal-backdrop" :class="{ fade: fade, in: animateBackdrop || !fade }"></div>
+    <div class="modal-backdrop" :class="{ fade: fade, show: animateBackdrop || !fade }"></div>
   </div>
 </template>
 
@@ -62,7 +62,7 @@
         this.$el.style.display = 'block';
         this._body = document.querySelector('body');
         const _this = this;
-        // wait for the display block, and then add class "in" class on the modal
+        // wait for the display block, and then add class "show" class on the modal
         this._modalAnimation = setTimeout(() => {
           _this.animateBackdrop = true;
           this._modalAnimation = setTimeout(() => {


### PR DESCRIPTION
Attention: I did very little testing on this, but "it works for me". I don't know where the "in" class originally came from (Bootstrap 3?). But in the documentation for Bootstrap 4 this class is never mentioned. Switching to "show" immediately fixed the modals for me.