### PR TITLE
Add default b_UID to dropdown

### DIFF
--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -74,7 +74,7 @@
                 default: false
             },
             id: {
-                type String,
+                type: String,
                 default: null
             }
         },

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -1,5 +1,7 @@
 <template>
-    <div :class="['dropdown','btn-group',{dropup: dropup, show: visible}]">
+    <div :class="['dropdown','btn-group',{dropup: dropup, show: visible}]"
+         :id="id || ('b_' + _uid)"
+    >
 
         <b-button :class="{'dropdown-toggle': !split, 'btn-link': link}"
                   ref="button"
@@ -70,6 +72,10 @@
             link: {
                 type: Boolean,
                 default: false
+            },
+            id: {
+                type String,
+                default: null
             }
         },
         watch: {


### PR DESCRIPTION
Assigns a default `b_UID` to the dropdown if `id` not specified in props.