### PR TITLE
Allow numbers as values for form inputs, closes #64

### DIFF
--- a/components/form-input.vue
+++ b/components/form-input.vue
@@ -52,7 +52,7 @@
         },
         props: {
             value: {
-                type: String,
+                type: [String, Number],
                 default: null
             },
             type: {


### PR DESCRIPTION
As discussed in #64 the prop validation should allow for Numbers as well.