### PR TITLE
Use default id (b_UID) for checkbox, file and select.

### DIFF
--- a/lib/components/form-checkbox.vue
+++ b/lib/components/form-checkbox.vue
@@ -2,7 +2,7 @@
     <label :class="[inputClass,checkboxClass,custom?'custom-checkbox':null]">
         <input
                 type="checkbox"
-                :id="id"
+                :id="id || ('b_'+_uid)"
                 :name="name"
                 :value="value"
                 :disabled="disabled"

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -15,7 +15,7 @@
         <!-- Real Form input -->
         <input type="file"
                :name="name"
-               :id="id"
+               :id="id || ('b_'+_uid)"
                :disabled="disabled"
                ref="input"
                :accept="accept"

--- a/lib/components/form-select.vue
+++ b/lib/components/form-select.vue
@@ -1,7 +1,7 @@
 <template>
     <select :class="[inputClass,custom?'custom-select':null]"
             :name="name"
-            :id="id"
+            :id="id || ('b_'+_uid)"
             v-model="localValue"
             :disabled="disabled"
             ref="input"


### PR DESCRIPTION
This behavior already exists in the form-input and will ensure
a valid id exists for the label to reference when using the
form-fieldset component.