### PR TITLE
Fix carousel indicators

### DIFF
--- a/components/carousel.vue
+++ b/components/carousel.vue
@@ -3,7 +3,7 @@
 
     <!-- Indicators -->
     <ol class="carousel-indicators" v-show="indicators">
-      <li v-for="(item,index) in slides" :class="{active:item == index}" @click="changeSlide(index)"></li>
+      <li v-for="(item,indicatorIndex) in slides" :class="{active:indicatorIndex === index}" @click="changeSlide(indicatorIndex)"></li>
     </ol>
 
     <!-- Wrapper for slides -->


### PR DESCRIPTION
Carousel indicators are not updating properly, because the same variable "index" is used in the loop and in the data property