### PR TITLE
b-form-field fixed feedback class, & change choosing 'for' target ID

### DIFF
--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -86,7 +86,7 @@
                 type: Boolean,
                 default: true
             },
-            toggletext: {
+            toggleText: {
                 type: String,
                 default: 'Toggle Dropdown'
             }

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -114,10 +114,10 @@
         methods: {
             toggle() {
                 this.visible = !this.visible;
-				if (this.visible) {
-					// focus the dropdown-menu
-					this.$refs.menu.focus();
-				}
+                if (this.visible) {
+                    // focus the dropdown-menu
+                    this.$refs.menu.focus();
+                }
             },
             clickOutListener() {
                 this.visible = false;
@@ -129,42 +129,42 @@
                 } else {
                     this.toggle();
                 }
+            },
+            onEsc(e) {
+                if (!this.visible || !this.closeOnEsc) {
+                    return;
+                }
+                this.visble = false;
+                // Return focus to button/toggle
+                (this.split ? this.$refs.toggle : this.$refs.button).focus();
+                // In case dropdown inside Modal
+                e.stopPropagation();
+            },
+            onKeyMove(e, up) {
+                if (!this.visible || this.disabled) {
+                    return;
+                }
+                // get current list of enabled dropdown-items
+                // if ES6 then items = [...this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)')]
+                var items = [].slice.call(this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)'));
+                if (!items.length) {
+                    return;
+                }
+                items.forEach(function(i) {
+                    // ensure dropdown-items are not in tab sequence, but still focusable
+                    i.setAttribute('tabindex','-1');
+                }
+                var index = items.indexOf(e.target);
+                if (up) {
+                    index--;
+                } else if (index < items.length) {
+                    index++;
+                }
+                if (index < 0) {
+                    index = 0;
+				}
+                items[index].focus();
             }
-			onEsc(e) {
-				if (!this.visible || !this.closeOnEsc) {
-					return;
-				}
-				this.visble = false;
-				// Return focus to button/toggle
-				(this.split ? this.$refs.toggle : this.$refs.button).focus();
-				// In case dropdown inside Modal
-				e.stopPropagation();
-			},
-			onKeyMove(e, up) {
-				if (!this.visible || this.disabled) {
-					return;
-				}
-				// get current list of enabled dropdown-items
-				// if ES6 then items = [...this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)')]
-				var items = [].slice.call(this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)'));
-				if (!items.length) {
-					return;
-				}
-				items.forEach(function(i) {
-					// ensure dropdown-items are not in tab sequence, but still focusable
-					i.setAttribute('tabindex','-1');
-				}
-				var index = items.indexOf(e.target);
-				if (up) {
-					index--;
-				} else if (index < items.length) {
-					index++;
-				}
-				if (index < 0) {
-					index = 0;
-				}
-				items[index].focus();
-			}
         }
     };
 

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -26,10 +26,10 @@
         <div :class="['dropdown-menu',right?'dropdown-menu-right':'']"
              ref="menu"
              tabindex="-1"
-		     @keydown.esc="onEsc($event)"
-		     @keydown.up="onKeyMove($event,true)"
-		     @keydown.down="onKeyMove($event,false)"
-		     @keydown.tab="toggle"
+             @keydown.esc="onEsc($event)"
+             @keydown.up="onKeyMove($event,true)"
+             @keydown.down="onKeyMove($event,false)"
+             @keydown.tab="toggle"
         >
             <slot></slot>
         </div>
@@ -162,7 +162,7 @@
                 }
                 if (index < 0) {
                     index = 0;
-				}
+                }
                 items[index].focus();
             }
         }

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -153,7 +153,7 @@
                 items.forEach(function(i) {
                     // ensure dropdown-items are not in tab sequence, but still focusable
                     i.setAttribute('tabindex','-1');
-                }
+                });
                 var index = items.indexOf(e.target);
                 if (up) {
                     index--;

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -2,6 +2,7 @@
     <div :class="['dropdown','btn-group',visible?'show':'',dropup?'dropup':'']">
 
         <b-button :class="[split?'':'dropdown-toggle']"
+                  ref="button"
                   @click="click"
                   aria-haspopup="true"
                   :aria-expanded="visible"
@@ -13,15 +14,23 @@
 
         <b-button class="dropdown-toggle dropdown-toggle-split"
                   v-if="split"
+                  ref="toggle"
                   @click="toggle"
                   :variant="variant"
                   :size="size"
                   :disabled="disabled"
         >
-            <span class="sr-only">Toggle Dropdown</span>
+            <span class="sr-only">{{toggleText}}</span>
         </b-button>
 
-        <div :class="['dropdown-menu',right?'dropdown-menu-right':'']">
+        <div :class="['dropdown-menu',right?'dropdown-menu-right':'']"
+             ref="menu"
+             tabindex="-1"
+		     @keydown.esc="onEsc($event)"
+		     @keydown.up="onKeyMove($event,true)"
+		     @keydown.down="onKeyMove($event,false)"
+		     @keydown.tab="toggle"
+        >
             <slot></slot>
         </div>
 
@@ -72,6 +81,14 @@
             right: {
                 type: Boolean,
                 default: false
+            },
+            closeOnEsc: {
+                type: Boolean,
+                default: true
+            },
+            toggletext: {
+                type: String,
+                default: 'Toggle Dropdown'
             }
         },
         created() {
@@ -97,6 +114,10 @@
         methods: {
             toggle() {
                 this.visible = !this.visible;
+				if (this.visible) {
+					// focus the dropdown-menu
+					this.$refs.menu.focus();
+				}
             },
             clickOutListener() {
                 this.visible = false;
@@ -109,6 +130,41 @@
                     this.toggle();
                 }
             }
+			onEsc(e) {
+				if (!this.visible || !this.closeOnEsc) {
+					return;
+				}
+				this.visble = false;
+				// Return focus to button/toggle
+				(this.split ? this.$refs.toggle : this.$refs.button).focus();
+				// In case dropdown inside Modal
+				e.stopPropagation();
+			},
+			onKeyMove(e, up) {
+				if (!this.visible || this.disabled) {
+					return;
+				}
+				// get current list of enabled dropdown-items
+				// if ES6 then items = [...this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)')]
+				var items = [].slice.call(this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)'));
+				if (!items.length) {
+					return;
+				}
+				items.forEach(function(i) {
+					// ensure dropdown-items are not in tab sequence, but still focusable
+					i.setAttribute('tabindex','-1');
+				}
+				var index = items.indexOf(e.target);
+				if (up) {
+					index--;
+				} else if (index < items.length) {
+					index++;
+				}
+				if (index < 0) {
+					index = 0;
+				}
+				items[index].focus();
+			}
         }
     };
 

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -149,7 +149,7 @@
                 if (items.length > 0) {
                     return;
                 }
-                items.forEach( (i) => {
+                items.forEach(i => {
                     // Ensure dropdown-items are not in tab sequence, but still focusable
                     i.setAttribute('tabindex', '-1');
                 });

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -2,7 +2,6 @@
     <div :class="['dropdown','btn-group',visible?'show':'',dropup?'dropup':'']">
 
         <b-button :class="[split?'':'dropdown-toggle']"
-                  ref="button"
                   @click="click"
                   aria-haspopup="true"
                   :aria-expanded="visible"
@@ -14,23 +13,15 @@
 
         <b-button class="dropdown-toggle dropdown-toggle-split"
                   v-if="split"
-                  ref="toggle"
                   @click="toggle"
                   :variant="variant"
                   :size="size"
                   :disabled="disabled"
         >
-            <span class="sr-only">{{toggleText}}</span>
+            <span class="sr-only">Toggle Dropdown</span>
         </b-button>
 
-        <div :class="['dropdown-menu',right?'dropdown-menu-right':'']"
-             ref="menu"
-             tabindex="-1"
-             @keydown.esc="onEsc($event)"
-             @keydown.up="onKeyMove($event,true)"
-             @keydown.down="onKeyMove($event,false)"
-             @keydown.tab="toggle"
-        >
+        <div :class="['dropdown-menu',right?'dropdown-menu-right':'']">
             <slot></slot>
         </div>
 
@@ -81,14 +72,6 @@
             right: {
                 type: Boolean,
                 default: false
-            },
-            closeOnEsc: {
-                type: Boolean,
-                default: true
-            },
-            toggleText: {
-                type: String,
-                default: 'Toggle Dropdown'
             }
         },
         created() {
@@ -114,10 +97,6 @@
         methods: {
             toggle() {
                 this.visible = !this.visible;
-                if (this.visible) {
-                    // Focus the dropdown-menu
-                    this.$refs.menu.focus();
-                }
             },
             clickOutListener() {
                 this.visible = false;
@@ -129,40 +108,6 @@
                 } else {
                     this.toggle();
                 }
-            },
-            onEsc(e) {
-                if (!this.visible || !this.closeOnEsc) {
-                    return;
-                }
-                this.visble = false;
-                // Return focus to button/toggle
-                (this.split ? this.$refs.toggle : this.$refs.button).focus();
-                // In case dropdown inside Modal
-                e.stopPropagation();
-            },
-            onKeyMove(e, up) {
-                if (!this.visible || this.disabled) {
-                    return;
-                }
-                // Get current list of enabled dropdown-items
-                const items = [...this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)')];
-                if (items.length > 0) {
-                    return;
-                }
-                items.forEach(i => {
-                    // Ensure dropdown-items are not in tab sequence, but still focusable
-                    i.setAttribute('tabindex', '-1');
-                });
-                let index = items.indexOf(e.target);
-                if (up) {
-                    index--;
-                } else if (index < items.length) {
-                    index++;
-                }
-                if (index < 0) {
-                    index = 0;
-                }
-                items[index].focus();
             }
         }
     };

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -115,7 +115,7 @@
             toggle() {
                 this.visible = !this.visible;
                 if (this.visible) {
-                    // focus the dropdown-menu
+                    // Focus the dropdown-menu
                     this.$refs.menu.focus();
                 }
             },
@@ -144,17 +144,16 @@
                 if (!this.visible || this.disabled) {
                     return;
                 }
-                // get current list of enabled dropdown-items
-                // if ES6 then items = [...this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)')]
-                var items = [].slice.call(this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)'));
-                if (!items.length) {
+                // Get current list of enabled dropdown-items
+                const items = [...this.$refs.menu.querySelectorAll('.dropdown-item:not(.disabled)')];
+                if (items.length > 0) {
                     return;
                 }
-                items.forEach(function(i) {
-                    // ensure dropdown-items are not in tab sequence, but still focusable
-                    i.setAttribute('tabindex','-1');
+                items.forEach( (i) => {
+                    // Ensure dropdown-items are not in tab sequence, but still focusable
+                    i.setAttribute('tabindex', '-1');
                 });
-                var index = items.indexOf(e.target);
+                let index = items.indexOf(e.target);
                 if (up) {
                     index--;
                 } else if (index < items.length) {


### PR DESCRIPTION
Changed feedback text block from class 'form-text' to 'form-control-feedback' to convey state.

Added ARIA role="alert" to feedback div.

Changed the target select from first child of content to querySelector() of first input element in content. This selector is  configurable as a prop inputSelector and defaults to 'input, select, textarea'