### PR TITLE
Enhancement of modal open/close transitions

### DIFF
--- a/components/modal.vue
+++ b/components/modal.vue
@@ -1,12 +1,19 @@
 <template>
     <div>
-        <div :id="id"
-             :class="['modal',fade?'fade':null,visible?'show':null]"
-             :style="{display:visible?'block':'none'}"
-             @click="onClickOut($event)">
-            <div :class="['modal-dialog','modal-'+size]">
-                <div class="modal-content">
-
+        <transition enter-class="hidden"
+                    enter-to-class="show"
+                    enter-active-class=""
+                    leave-class="show"
+                    leave-active-class=""
+                    leave-to-class="hidden"
+                    v-on:after-enter="afterEnter"
+        >
+            <div :id="id"
+                 v-show="visible"
+                 :class="['modal',{fade :fade}]"
+                 @click="onClickOut($event)">
+                <div :class="['modal-dialog','modal-'+size]">
+                    <div class="modal-content">
                     <div class="modal-header" v-if="!hideHeader">
                         <slot name="modal-header">
                             <h5 class="modal-title">
@@ -29,11 +36,13 @@
                         </slot>
                     </div>
 
+                    </div>
                 </div>
             </div>
-        </div>
+        </transition>
+
         <transition enter-class="hidden">
-            <div :class="['modal-backdrop','show',fade?'fade':null]" v-if="visible"></div>
+            <div :class="['modal-backdrop','show',{fade: fade}]" v-if="visible"></div>
         </transition>
     </div>
 </template>
@@ -42,6 +51,10 @@
     .hidden {
         opacity: 0 !important;
     }
+    .modal {
+        display:block;
+    }
+
 </style>
 
 <script>
@@ -118,7 +131,7 @@
                     return;
                 }
                 this.visible = false;
-                this.$root.$emit('hide::modal', this.id);
+                this.$root.$emit('hidden::modal', this.id);
                 this.body.classList.remove('modal-open');
             },
             $save() {
@@ -153,20 +166,23 @@
                 if (key === 27) { // 27 is esc
                     this.hide();
                 }
+            },
+            afterEnter: function(el){
+                el.classList.add('show');
             }
         },
         created() {
             this.$root.$on('show::modal', id => {
                 if (id === this.id) {
-                    this.show();
-                }
-            });
+                this.show();
+            }
+        });
 
             this.$root.$on('hide::modal', id => {
                 if (id === this.id) {
-                    this.hide();
-                }
-            });
+                this.hide();
+            }
+        });
         },
         mounted() {
             if (typeof document !== 'undefined') {

--- a/components/modal.vue
+++ b/components/modal.vue
@@ -169,7 +169,7 @@
                     this.hide();
                 }
             },
-            afterEnter: function(el){
+            afterEnter(el){
                 // add show class to keep el showed just after transition is ended, because transition removes all used classes
                 el.classList.add('show');
             }

--- a/components/modal.vue
+++ b/components/modal.vue
@@ -172,15 +172,15 @@
         created() {
             this.$root.$on('show::modal', id => {
                 if (id === this.id) {
-                this.show();
-            }
-        });
+                    this.show();
+                }
+            });
 
             this.$root.$on('hide::modal', id => {
                 if (id === this.id) {
-                this.hide();
-            }
-        });
+                    this.hide();
+                }
+            });
         },
         mounted() {
             if (typeof document !== 'undefined') {

--- a/components/modal.vue
+++ b/components/modal.vue
@@ -1,49 +1,47 @@
 <template>
     <div>
-        <transition enter-class="hidden"
-                    enter-to-class="show"
-                    enter-active-class=""
-                    leave-class="show"
-                    leave-active-class=""
-                    leave-to-class="hidden"
-                    v-on:after-enter="afterEnter"
+        <transition-group enter-class="hidden"
+                          enter-to-class="show"
+                          enter-active-class=""
+                          leave-class="show"
+                          leave-active-class=""
+                          leave-to-class="hidden"
+                          v-on:after-enter="afterEnter"
         >
-            <div :id="id"
+            <div key="modal" :id="id"
                  v-show="visible"
                  :class="['modal',{fade :fade}]"
                  @click="onClickOut($event)">
                 <div :class="['modal-dialog','modal-'+size]">
                     <div class="modal-content">
-                    <div class="modal-header" v-if="!hideHeader">
-                        <slot name="modal-header">
-                            <h5 class="modal-title">
-                                <slot name="modal-title">{{title}}</slot>
-                            </h5>
-                            <button type="button" class="close" aria-label="Close" @click="hide">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </slot>
-                    </div>
 
-                    <div class="modal-body">
-                        <slot></slot>
-                    </div>
+                        <div class="modal-header" v-if="!hideHeader">
+                            <slot name="modal-header">
+                                <h5 class="modal-title">
+                                    <slot name="modal-title">{{title}}</slot>
+                                </h5>
+                                <button type="button" class="close" aria-label="Close" @click="hide">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </slot>
+                        </div>
 
-                    <div class="modal-footer" v-if="!hideFooter">
-                        <slot name="modal-footer">
-                            <b-btn variant="secondary" @click="$close">{{closeTitle}}</b-btn>
-                            <b-btn variant="primary" @click="$save">{{saveTitle}}</b-btn>
-                        </slot>
-                    </div>
+                        <div class="modal-body">
+                            <slot></slot>
+                        </div>
+
+                        <div class="modal-footer" v-if="!hideFooter">
+                            <slot name="modal-footer">
+                                <b-btn variant="secondary" @click="$close">{{closeTitle}}</b-btn>
+                                <b-btn variant="primary" @click="$save">{{saveTitle}}</b-btn>
+                            </slot>
+                        </div>
 
                     </div>
                 </div>
             </div>
-        </transition>
-
-        <transition enter-class="hidden">
-            <div :class="['modal-backdrop','show',{fade: fade}]" v-if="visible"></div>
-        </transition>
+            <div key="modal-backdrop" :class="['modal-backdrop',{fade: fade}]" v-if="visible"></div>
+        </transition-group>
     </div>
 </template>
 

--- a/components/modal.vue
+++ b/components/modal.vue
@@ -12,6 +12,7 @@
                  v-show="visible"
                  :class="['modal',{fade :fade}]"
                  @click="onClickOut($event)">
+
                 <div :class="['modal-dialog','modal-'+size]">
                     <div class="modal-content">
 
@@ -40,6 +41,7 @@
                     </div>
                 </div>
             </div>
+
             <div key="modal-backdrop" :class="['modal-backdrop',{fade: fade}]" v-if="visible"></div>
         </transition-group>
     </div>
@@ -49,6 +51,8 @@
     .hidden {
         opacity: 0 !important;
     }
+
+    /* Make modal display as block instead of inline style, and because Vue's v-show deletes inline "display" style*/
     .modal {
         display:block;
     }
@@ -166,6 +170,7 @@
                 }
             },
             afterEnter: function(el){
+                // add show class to keep el showed just after transition is ended, because transition removes all used classes
                 el.classList.add('show');
             }
         },

--- a/components/modal.vue
+++ b/components/modal.vue
@@ -169,7 +169,7 @@
                     this.hide();
                 }
             },
-            afterEnter(el){
+            afterEnter(el) {
                 // add show class to keep el showed just after transition is ended, because transition removes all used classes
                 el.classList.add('show');
             }


### PR DESCRIPTION
This PR is for issue #147 
1. Added and properly configured global vue transition-group to cover both modal and backdrop. 
2. Made small local fix to Bootstrap's `.modal` class.
3. Added transition callback on after-enter event to modal stay showed.
4. chanded emmited event to `hidden ` at the hide method. 
