### PR TITLE
Dropdown ARIA keyboard nav

### DIFF
--- a/lib/components/dropdown-divider.vue
+++ b/lib/components/dropdown-divider.vue
@@ -1,5 +1,5 @@
 <template>
-    <div role="separator" tabindex="-1" class="dropdown-divider"></div>
+    <div role="separator" class="dropdown-divider"></div>
 </template>
 
 <script>

--- a/lib/components/dropdown-divider.vue
+++ b/lib/components/dropdown-divider.vue
@@ -1,5 +1,5 @@
 <template>
-    <div role="separator" class="dropdown-divider"></div>
+    <div role="separator" tabindex="-1" class="dropdown-divider"></div>
 </template>
 
 <script>

--- a/lib/components/dropdown-header.vue
+++ b/lib/components/dropdown-header.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="tag" tabindex="-1" class="dropdown-header">
+    <component :is="tag" class="dropdown-header">
         <slot></slot>
     </component>
 </template>

--- a/lib/components/dropdown-header.vue
+++ b/lib/components/dropdown-header.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="tag" class="dropdown-header">
+    <component :is="tag" tabindex="-1" class="dropdown-header">
         <slot></slot>
     </component>
 </template>

--- a/lib/components/dropdown-item.vue
+++ b/lib/components/dropdown-item.vue
@@ -1,10 +1,10 @@
 <template>
     <a :is="itemType"
-       :class="[dropdown-item,{ disabled: disabled}]"
+       :class="[dropdown-item,{ disabled: disabled }]"
        :to="to"
        :href="hrefString"
        :disabled="disabled"
-       :tabindex="disabled ? '-1' : '0'"
+       tabindex="-1"
        @click="click"
     ><slot></slot></a>
 </template>

--- a/lib/components/dropdown-item.vue
+++ b/lib/components/dropdown-item.vue
@@ -5,6 +5,7 @@
        :href="hrefString"
        :disabled="disabled"
        tabindex="-1"
+       role="menuitem"
        @click="click"
     ><slot></slot></a>
 </template>

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -25,7 +25,7 @@
         <div ref="menu"
              role="menu"
              :class="['dropdown-menu',right?'dropdown-menu-right':'']"
-             @keydown.esc.stop.prevent="onEsc"
+             @keyup.esc="onEsc"
              @keydown.up="focusNext($event,true)"
              @keydown.down="focusNext($event,false)"
         ><slot></slot></div>
@@ -131,9 +131,13 @@
                 }
             },
             onEsc(e) {
-                this.visible = false;
-                // Return focus to original button
-                (this.split ? this.$refs.toggle : this.$refs.button).focus();
+                if (this.visible) {
+                    this.visible = false;
+                    // Return focus to original button
+                    (this.split ? this.$refs.toggle : this.$refs.button).focus();
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
             },
             onNext(e, up) {
                 if (!this.visible) {
@@ -150,7 +154,7 @@
                 if (up) {
                     index--;
                 } else if (index < items.length - 2) {
-                    index++
+                    index++;
                 }
                 if (index < 0) {
                     index = 0;

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -62,7 +62,7 @@
             toggleText: {
                 type: String,
                 default: 'Toggle Dropdown'
-            }
+            },
             size: {
                 type: String,
                 default: null

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -108,17 +108,21 @@
 
                 if (state) {
                     this.$root.$emit('shown::dropdown', this);
-                    // if this is a touch-enabled device we add extra
-                    // empty mouseover listeners to the body's immediate children;
-                    // only needed because of broken event delegation on iOS
-                    // https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
+                    /*
+                      If this is a touch-enabled device we add extra
+                      empty mouseover listeners to the body's immediate children;
+                      only needed because of broken event delegation on iOS
+                      https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
+                    */
                     if (document && 'ontouchstart' in document.documentElement) {
                         document.body.children.addEventListener('mouseover', this.noop);
                     }
                 } else {
                     this.$root.$emit('hidden::dropdown', this);
-                    // if this is a touch-enabled device we remove the extra
-                    // empty mouseover listeners we added for iOS support
+                    /*
+                      If this is a touch-enabled device we remove the extra
+                      empty mouseover listeners we added for iOS support
+                    */
                     if (document && 'ontouchstart' in document.documentElement) {
                         document.body.children.removeEventListener('mouseover', this.noop);
                     }
@@ -165,7 +169,7 @@
                 if (!this.visible) {
                     return;
                 }
-                
+
                 e.preventDefault();
                 e.stopPropagation();
 
@@ -173,12 +177,12 @@
                 if (items.length < 1) {
                     return;
                 }
-                
+
                 let index = items.indexOf(e.taqrget);
                 if (index < 0) {
                     return;
                 }
-                
+
                 if (up && index > 0) {
                     index--;
                 } else if (!up && index < items.length - 1) {
@@ -187,11 +191,10 @@
                 if (index < 0) {
                     index = 0;
                 }
-                
+
                 items[index].focus();
             },
             noop() {
-                return;
             }
         }
     };

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['dropdown','btn-group',visible?'show':'',dropup?'dropup':'']">
+    <div :class="['dropdown','btn-group',{dropup: dropup, show: visible}]">
 
         <b-button :class="{'dropdown-toggle': !split, 'btn-link': link}"
                   ref="button"

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -41,7 +41,7 @@
     import clickOut from '../mixins/clickout';
     import bButton from './button.vue';
 
-    const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled]';
+    const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled]),dropdown-header';
     
     export default {
         mixins: [
@@ -165,7 +165,7 @@
                     this.visible = false;
                 }
             },
-            onNext(e, up) {
+            focusNext(e, up) {
                 if (!this.visible) {
                     return;
                 }
@@ -178,8 +178,7 @@
                     return;
                 }
 
-                let index = items.indexOf(e.taqrget);
-
+                let index = items.indexOf(e.target);
                 if (up && index > 0) {
                     index--;
                 } else if (!up && index < items.length - 1) {

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -136,7 +136,7 @@
                     // Focus first non-dsabled item
                     const items = this.getItems();
                     if (items.length > 0) {
-                        items.[0].focus();
+                        items[0].focus();
                     }
                 }
             },

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -41,7 +41,7 @@
     import clickOut from '../mixins/clickout';
     import bButton from './button.vue';
 
-    const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled];
+    const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled]';
     
     export default {
         mixins: [

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -131,6 +131,11 @@
         },
         methods: {
             toggle() {
+                if (this.disabled) {
+                    this.visible = false;
+                    return;
+                }
+
                 this.visible = !this.visible;
                 if (this.visible) {
                     // Focus first non-dsabled item
@@ -144,6 +149,11 @@
                 this.visible = false;
             },
             click(e) {
+                if (this.disabled) {
+                    this.visible = false;
+                    return;
+                }
+
                 if (this.split) {
                     this.$emit('click', e);
                     this.$root.$emit('shown::dropdown', this);
@@ -194,7 +204,7 @@
                 return [...this.$refs.menu.querySelectorAll(ITEM_SELECTOR)];
             },
             noop() {
-                // Do nothing
+                // Do nothing event handler
             }
         }
     };

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -134,9 +134,9 @@
                 this.visible = !this.visible;
                 if (this.visible) {
                     // Focus first non-dsabled item
-                    const first = this.$refs.menu.querySelector(ITEM_SELECTOR);
-                    if (first) {
-                        first.focus();
+                    const items = this.getItems();
+                    if (items.length > 0) {
+                        items.[0].focus();
                     }
                 }
             },
@@ -154,10 +154,10 @@
             onEsc(e) {
                 if (this.visible) {
                     this.visible = false;
-                    // Return focus to original button
-                    (this.split ? this.$refs.toggle : this.$refs.button).focus();
                     e.preventDefault();
                     e.stopPropagation();
+                    // Return focus to original button
+                    (this.split ? this.$refs.toggle : this.$refs.button).focus();
                 }
             },
             onTab() {
@@ -173,15 +173,12 @@
                 e.preventDefault();
                 e.stopPropagation();
 
-                const items = [...this.$refs.menu.querySelectorAll(ITEM_SELECTOR)];
+                const items = this.getItems();
                 if (items.length < 1) {
                     return;
                 }
 
                 let index = items.indexOf(e.taqrget);
-                if (index < 0) {
-                    return;
-                }
 
                 if (up && index > 0) {
                     index--;
@@ -194,7 +191,11 @@
 
                 items[index].focus();
             },
+            getItems() {
+                return [...this.$refs.menu.querySelectorAll(ITEM_SELECTOR)];
+            },
             noop() {
+                // Do nothing
             }
         }
     };

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -95,7 +95,7 @@
                     this.visible = !this.visible;
                     if (this.visible) {
                         // Focus first item
-                        const items = getitems();
+                        const items = getItems();
                         if (items.length > 0) {
                             items[0].focus();
                         }

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -1,20 +1,20 @@
 <template>
-    <li :class="{'nav-item': true, show: visible, dropdown: !dropup, dropup: dropup}">
+    <li :class="['nav-item',{show: visible, dropdown: !dropup, dropup: dropup}]">
 
-        <a @click.stop.prevent="toggle($event)"
-           :class="['nav-link', dropdownToggle, {disabled:disabled}]"
+        <a :class="['nav-link', dropdownToggle, {disabled:disabled}]"
            href=""
            ref="button"
            :id="'b_dropdown_button_' + _uid"
            aria-haspopup="true"
            :aria-expanded="visible"
            :disabled="disabled"
+            @click.stop.prevent="toggle($event)"
         ><slot name="text">{{ text }}</slot></a>
 
-        <div role="menu"
+        <div :class="['dropdown-menu',{'dropdown-menu-right': right}"
+             role="menu"
              ref="menu"
              :aria-labelledby="'b_dropdown_button_' + _uid"
-             :class="{'dropdown-menu': true, 'dropdown-menu-right': rightAlignment}"
              @keyup.esc="onEsc"
              @keydown.tab="onTab"
              @keydown.up="focusNext($event,true)"
@@ -26,12 +26,12 @@
 
 <script>
     import clickOut from '../mixins/clickout';
-
-    const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled]),.dropdown-header';
+    import dDown from '../mixins/dropdown';
 
     export default {
         mixins: [
-            clickOut
+            clickOut,
+            dDown
         ],
         data() {
             return {
@@ -48,31 +48,7 @@
                 type: Boolean,
                 default: true
             },
-            text: {
-                type: String,
-                default: ''
-            },
-            dropup: {
-                type: Boolean,
-                default: false
-            },
-            rightAlignment: {
-                type: Boolean,
-                default: false
-            },
-            disabled: {
-                type: Boolean,
-                default: false
-            },
             class: ['class']
-        },
-        created() {
-            // To keep one dropdown opened at page
-            this.$root.$on('shown::dropdown', el => {
-                if (el !== this) {
-                    this.visible = false;
-                }
-            });
         },
         watch: {
             visible(state, old) {
@@ -88,63 +64,8 @@
             }
         },
         methods: {
-            toggle() {
-                if (this.disabled) {
-                    this.visible = false;
-                } else {
-                    this.visible = !this.visible;
-                    if (this.visible) {
-                        // Focus first item
-                        const items = this.getItems();
-                        if (items.length > 0) {
-                            items[0].focus();
-                        }
-                    }
-                }
-            },
             clickOutListener() {
                 this.visible = false;
-            },
-            onEsc(e) {
-                if (this.visible) {
-                    this.visible = false;
-                    e.preventDefault();
-                    e.stopPropagation();
-                    // Return focus to original button
-                    this.$refs.button.focus();
-                }
-            },
-            onTab() {
-                if (this.visible) {
-                    this.visible = false;
-                }
-            },
-            focusNext(e, up) {
-                if (!this.visible) {
-                    return;
-                }
-
-                e.preventDefault();
-                e.stopPropagation();
-
-                const items = this.getItems();
-                if (items.length < 1) {
-                    return;
-                }
-
-                let index = items.indexOf(e.target);
-                if (up && index > 0) {
-                    index--;
-                } else if (!up && index < items.length - 1) {
-                    index++;
-                }
-                if (index < 0) {
-                    index = 0;
-                }
-                items[index].focus();
-            },
-            getItems() {
-                return [...this.$refs.menu.querySelectorAll(ITEM_SELECTOR)];
             }
         }
     };

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -5,7 +5,7 @@
            :class="['nav-link', dropdownToggle]"
            href=""
            ref="button"
-           :id="b_dropdown_button_' + _uid"
+           :id="'b_dropdown_button_' + _uid"
            aria-haspopup="true"
            :aria-expanded="visible"
            :disabled="disabled"
@@ -13,7 +13,7 @@
 
         <div role="menu"
              ref="menu"
-             :aria-labelledby="b_dropdown_button_' + _uid"
+             :aria-labelledby="'b_dropdown_button_' + _uid"
              :class="{'dropdown-menu': true, 'dropdown-menu-right': rightAlignment}"
              @keyup.esc="onEsc"
              @keydown.tab="onTab"

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -95,7 +95,7 @@
                     this.visible = !this.visible;
                     if (this.visible) {
                         // Focus first item
-                        const items = getItems();
+                        const items = this.getItems();
                         if (items.length > 0) {
                             items[0].focus();
                         }

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -1,7 +1,7 @@
 <template>
-    <li :class="['nav-item',{show: visible, dropdown: !dropup, dropup: dropup}]">
+    <li :class="['nav-item',{dropdown: !dropup, dropup: dropup, show: visible}]">
 
-        <a :class="['nav-link', dropdownToggle, {disabled:disabled}]"
+        <a :class="['nav-link', dropdownToggle, {disabled: disabled}]"
            href=""
            ref="button"
            :id="'b_dropdown_button_' + _uid"

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -2,7 +2,7 @@
     <li :class="{'nav-item': true, show: visible, dropdown: !dropup, dropup: dropup}">
 
         <a @click.stop.prevent="toggle($event)"
-           :class="['nav-link', dropdownToggle]"
+           :class="['nav-link', dropdownToggle, {disabled:disabled}]"
            href=""
            ref="button"
            :id="'b_dropdown_button_' + _uid"

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -11,7 +11,7 @@
             @click.stop.prevent="toggle($event)"
         ><slot name="text">{{ text }}</slot></a>
 
-        <div :class="['dropdown-menu',{'dropdown-menu-right': right}"
+        <div :class="['dropdown-menu',{'dropdown-menu-right': right}]"
              role="menu"
              ref="menu"
              :aria-labelledby="'b_dropdown_button_' + _uid"

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,4 +1,4 @@
-const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled]),dropdown-header';
+const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled]),.dropdown-header';
 
 export default {
     props: {

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,0 +1,88 @@
+const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled]),dropdown-header';
+
+export default = {
+    props: {
+        split: {
+            type: Boolean,
+            default: false
+        },
+        text: {
+            type: String,
+            default: ''
+        },
+        dropup: {
+            type: Boolean,
+            default: false
+        },
+        disabled: {
+            type: Boolean,
+            default: false
+        },
+        right: {
+            type: Boolean,
+            default: false
+        }
+    },
+    created() {
+        this.$root.$on('shown::dropdown', el => {
+            // To keep one dropdown opened on page 
+            if (el !== this) {
+                this.visible = false;
+            }
+        });
+    },
+    methods: {
+        toggle() {
+            if (this.disabled) {
+                this.visible = false;
+                return;
+            }
+            this.visible = !this.visible;
+            if (this.visible) {
+                // Focus first non-dsabled item
+                const items = this.getItems();
+                if (items.length > 0) {
+                    items[0].focus();
+                }
+            }
+        },
+        onTab() {
+            if (this.visible) {
+                this.visible = false;
+            }
+        },
+        onEsc(e) {
+            if (this.visible) {
+                this.visible = false;
+                e.preventDefault();
+                e.stopPropagation();
+                // Return focus to original button
+                ((this.split && this.$refs.toggle) ? this.$refs.toggle : this.$refs.button).focus();
+            }
+        },
+        focusNext(e, up) {
+            if (!this.visible) {
+                return;
+            }
+            e.preventDefault();
+            e.stopPropagation();
+            const items = this.getItems();
+            if (items.length < 1) {
+                return;
+            }
+            let index = items.indexOf(e.target);
+            if (up && index > 0) {
+                index--;
+            } else if (!up && index < items.length - 1) {
+                index++;
+            }
+            if (index < 0) {
+                index = 0;
+            }
+            items[index].focus();
+        },
+        getItems() {
+            return [...this.$refs.menu.querySelectorAll(ITEM_SELECTOR)];
+        }
+    }
+};

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -25,7 +25,7 @@ export default {
     },
     created() {
         this.$root.$on('shown::dropdown', el => {
-            // To keep one dropdown opened on page 
+            // To keep one dropdown opened on page
             if (el !== this) {
                 this.visible = false;
             }

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,6 +1,6 @@
 const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled]),dropdown-header';
 
-export default = {
+export default {
     props: {
         split: {
             type: Boolean,


### PR DESCRIPTION
Adds in keyboard navigation to dropdown menus (and navbar dropdowns), suitable for both keyboard-only users and screen reader-users.

Keyboard handling based on boostrap's V4 code for dropdown at:
https://github.com/twbs/bootstrap/blob/v4-dev/js/src/dropdown.js
and closely follows the W3 ARIA best practices standard:
https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_general_within

This works similar to native `<select>` elements and OS menus:
- When the menu is opened, the first `.dropdown-item` or `.dropdown-header` is focused (`.dropdown-divider`s are ignored)
- Pressing cursor up/down will navigate the enabled menu items. Disabled items will be skipped.
- Pressing `ESC` while the menu is open/focused will close the menu and return focus to the menu toggle button.
- Hitting `TAB` while the menu is open/focused will close the menu and go to the next (or previous, if the `SHIFT-TAB` is pressed) focusable item on the page.

`dropdown-item`s now have the ARIA  `role="menuitem"`

The `.sr-only` toggle text  (for split dropdowns) can now be set via the prop `toggleText` on `<b-dropdown>` for better language/locale support. Defaults to _"Toggle Dropdown"_.

**Notes:**
- The original bootstrap V4 code ignores `dropdown-header`s for keyboard navigation, although I have added them in as otherwise they are not "visible" to screen reader users. Headers might provide more context to the items below them:
```html
<div class="dropdown-menu" role="menu">
  <h6 class="dropdown-header">User</h6>
  <a class="dropdown-item" href="#">Delete</a>
  <a class="dropdown-item" href="#">Show</a>
  <h6 class="dropdown-header">Group</h6>
  <a class="dropdown-item" href="#">Delete</a>
  <a class="dropdown-item" href="#">Show</a>
</div>
```
- The original Bootstrap V4 dropdown code didn't automatically focus the first item in the dropdown. This PR diverges from Bootstrap's code and more closely follows the W3 best practices.
- Bug fix: Menu toggle buttons now respect the `disabled` attribute.  If you had a disabled menu, clicking the button would still open it. This is now fixed

Please review at your leisure.

