### PR TITLE
b-carousel-slide: Hiding content for some viewport

### DIFF
--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="carousel-item" :style="{background,height}">
         <img class="d-block img-fluid" v-if="img" :src="img" :alt="imgAlt">
-        <div :class="{ 'carousel-caption': !!caption }">
+        <div :class="contentClasses">
             <h3 v-if="caption" v-html="caption"></h3>
             <p v-if="text" v-html="text"></p>
             <slot></slot>
@@ -18,7 +18,9 @@
             imgAlt: {
                 type: String
             },
-
+            contentVisibleUp: {
+                type: String
+            },
             caption: {
                 type: String
             },
@@ -30,6 +32,18 @@
             },
             height: {
                 type: String
+            }
+        },
+        computed: {
+            contentClasses() {
+                const classes = {
+                    'carousel-caption': Boolean(this.caption)
+                };
+                if (this.contentVisibleUp) {
+                    classes['d-none'] = true;
+                    classes[`d-${this.contentVisibleUp}-block`] = true;
+                }
+                return classes;
             }
         }
     };


### PR DESCRIPTION
I didn't meet the timeline I promised but here is the feature you requested!

I went for the most descriptive property name I could think of. If you want me to put `visible-size` as you suggested feel free to ask and I'll change it.

The setting is given for each slide. This may be unoptimal performance-wise but the implementation is very straightforward and, would a user want it for some reason, it allows to set different sizes for different slides in the same carousel.

Also, if you explain to me how to edit the documentation, I'd be happy to do so.