### PR TITLE
[Table] Fixed pagination when filtered table

### DIFF
--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -119,9 +119,9 @@
                             regex = new RegExp('.*' + this.filter + '.*', 'ig');
                         }
                         items = items.filter(item => {
-                            let test = regex.test(toString(item));
+                            const test = regex.test(toString(item));
                             regex.lastIndex = 0;
-                            return test
+                            return test;
                         });
                     }
                 }

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -55,8 +55,7 @@
             },
             fields: {
                 type: Object,
-                default: () => {
-                }
+                default: () => {}
             },
             striped: {
                 type: Boolean,
@@ -91,8 +90,8 @@
                 default: null
             },
             value: {
-                type: Number,
-                default: 0
+                type: Array,
+                default: () => []
             }
         },
 
@@ -119,7 +118,11 @@
                         } else {
                             regex = new RegExp('.*' + this.filter + '.*', 'ig');
                         }
-                        items = items.filter(item => regex.test(toString(item)));
+                        items = items.filter(item => {
+                            let test = regex.test(toString(item));
+                            regex.lastIndex = 0;
+                            return test
+                        });
                     }
                 }
 
@@ -131,7 +134,9 @@
                         return this.sortDesc ? r : r * -1;
                     });
                 }
-                this.$emit('input', items.length);
+
+                this.$emit('input', items);
+
                 // Apply pagination
                 if (this.perPage) {
                     items = items.slice((this.currentPage - 1) * this.perPage, this.currentPage * this.perPage);

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -89,6 +89,10 @@
             itemsProvider: {
                 type: Function,
                 default: null
+            },
+            value: {
+                type: Number,
+                default: 0
             }
         },
 
@@ -127,12 +131,11 @@
                         return this.sortDesc ? r : r * -1;
                     });
                 }
-
+                this.$emit('input', items.length);
                 // Apply pagination
                 if (this.perPage) {
                     items = items.slice((this.currentPage - 1) * this.perPage, this.currentPage * this.perPage);
                 }
-
                 return items;
             }
         },


### PR DESCRIPTION
Fixed pagination by adding v-model to table, so it can throw outside count of filtered items, then we can pass this data to pagination as totalrows.

The another approach may be using `this.$root` as event bus for `table.emit('filtered', items.count)` and `pagination.on('filtered', function(totalrows){....})`.