### PR TITLE
[link] Allow both router links and regular links to co-exist in same document

### DIFF
--- a/lib/components/link.vue
+++ b/lib/components/link.vue
@@ -1,7 +1,6 @@
 <template>
     <!-- When VueRouter is available -->
-    <a v-if="routerAvailable"
-       is="router-link"
+    <a v-if="routerAvailable && to"
        :active-class="activeClass"
        :exact-active-class="exactActiveClass"
        :disabled="disabled"
@@ -52,15 +51,11 @@
             },
             _to() {
                 if (!this.routerAvailable || this.disabled) {
-                    return '#';
+                    return null;
                 }
 
                 if (this.to) {
                     return this.to;
-                }
-
-                if (this.href) {
-                    return this.href;
                 }
             }
         },

--- a/lib/components/link.vue
+++ b/lib/components/link.vue
@@ -1,6 +1,7 @@
 <template>
     <!-- When VueRouter is available -->
     <a v-if="routerAvailable && to"
+       is='router-link'
        :active-class="activeClass"
        :exact-active-class="exactActiveClass"
        :disabled="disabled"

--- a/lib/components/link.vue
+++ b/lib/components/link.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- When VueRouter is available -->
-    <a v-if="routerAvailable && to"
+    <a v-if="isRouterLink"
        is="router-link"
        :active-class="activeClass"
        :exact-active-class="exactActiveClass"
@@ -32,8 +32,8 @@
 
     export default {
         computed: {
-            routerAvailable() {
-                return Boolean(this.$router);
+            isRouterLink() {
+                return this.$router && !this.to;
             },
             _href() {
                 if (this.disabled) {

--- a/lib/components/link.vue
+++ b/lib/components/link.vue
@@ -51,7 +51,7 @@
                 }
             },
             _to() {
-                if (!this.routerAvailable || this.disabled) {
+                if (this.disabled) {
                     return null;
                 }
 

--- a/lib/components/link.vue
+++ b/lib/components/link.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- When VueRouter is available -->
     <a v-if="routerAvailable && to"
-       is='router-link'
+       is="router-link"
        :active-class="activeClass"
        :exact-active-class="exactActiveClass"
        :disabled="disabled"


### PR DESCRIPTION
In some cases one would like to have both regular links (i.e. links to an in-page ID) and router links (routed by vue-router).

If `to` is not specified, then assume a regular local link (not handled by router).

Addresses #362 and #363  (I think... discussion is welcome)