### PR TITLE
href prop isnt needed if object in to prop

### DIFF
--- a/components/nav-item.vue
+++ b/components/nav-item.vue
@@ -3,7 +3,7 @@
         <component
                 :class="classObject"
                 @click="onclick"
-                :href="href || to"
+                :href="hrefString"
                 :is="componentType"
                 active-class="active"
                 :to="to"
@@ -28,6 +28,9 @@
             },
             componentType() {
                 return this.to ? 'router-link' : 'a';
+            },
+            hrefString() {
+                return typeof this.to === 'object' ? this.href || undefined : this.href || this.to;
             }
         },
         props: {


### PR DESCRIPTION
If you use an object in to prop without using the href prop (for example if you use named routes) you will get href="[object Object]" in your html.
My pull request will fix this.