### PR TITLE
Declared but Unused Method

### DIFF
--- a/examples/modals/demo.js
+++ b/examples/modals/demo.js
@@ -14,7 +14,7 @@ window.app = new Vue({
             }
 
             this.names.push(this.name);
-            this.name = '';
+            this.clearName();
         }
     }
 });


### PR DESCRIPTION
The `clearName()` method is declared but not used.