### PR TITLE
added explicit import of button to dropdown.vue

### DIFF
--- a/components/dropdown.vue
+++ b/components/dropdown.vue
@@ -32,7 +32,12 @@
 </template>
 
 <script>
+    import bButton from 'bootstrap-vue/components/button.vue'
+
     export default {
+        components: {
+            bButton
+        },
         data() {
             return {
                 show: false


### PR DESCRIPTION
another instance where we need to import the dependent components directly. similar to #99 and #98 