### PR TITLE
Added maxwidth property to popover

### DIFF
--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -174,10 +174,10 @@
                     targetAttachment: this.placementParameters.targetAttachment
                 };
             },
-            
+
             setPopoverStyle() {
                 return this.popoverStyle;
-            },
+            }
 
         },
 

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -177,7 +177,7 @@
             popoverMaxWidth() {
                 var sizing = {
                     'v-sm': '75px',
-                    'sm': '250px',
+                    'sm': '276px',
                     'md': '450px',
                     'lg': '575px',
                     'v-lg': '750px',

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -110,7 +110,7 @@
                 },
                 validator(value) {
                     return typeof value === 'object';
-                },
+                }
             }
         },
 

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -103,7 +103,7 @@
                     return value >= 0;
                 }
             },
-            maxWidth: {
+            maxwidth: {
                 type: String,
                 default: 'sm',
                 validator(value) {
@@ -176,7 +176,7 @@
             //Sets max-width manually for each option
             popoverMaxWidth() {
                 var sizing = {
-                    'v-sm': '100px',
+                    'v-sm': '75px',
                     'sm': '250px',
                     'md': '450px',
                     'lg': '575px',
@@ -184,7 +184,7 @@
                 };
 
                 return {
-                    'max-width': sizing[this.maxWidth],
+                    'max-width': sizing[this.maxwidth],
                 };
             }
             

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -2,8 +2,7 @@
     <div>
         <span ref="trigger"><slot></slot></span>
 
-        <div tabindex="-1" :class="['popover',popoverAlignment]" ref="popover" @focus="$emit('focus')"
-             @blur="$emit('blur')">
+        <div tabindex="-1" :class="['popover',popoverAlignment]" ref="popover" @focus="$emit('focus')" @blur="$emit('blur')" v-bind:style="popoverMaxWidth">
             <div class="popover-arrow"></div>
             <h3 class="popover-title" v-if="title" v-html="title"></h3>
             <div class="popover-content">
@@ -103,6 +102,13 @@
                 validator(value) {
                     return value >= 0;
                 }
+            },
+            maxWidth: {
+                type: String,
+                default: 'sm',
+                validator(value) {
+                    return ['v-sm', 'sm', 'md', 'lg', 'v-lg'].indexOf(value) !== -1;
+                }
             }
         },
 
@@ -165,7 +171,23 @@
                     attachment: this.placementParameters.attachment,
                     targetAttachment: this.placementParameters.targetAttachment
                 };
+            },
+
+            //Sets max-width manually for each option
+            popoverMaxWidth() {
+                var sizing = {
+                    'v-sm': '100px',
+                    'sm': '250px',
+                    'md': '450px',
+                    'lg': '575px',
+                    'v-lg': '750px',
+                };
+
+                return {
+                    'max-width': sizing[this.maxWidth],
+                };
             }
+            
         },
 
         watch: {

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -109,7 +109,7 @@
                     return null;
                 },
                 validator(value) {
-                    return typeof value === 'object';
+                    return (typeof value === 'object');
                 }
             }
         },

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -2,7 +2,7 @@
     <div>
         <span ref="trigger"><slot></slot></span>
 
-        <div tabindex="-1" :class="['popover',popoverAlignment]" ref="popover" @focus="$emit('focus')" @blur="$emit('blur')" :style="setPopoverStyle">
+        <div tabindex="-1" :class="['popover',popoverAlignment]" ref="popover" @focus="$emit('focus')" @blur="$emit('blur')" :style="popoverStyle">
             <div class="popover-arrow"></div>
             <h3 class="popover-title" v-if="title" v-html="title"></h3>
             <div class="popover-content">
@@ -105,12 +105,7 @@
             },
             popoverStyle: {
                 type: Object,
-                default() {
-                    return null;
-                },
-                validator(value) {
-                    return (typeof value === 'object');
-                }
+                default: null
             }
         },
 
@@ -173,12 +168,7 @@
                     attachment: this.placementParameters.attachment,
                     targetAttachment: this.placementParameters.targetAttachment
                 };
-            },
-
-            setPopoverStyle() {
-                return this.popoverStyle;
             }
-
         },
 
         watch: {

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -2,7 +2,7 @@
     <div>
         <span ref="trigger"><slot></slot></span>
 
-        <div tabindex="-1" :class="['popover',popoverAlignment]" ref="popover" @focus="$emit('focus')" @blur="$emit('blur')" v-bind:style="popoverMaxWidth">
+        <div tabindex="-1" :class="['popover',popoverAlignment]" ref="popover" @focus="$emit('focus')" @blur="$emit('blur')" :style="setPopoverStyle">
             <div class="popover-arrow"></div>
             <h3 class="popover-title" v-if="title" v-html="title"></h3>
             <div class="popover-content">
@@ -103,12 +103,14 @@
                     return value >= 0;
                 }
             },
-            maxwidth: {
-                type: String,
-                default: 'sm',
+            popoverStyle: {
+                type: Object,
+                default() {
+                    return null;
+                },
                 validator(value) {
-                    return ['v-sm', 'sm', 'md', 'lg', 'v-lg'].indexOf(value) !== -1;
-                }
+                    return typeof value === 'object';
+                },
             }
         },
 
@@ -172,22 +174,11 @@
                     targetAttachment: this.placementParameters.targetAttachment
                 };
             },
-
-            //Sets max-width manually for each option
-            popoverMaxWidth() {
-                var sizing = {
-                    'v-sm': '75px',
-                    'sm': '276px',
-                    'md': '450px',
-                    'lg': '575px',
-                    'v-lg': '750px',
-                };
-
-                return {
-                    'max-width': sizing[this.maxwidth],
-                };
-            }
             
+            setPopoverStyle() {
+                return this.popoverStyle;
+            },
+
         },
 
         watch: {


### PR DESCRIPTION
I used this library to show small forms on the click of a button and
overwriting the max-width that was set via CSS does not work for me, 
so I forked the repo and added these small changes. 

The only change is a small property 'maxwidth' that accepts the values 'v-sm', 'sm', 'md', 'lg' and 'v-lg'.
It's still only the max-width that changes and not the width itself and the default is still set to 276px, as per constraint, so the impact on users who do not want anything changed, will be nonexistant.