### PR TITLE
Fix text slot on nav-item-dropdown.

### DIFF
--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -8,9 +8,8 @@
            :aria-expanded="visible"
            :disabled="disabled"
            @click.stop.prevent="toggle($event)"
-           v-html="text"
         >
-            <slot name="text"></slot>
+            <slot name="text"><span v-html="text"></span></slot>
         </a>
 
         <div :class="['dropdown-menu',{'dropdown-menu-right': right}]"


### PR DESCRIPTION
The use of v-html on the element wrapping the text slot prevents
it from being used, even when v-html is bound to null. Move the
v-html to a span inside the slot to fix.