### PR TITLE
Add option to get class onto td of table

### DIFF
--- a/components/table.vue
+++ b/components/table.vue
@@ -12,7 +12,7 @@
         </thead>
         <tbody>
         <tr v-for="item in _items" :key="items_key" :class="[item.state?'table-'+item.state:null]">
-            <td v-for="(field,key) in fields">
+            <td v-for="(field,key) in fields" :class="field.class">
                 <slot :name="key" :value="item[key]" :item="item">{{item[key]}}</slot>
             </td>
         </tr>

--- a/components/table.vue
+++ b/components/table.vue
@@ -3,7 +3,7 @@
         <thead>
         <tr>
             <th @click="headClick(field,key)"
-                :class="[field.sortable?'sorting':null,sort===key?'sorting_'+(sortDesc?'desc':'asc'):'',field.class]"
+                :class="[field.sortable?'sorting':null,sort===key?'sorting_'+(sortDesc?'desc':'asc'):'',field.class?field.class:null]"
                 v-for="field,key in fields"
             >
                 {{field.label}}
@@ -12,7 +12,7 @@
         </thead>
         <tbody>
         <tr v-for="item in _items" :key="items_key" :class="[item.state?'table-'+item.state:null]">
-            <td v-for="(field,key) in fields" :class="field.class">
+            <td v-for="(field,key) in fields" :class="[field.class?field.class:null]">
                 <slot :name="key" :value="item[key]" :item="item">{{item[key]}}</slot>
             </td>
         </tr>


### PR DESCRIPTION
As an extension of #115 we needed to be able to access the `<td>`, so this uses the `field.class`.

Just a quick question, potentially this should have been a ternary that checks if field.class exists? Or is this simplistic method ok?