### PR TITLE
Form input:  Add form-control-static support

### DIFF
--- a/lib/components/form-fieldset.vue
+++ b/lib/components/form-fieldset.vue
@@ -82,7 +82,7 @@
             },
             inputSelector: {
                 type: String,
-                default: 'input, select, textarea, .dropdown, .dropup'
+                default: 'input,select,textarea,.form-control,.form-control-static,.dropdown,.dropup'
             }
         }
     };

--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -1,5 +1,5 @@
 <template>
-    <input
+    <input  v-if="!static"
             :type="type"
             :value="value"
             :name="name"
@@ -19,6 +19,9 @@
             @focus="$emit('focus')"
             @blur="$emit('blur')"
     />
+    <p v-if="static" :id="id || ('b_'+_uid)" :class="['form-control-static',inputClass]">
+        {{ staticValue }}
+    </p>
 </template>
 
 <script>
@@ -29,6 +32,9 @@
         computed: {
             rowsCount() {
                 return (this.value || '').toString().split('\n').length;
+            },
+            staticValue() {
+                return this.formatter ? this.formatter(value) : value;
             }
         },
         methods: {
@@ -64,6 +70,10 @@
             type: {
                 type: String,
                 default: 'text'
+            },
+            static: {
+                type: Boolean,
+                default: false
             },
             placeholder: {
                 type: String,


### PR DESCRIPTION
Allows form-input to be rendered as a `p.form-control-static` via the addition of a new Boolean prop `static` (default `false`)

Switching the prop `static` to `true` will re-render the input as a bootstrap `form-control-static`:

```html
<p id="..." class="form-control-static ...">
    formatted value
</p>
```

Changing `static` back to `false` will re-render the original input element. Handy if you need to "lock" an input, but don't want to do a bunch of `v-if`s  (and don't like the bootstrap disabled/readonly stylings).
