### PR TITLE
Two minor fixes

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -15,7 +15,7 @@
             >
 
                 <div :class="['modal-dialog','modal-'+size]">
-                    <div class="modal-content">
+                    <div class="modal-content" @click.stop>
 
                         <div class="modal-header" v-if="!hideHeader">
                             <slot name="modal-header">
@@ -157,9 +157,9 @@
                     this.body.classList.remove('modal-open');
                 }
             },
-            onClickOut(e) {
+            onClickOut() {
                 // If backdrop clicked, hide modal
-                if (this.closeOnBackdrop && e.target.id && e.target.id === this.id) {
+                if (this.closeOnBackdrop) {
                     this.hide();
                 }
             },


### PR DESCRIPTION
I'm submitting two fixes:

- ~~Added the `id` prop to b-form-input. This is not necessary but it prevents Vue from complaining that the property is not defined~~
- I changed the behavior of b-modal's click events so that `closeOnBackdrop` has the intended behaviour. In particular:
  * I removed the `id` check is I want to use modals without setting any id
  * I capture click events on the modal's content. That way the modal only closes when the user clicks on the backdrop; not on the modal itself


