### PR TITLE
b-modal: Remove !important in display: block

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -71,7 +71,7 @@
 
     /* Make modal display as block instead of inline style, and because Vue's v-show deletes inline "display" style*/
     .modal {
-        display: block !important;
+        display: block;
     }
 </style>
 


### PR DESCRIPTION
Revert back the change from https://github.com/bootstrap-vue/bootstrap-vue/commit/eaf42348ea3808f290c75ef0a662d6685d55a598 and its previous commit.

I don't know what was the rationale for setting `!important` but it definitely caused a bug.
The modal's div was indeed hidden but overlayed the whole page content as `display` couldn't be set to `none`. In my particular case it caused every mouse input over it to be silently captured. This is one of the unintended behaviours it may have caused.

Paging @mosinve to discuss this.