### PR TITLE
Add dropdown-header component

### DIFF
--- a/docs/components/dropdown/README.md
+++ b/docs/components/dropdown/README.md
@@ -5,6 +5,7 @@
 Simple usage:
 ```html
 <b-dropdown text="Dropdown" variant="success"  class="m-md-2">
+    <b-dropdown-header>This is a heading</b-dropdown-header>
     <b-dropdown-item>Action</b-dropdown-item>
     <b-dropdown-item>Another action</b-dropdown-item>
     <b-dropdown-divider></b-dropdown-divider>

--- a/lib/components/dropdown-header.vue
+++ b/lib/components/dropdown-header.vue
@@ -1,0 +1,16 @@
+<template>
+    <component :is="tag" class="dropdown-header">
+        <slot></slot>
+    </component>
+</template>
+
+<script>
+    export default {
+        props: {
+            tag: {
+                type: String,
+                default: 'h6'
+            }
+        }
+    };
+</script>

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -10,6 +10,7 @@ import bCollapse from './collapse.vue';
 import bDropdown from './dropdown.vue';
 import bDropdownItem from './dropdown-item.vue';
 import bDropdownDivider from './dropdown-divider.vue';
+import bDropdownHeader from './dropdown-header.vue';
 import bDropdownSelect from './dropdown-select.vue';
 import bForm from './form.vue';
 import bFormFieldset from './form-fieldset.vue';
@@ -49,6 +50,7 @@ export {
     bDropdown,
     bDropdownItem,
     bDropdownDivider,
+    bDropdownHeader,
     bDropdownSelect,
     bForm,
     bFormCheckbox,


### PR DESCRIPTION
Adds a  `dropdown-header` component:

```html
<b-drop-down>
  <b-dropdown-header>Header using h6 (dafault)</b-dropdown-header>
  <b-dropdown-item>Some Item</b-dropdown-item>
  <b-dropdown-header tag="h5">Header using h5</b-dropdown-header>
  <b-dropdown-item>Some other Item</b-dropdown-item>
<b-drop-down>
```