### PR TITLE
Add an option for a custom tab-head

### DIFF
--- a/lib/components/tab.vue
+++ b/lib/components/tab.vue
@@ -1,11 +1,12 @@
 <template>
     <transition enter-to-class="show" leave-class="show" @after-enter="afterEnter" mode="out-in">
-        <div role="tabpanel" class="tab-pane"
+        <div role="tabpanel"
+             class="tab-pane"
              :class="[{fade, disabled, active: localActive}]"
-             v-if="localActive || !lazy" v-show="localActive || lazy"
-        ref="panel"
-   >
-       <slot></slot>
+             v-if="localActive || !lazy"
+             v-show="localActive || lazy"
+             ref="panel">
+             <slot></slot>
         </div>
     </transition>
 </template>
@@ -32,6 +33,10 @@
             title: {
                 type: String,
                 default: ''
+            },
+            headHtml: {
+                type: String,
+                default: null
             },
             disabled: {
                 type: Boolean,

--- a/lib/components/tabs.vue
+++ b/lib/components/tabs.vue
@@ -6,8 +6,11 @@
                     <a :class="['nav-link',{small: small, active: tab.localActive, disabled: tab.disabled}]"
                        :href="tab.href"
                        @click.prevent.stop="setTab(index)"
-                       v-html="tab.title"
-                    ></a>
+                       v-if="!tab.headHtml"
+                       >{{ tab.title }}</a>
+                    <div :class="['tab-head',{small: small, active: tab.localActive, disabled: tab.disabled}]"
+                         v-else
+                         v-html="tab.headHtml"></div>
                 </li>
                 <slot name="tabs"></slot>
             </ul>

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "rollup-plugin-uglify": "^1.0.1",
     "rollup-plugin-vue": "^2.3.1",
     "rollup-watch": "^3.2.2",
+    "vue": "2.2.5",
     "xo": "^0.18.1"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "rollup-plugin-uglify": "^1.0.1",
     "rollup-plugin-vue": "^2.3.1",
     "rollup-watch": "^3.2.2",
-    "vue": "2.2.5",
     "xo": "^0.18.1"
   },
   "xo": {


### PR DESCRIPTION
There use cases when you need custom tab heads that are not <a>.