### PR TITLE
[pagination] ARIA attributes + Keyboard navigation

### DIFF
--- a/lib/components/pagination.vue
+++ b/lib/components/pagination.vue
@@ -8,50 +8,52 @@
                 :class="['btn','btn-'+secondaryVariant]"
                 :disabled="currentPage == 1 "
                 :aria-label="labelPrevPage"
-                @click.prevent="(currentPage == 1) ? _return : currentPage--">
+                @click.prevent="(currentPage == 1) ? _return : currentPage--"
+        >
             <span aria-hidden="true">&laquo;</span>
         </button>
 
         <button type="button"
-                :class="['btn','btn-'+secondaryVariant,isActivePage(1) ?  'active' : '']"
+                :class="['btn','btn-'+secondaryVariant,isActive(1)?'active':'']"
                 :aria-label="labelPage + ' 1'"
-                :aria-current="currentpage === 1 ? 'true' : 'false'"
+                :aria-current="isActive(1) ? 'true' : 'false'"
                 :aria-setsize="numberOfPages"
                 :aria-posinset="1"
                 @click.prevent="currentPage = 1"
-                v-show="showPrev">1
-        </button>
+                v-show="showPrev"
+        >1</button>
 
         <span:class="['btn','btn-'+secondaryVariant]" v-show="showPrev">...</span>
 
         <button type="button"
                 class="btn"
-                :class="[btnVariant(index),isActivePage(index + diff) ? 'active' : '',isActivePage(index + diff) ? '' : 'hidden-xs-down']"
+                :class="[btnVariant(index),isActive(index + diff)?'active':'',isActive(index + diff)?'':'hidden-xs-down']"
                 :aria-label="labelPage + ' ' + (index + diff)"
-                :aria-current="currentpage === (index + diff) ? 'true' : 'false'"
+                :aria-current="isActive(index + diff) ? 'true' : 'false'"
                 :aria-setsize="numberOfPages"
                 :aria-posinset="index + diff"
                 v-for="_,index in pageLinks"
-                @click.prevent="currentPage = index + diff">{{index + diff}}
-        </button>
+                @click.prevent="currentPage = index + diff"
+        >{{index + diff}}</button>
 
         <span :class="['btn','btn-'+secondaryVariant]" v-show="showNext">...</span>
 
         <button type="button"
-                :class="['btn','btn-'+secondaryVariant,isActivePage(numberOfPages) ? 'active' : '']"
+                :class="['btn','btn-'+secondaryVariant,isActive(numberOfPages) ? 'active' : '']"
                 :aria-label="labelPage + ' ' + numberOfPages"
-                :aria-current="currentpage === numberOfPages ? 'true' : 'false'"
+                :aria-current="isActive(numberOfPages) ? 'true' : 'false'"
                 :aria-setsize="numberOfPages"
                 :aria-posinset="numberOfPages"
                 v-show="showNext"
-                @click.prevent="currentPage = numberOfPages">{{numberOfPages}}
-        </button>
+                @click.prevent="currentPage = numberOfPages"
+        >{{numberOfPages}}</button>
 
         <button type="button"
                 :class="['btn','btn-'+secondaryVariant]"
                 :disabled="currentPage == numberOfPages"
                 :aria-label="labelNextPage"
-                @click.prevent="(currentPage == numberOfPages) ? _return : currentPage++">
+                @click.prevent="isActive(numberOfPages) ? _return : currentPage++"
+        >
             <span aria-hidden="true">&raquo;</span>
         </button>
 
@@ -76,8 +78,8 @@
             btnSize() {
                 return !this.size || this.size === `default` ? `` : `pagination-${this.size}`;
             },
-            isActivePage(p) {
-                return p === currentPage ? true : false;
+            isActive(page) {
+                return page === currentPage ? true : false;
             },
             pageLinks() {
                 if (this.currentPage > this.numberOfPages) {

--- a/lib/components/pagination.vue
+++ b/lib/components/pagination.vue
@@ -149,7 +149,7 @@
                 }
             },
             focusCurrent() {
-                const btn = this.$refs.buttons.find(el => parseInt(el.getAttribute('aria-posinset'),10) === this.currentPage);
+                const btn = this.$refs.buttons.find(el => parseInt(el.getAttribute('aria-posinset'), 10) === this.currentPage);
                 if (btn && btn.focus) {
                     btn.focus();
                 } else {

--- a/lib/components/pagination.vue
+++ b/lib/components/pagination.vue
@@ -1,42 +1,58 @@
 <template>
-    <div class="btn-group pagination" role="group" aria-label="Pagination">
+    <div :class="['btn-group','pagination',btnSize]" 
+         role="group"
+         :aria-label="ariaLabel ? ariaLabel : null"
+    >
 
         <button type="button"
-                :class="['btn','btn-'+secondaryVariant,btnSize]"
+                :class="['btn','btn-'+secondaryVariant]"
                 :disabled="currentPage == 1 "
+                :aria-label="labelPrevPage"
                 @click.prevent="(currentPage == 1) ? _return : currentPage--">
             <span aria-hidden="true">&laquo;</span>
         </button>
 
         <button type="button"
-                :class="['btn','btn-'+secondaryVariant,btnSize,currentPage === 1 ?  'active' : '']"
+                :class="['btn','btn-'+secondaryVariant,currentPage === 1 ?  'active' : '']"
+                :aria-label="labelPage + ' 1'"
+                :aria-current="currentpage === 1 ? 'true' : 'false'"
+                :aria-setsize="numberOfPages"
+                :aria-posinset="1"
                 @click.prevent="currentPage = 1"
                 v-show="showPrev">1
         </button>
 
-        <span :class="['btn','btn-'+secondaryVariant,btnSize]" v-show="showPrev">...</span>
+        <span:class="['btn','btn-'+secondaryVariant]" v-show="showPrev">...</span>
 
         <button type="button"
                 :class="['btn',
-                btnSize,
                 btnVariant(index),
                 index + diff === currentPage ? 'active' : '',
                 index + diff !== currentPage ? 'hidden-xs-down' : '']"
+                :aria-label="labelPage + ' ' + (index + diff)"
+                :aria-current="currentpage === (index + diff) ? 'true' : 'false'"
+                :aria-setsize="numberOfPages"
+                :aria-posinset="index + diff"
                 v-for="_,index in pageLinks"
                 @click.prevent="currentPage = index + diff">{{index + diff}}
         </button>
 
-        <span :class="['btn','btn-'+secondaryVariant,btnSize]" v-show="showNext">...</span>
+        <span :class="['btn','btn-'+secondaryVariant]" v-show="showNext">...</span>
 
         <button type="button"
-                :class="['btn','btn-'+secondaryVariant,btnSize,numberOfPages === currentPage ? 'active' : '']"
+                :class="['btn','btn-'+secondaryVariant,numberOfPages === currentPage ? 'active' : '']"
+                :aria-label="labelPage + ' ' + numberOfPages"
+                :aria-current="currentpage === numberOfPages ? 'true' : 'false'"
+                :aria-setsize="numberOfPages"
+                :aria-posinset="numberOfPages"
                 v-show="showNext"
                 @click.prevent="currentPage = numberOfPages">{{numberOfPages}}
         </button>
 
         <button type="button"
-                :class="['btn','btn-'+secondaryVariant,btnSize]"
+                :class="['btn','btn-'+secondaryVariant]"
                 :disabled="currentPage == numberOfPages"
+                :aria-label="labelNextPage"
                 @click.prevent="(currentPage == numberOfPages) ? _return : currentPage++">
             <span aria-hidden="true">&raquo;</span>
         </button>
@@ -60,7 +76,7 @@
                 return (result < 1) ? 1 : result;
             },
             btnSize() {
-                return !this.size || this.size === `default` ? `` : `btn-${this.size}`;
+                return !this.size || this.size === `default` ? `` : `pagination-${this.size}`;
             },
             pageLinks() {
                 if (this.currentPage > this.numberOfPages) {
@@ -148,6 +164,22 @@
             secondaryVariant: {
                 type: String,
                 default: 'secondary'
+            },
+            ariaLabel {
+                type: String,
+                default: 'Pagination'
+            },
+            labelPrevPage: {
+                type: String,
+                default: 'First Page'
+            },
+            labelNextPage: {
+                type: String,
+                default: 'Last Page'
+            },
+            labelPage: {
+                type: String,
+                default: 'Page'
             }
         }
     };

--- a/lib/components/pagination.vue
+++ b/lib/components/pagination.vue
@@ -29,7 +29,7 @@
                 :aria-posinset="1"
                 tabindex="-1"
                 ref="buttons"
-                v-if"showPrev"
+                v-if="showPrev"
                 @click.prevent="currentPage = 1"
         >1</button>
 

--- a/lib/components/pagination.vue
+++ b/lib/components/pagination.vue
@@ -13,7 +13,7 @@
         </button>
 
         <button type="button"
-                :class="['btn','btn-'+secondaryVariant,currentPage === 1 ?  'active' : '']"
+                :class="['btn','btn-'+secondaryVariant,isActivePage(1) ?  'active' : '']"
                 :aria-label="labelPage + ' 1'"
                 :aria-current="currentpage === 1 ? 'true' : 'false'"
                 :aria-setsize="numberOfPages"
@@ -25,10 +25,8 @@
         <span:class="['btn','btn-'+secondaryVariant]" v-show="showPrev">...</span>
 
         <button type="button"
-                :class="['btn',
-                btnVariant(index),
-                index + diff === currentPage ? 'active' : '',
-                index + diff !== currentPage ? 'hidden-xs-down' : '']"
+                class="btn"
+                :class="[btnVariant(index),isActivePage(index + diff) ? 'active' : '',isActivePage(index + diff) ? '' : 'hidden-xs-down']"
                 :aria-label="labelPage + ' ' + (index + diff)"
                 :aria-current="currentpage === (index + diff) ? 'true' : 'false'"
                 :aria-setsize="numberOfPages"
@@ -40,7 +38,7 @@
         <span :class="['btn','btn-'+secondaryVariant]" v-show="showNext">...</span>
 
         <button type="button"
-                :class="['btn','btn-'+secondaryVariant,numberOfPages === currentPage ? 'active' : '']"
+                :class="['btn','btn-'+secondaryVariant,isActivePage(numberOfPages) ? 'active' : '']"
                 :aria-label="labelPage + ' ' + numberOfPages"
                 :aria-current="currentpage === numberOfPages ? 'true' : 'false'"
                 :aria-setsize="numberOfPages"
@@ -77,6 +75,9 @@
             },
             btnSize() {
                 return !this.size || this.size === `default` ? `` : `pagination-${this.size}`;
+            },
+            isActivePage(p) {
+                return p === currentPage ? true : false;
             },
             pageLinks() {
                 if (this.currentPage > this.numberOfPages) {

--- a/lib/components/pagination.vue
+++ b/lib/components/pagination.vue
@@ -168,7 +168,7 @@
                 type: String,
                 default: 'secondary'
             },
-            ariaLabel {
+            ariaLabel: {
                 type: String,
                 default: 'Pagination'
             },

--- a/lib/components/pagination.vue
+++ b/lib/components/pagination.vue
@@ -79,7 +79,7 @@
                 return !this.size || this.size === `default` ? `` : `pagination-${this.size}`;
             },
             isActive(page) {
-                return page === currentPage ? true : false;
+                return page === this.currentPage;
             },
             pageLinks() {
                 if (this.currentPage > this.numberOfPages) {

--- a/lib/components/pagination.vue
+++ b/lib/components/pagination.vue
@@ -23,7 +23,7 @@
                 v-show="showPrev"
         >1</button>
 
-        <span:class="['btn','btn-'+secondaryVariant]" v-show="showPrev">...</span>
+        <span :class="['btn','btn-'+secondaryVariant]" v-show="showPrev">...</span>
 
         <button type="button"
                 class="btn"


### PR DESCRIPTION
Added ARIA attributes:
- `aria-label`
- `aria-current` (set to `"true"` on the current page button)
- `aria-posinset` reflects the page number the button represents
- `aria-setsize` reflects the total number of pages (appears on each button with an `aria-posinset`)

Enabled keyboard navigation of buttons:
- `LEFT` focus previous button
- `RIGHT` focus next button
- `SHIFT+LEFT` will focus first non-disabled button
- `SHIFT+RIGHT` fill focus last non-disabled button
- When pagination widget is tabbed into, the current page button is focused

New props for localisation of button `aria-label`s:
- `labelPrev` defaults to `'Previous Page'`
- `labelNext` defaults to `'Next Page'`
- `labelPage` defaults to `'Page'`. used on page number buttons (i.e. "Page 1", "Page 2", etc)
- `ariaLabel` will label the pagination widget (defaults to `'Pagination`)

Addresses parts of #333