### PR TITLE
Better dropdown router-link click handling

### DIFF
--- a/lib/components/dropdown-item.vue
+++ b/lib/components/dropdown-item.vue
@@ -7,6 +7,7 @@
        tabindex="-1"
        role="menuitem"
        @click="click"
+       @click.native="click"
     >
         <slot></slot>
     </a>

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -32,12 +32,6 @@ export default {
         });
     },
     watch: {
-        $route() {
-            // Handle lack of router-link event bubbling
-            if (this.visible)
-                this.visible = false;
-            }
-        },
         visible(state, old) {
             if (state === old) {
                 return; // Avoid duplicated emits


### PR DESCRIPTION
Better workaround for #284, which handles closing the dropdown when the clicked `<router-link>` is also the current route.

Previous iteration of this fix used a `$route` watcher. This uses the `@click.native="click"` handler to listen for the click event.  `@click="click"` is still needed for non `<router-link>` dropdown items

This solution appears a bit cleaner,

Hacked together example: https://jsfiddle.net/tmorehouse/fv6btm53/

