### PR TITLE
Format form input on change

### DIFF
--- a/components/form-input.vue
+++ b/components/form-input.vue
@@ -8,6 +8,7 @@
             :placeholder="placeholder"
             :value="value"
             @input="onInput($event.target.value)"
+            @change="onChange($event.target.value)"
             ref="input"
     />
     <textarea
@@ -38,6 +39,9 @@
         },
         methods: {
             onInput(value) {
+                this.$emit('input', value);
+            },
+            onChange(value) {
                 if (this.formatter) {
                     let formattedValue = this.formatter(value);
                     if (formattedValue != value) {


### PR DESCRIPTION
When formatting on input event, the input field loses focus and makes it really difficult to enter the desired value. Formatting on change feels much more natural.