### PR TITLE
[Tabs] Not Null check

### DIFF
--- a/lib/components/tabs.vue
+++ b/lib/components/tabs.vue
@@ -135,8 +135,11 @@
         },
         mounted() {
             // Probe tabs
-            this.tabs = this.$slots.default.filter(tab => tab.componentInstance || false)
-                .map(tab => tab.componentInstance);
+            if (this.$slots.default) {
+                this.tabs = this.$slots.default.filter(tab => tab.componentInstance || false)
+                    .map(tab => tab.componentInstance);
+
+            }
 
             this.tabs.forEach(tab => {
                 this.$set(tab, 'fade', this.fade);


### PR DESCRIPTION
Check if $slots.default exists before init this.tabs array.
test case: realtime creation of tabs based on user actions, init with undefined or empty tabs iteractor.