### PR TITLE
Disabled  dropdown item fix

### DIFF
--- a/lib/components/button.vue
+++ b/lib/components/button.vue
@@ -76,7 +76,12 @@
         },
         methods: {
             onclick(e) {
-                this.$emit('click', e);
+                if (this.disabled) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                } else {
+                    this.$emit('click', e);
+                }
             }
         }
     };

--- a/lib/components/dropdown-item.vue
+++ b/lib/components/dropdown-item.vue
@@ -1,7 +1,12 @@
 <template>
-    <a :is="itemType" class="dropdown-item" :to="to" :href="hrefString"  @click="click" tabindex="0">
-        <slot></slot>
-    </a>
+    <a :is="itemType"
+       :class="[dropdown-item,{ disabled: disabled}]"
+       :to="to"
+       :href="hrefString"
+       :disabled="disabled"
+       :tabindex="disabled ? '-1' : '0'"
+       @click="click"
+    ><slot></slot></a>
 </template>
 
 <script>

--- a/lib/components/link.vue
+++ b/lib/components/link.vue
@@ -1,7 +1,12 @@
 <template>
-    <a :is="componentType" :active-class="activeClass" :to="to" :href="hrefString" :exact="exact" @click="click">
-        <slot></slot>
-    </a>
+    <a :is="componentType"
+       :active-class="activeClass"
+       :disabled="disabled"
+       :to="to"
+       :href="hrefString"
+       :exact="exact"
+       @click="click"
+    ><slot></slot></a>
 </template>
 
 <script>
@@ -22,6 +27,10 @@
                 type: String,
                 default: 'active'
             },
+            disbled: {
+                type: Boolean,
+                default: false
+            },
             to: {
                 type: [String, Object],
                 default: null
@@ -37,8 +46,13 @@
         },
         methods: {
             click(e) {
-                this.$emit('click', e);
-                this.$root.$emit('shown::dropdown', this);
+                if (this.disabled) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                } else {
+                    this.$emit('click', e);
+                    this.$root.$emit('shown::dropdown', this);
+                }
             }
         }
     };

--- a/lib/components/link.vue
+++ b/lib/components/link.vue
@@ -2,6 +2,7 @@
     <a :is="componentType"
        :active-class="activeClass"
        :disabled="disabled"
+       :aria-disabled="disabled ? 'true' : 'false'"
        :to="to"
        :href="hrefString"
        :exact="exact"


### PR DESCRIPTION
I noticed that `dropdown-item`s were not reflecting the disabled state. See this fiddle for an example: https://jsfiddle.net/oeotafg1/2/

This PR adds in disabled handling in `b-dropdown-item`, `b-link` and `b-button`.

For items rendered as an `a` tag, it also prevents the click handler from firing, making it truly disabled.

Check it out and see if it makes sense.