### PR TITLE
[modal] focusFirst timing tweak

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -250,7 +250,9 @@
                 if (!el) {
                     el = this.$refs.content;
                 }
-                el.focus();
+                if (el && el.focus) {
+                    el.focus();
+                }
             },
             returnFocusTo() {
                 if (this.return_focus) {

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -3,6 +3,7 @@
         <transition-group enter-class="hidden"
                           enter-to-class=""
                           enter-active-class=""
+                          @after-enter="focusFirst"
                           leave-class="show"
                           leave-active-class=""
                           leave-to-class="hidden"
@@ -184,10 +185,6 @@
                     // Handle constrained focus
                     document.addEventListener('focusin', this.enforceFocus, false);
                 }
-                this.$nextTick(function () {
-                    // Make sure DOM is updated before focusing
-                    this.focusFirst();
-                });
             },
             hide(isOK) {
                 if (!this.is_visible) {


### PR DESCRIPTION
Moved focusFirst to run when enter transition is complete.

Tests to ensure focusable element exists and can be focused.

Addressing issue #352