### PR TITLE
Display modal as block when visible.

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -70,8 +70,8 @@
     }
 
     /* Make modal display as block instead of inline style, and because Vue's v-show deletes inline "display" style*/
-    .modal {
-        display: block !important;
+    .modal.show {
+        display: block;
     }
 </style>
 


### PR DESCRIPTION
Commit b76a37a84045e39a392ad2f44b2b84fa3cc5d706 flagged the
modal as display block !important, which overrides the inline
display: none added by v-show. The modal is not visible because
opacity is set to 0, but the dialog prevents interaction with
components below the dialog.

If the goal is to display:block when visible (v-show will remove
the inline display:none style), then the CSS could just select
.modal.show.

It is possible that this will fix #276 