### PR TITLE
added tab position option

### DIFF
--- a/lib/components/tabs.vue
+++ b/lib/components/tabs.vue
@@ -1,5 +1,9 @@
 <template>
     <div class="tabs">
+    <div v-if="position=='bottom'" :class="['tab-content',{'card-block': card}]" ref="tabsContainer">
+            <slot></slot>
+            <slot name="empty" v-if="!tabs || !tabs.length"></slot>
+        </div>
         <div :class="{'card-header': card}">
             <ul :class="['nav','nav-' + navStyle, card? 'card-header-'+navStyle: null]">
                 <li class="nav-item" v-for="(tab, index) in tabs">
@@ -15,7 +19,7 @@
                 <slot name="tabs"></slot>
             </ul>
         </div>
-        <div :class="['tab-content',{'card-block': card}]" ref="tabsContainer">
+        <div v-if="position=='top'" :class="['tab-content',{'card-block': card}]" ref="tabsContainer">
             <slot></slot>
             <slot name="empty" v-if="!tabs || !tabs.length"></slot>
         </div>
@@ -56,6 +60,10 @@
             lazy: {
                 type: Boolean,
                 default: false
+            },
+            position: {
+                type: String,
+                default: "top"
             }
         },
         watch: {


### PR DESCRIPTION
now tabs can be positioned below the tab-content. Styling has to be overridden because bootstrap doesn't support for tabs at bottom of tab-content.
new prop: position supports two options only, top and bottom