### PR TITLE
b-carousel-slide: Trim down classes

### DIFF
--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="carousel-item" :style="{background,height}">
         <img class="d-block img-fluid" v-if="img" :src="img" :alt="imgAlt">
-        <div class="carousel-caption d-none d-md-block">
+        <div :class="{ 'carousel-caption': !!caption }">
             <h3 v-if="caption" v-html="caption"></h3>
             <p v-if="text" v-html="text"></p>
             <slot></slot>
@@ -25,7 +25,6 @@
             text: {
                 type: String
             },
-
             background: {
                 type: String
             },


### PR DESCRIPTION
Two fixes here for b-carousel-slide:

- The class carousel-caption was used even when caption was not set. Now it checks for it.
- The association of d-none and d-md-block used to make the content disappear on small viewport. This is taken from bootstrap's documentation and was intentional in there. The intent was to hide the *caption* on small viewport. As it's very specific and also affects the content I removed it. If you want the intended behaviour back I can work on it.