### PR TITLE
New component b-button-toolbar

### DIFF
--- a/lib/components/button-group.vue
+++ b/lib/components/button-group.vue
@@ -1,50 +1,23 @@
 <template>
-    <div :class="classObject"
-         :role="toolbar ? 'toolbar' : 'group'"
-         :tabindex="isKeyNav ? '0' : null"
-         @focusin.self="focusFirst"
-         @keydown.left="focusNext($event,true)"
-         @keydown.up="focusNext($event,true)"
-         @keydown.right="focusNext($event,false)"
-         @keydown.down="focusNext($event,false)"
-         @keydown.shift.left="focusFirst($event)"
-         @keydown.shift.up="focusFirst($event)"
-         @keydown.shift.right="focusLast($event)"
-         @keydown.shift.down="focusLast($event)"
-    >
+    <div :class="classObject">
         <slot></slot>
     </div>
 </template>
 
 <script>
-    const ITEM_SELECTOR = [
-        '.btn:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])',
-        '.form-control:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])',
-        'select:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])',
-        'input[type="checkbox"]:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])',
-        'input[type="radio"]:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])'
-    ].join(',');
-
     export default {
         computed: {
             classObject() {
                 return [
-                    'btn-' + (this.toolbar ? 'toolbar' : 'group'),
+                    'btn-group',
                     this.vertical ? 'btn-group-vertical' : '',
                     (this.justify && !this.vertical) ? 'justify-content-between' : '',
                     this.size ? ('btn-group-' + this.size) : ''
                 ];
-            },
-            isKeyNav() {
-                return this.toolbar && this.toolbarkeyNav;
             }
         },
         props: {
             vertical: {
-                type: Boolean,
-                default: false
-            },
-            toolbar: {
                 type: Boolean,
                 default: false
             },
@@ -56,69 +29,6 @@
                 type: String,
                 default: null
             },
-            toobarKeyNav: {
-                type: Boolean,
-                default: false
-            }
-        },
-        methods: {
-            focusNext(e, prev) {
-                if (!this.isKeyNav) {
-                    return;
-                }
-                e.preventDefault();
-                e.stopPropagation();
-                const items = this.getItems();
-                if (items.length < 1) {
-                    return;
-                }
-                let index = items.indexOf(e.target);
-                if (prev && index > 0) {
-                    index--;
-                } else if (!prev && index < items.length - 1) {
-                    index++;
-                }
-                if (index < 0) {
-                    index = 0;
-                }
-                items[index].focus();
-            },
-            focusFirst(e) {
-                if (!this.isKeyNav) {
-                    return;
-                }
-                e.preventDefault();
-                e.stopPropagation();
-                const items = this.getItems();
-                if (items.length > 0) {
-                    items[0].focus();
-                }
-            },
-            focusLast(e) {
-                if (!this.isKeyNav) {
-                    return;
-                }
-                e.preventDefault();
-                e.stopPropagation();
-                const items = this.getItems();
-                if (items.length > 0) {
-                    items[items.length - 1].focus();
-                }
-            },
-            getItems() {
-                const items = Array.prototype.slice.call(this.$el.querySelectorAll(ITEM_SELECTOR));
-                items.forEach(item => {
-                    // Ensure tabfocus is -1 on any new elements
-                    item.tabIndex = -1;
-                });
-                return items;
-            }
-        },
-        mounted() {
-            if (this.isKeyNav) {
-                // Pre-set the tabindexes if the markup does not include tabindex="-1" on the toolbar items
-                this.getItems();
-            }
         }
     };
 </script>

--- a/lib/components/button-group.vue
+++ b/lib/components/button-group.vue
@@ -28,7 +28,7 @@
             size: {
                 type: String,
                 default: null
-            },
+            }
         }
     };
 </script>

--- a/lib/components/button-toolbar.vue
+++ b/lib/components/button-toolbar.vue
@@ -29,9 +29,8 @@
         computed: {
             classObject() {
                 return [
-                    'btn-toolbar,
-                    (this.justify && !this.vertical) ? 'justify-content-between' : '',
-                    this.size ? ('btn-group-' + this.size) : ''
+                    'btn-toolbar',
+                    (this.justify && !this.vertical) ? 'justify-content-between' : ''
                 ];
             }
         },
@@ -39,10 +38,6 @@
             justify: {
                 type: Boolean,
                 default: false
-            },
-            size: {
-                type: String,
-                default: null
             },
             KeyNav: {
                 type: Boolean,

--- a/lib/components/button-toolbar.vue
+++ b/lib/components/button-toolbar.vue
@@ -1,0 +1,112 @@
+<template>
+    <div :class="classObject"
+         role="toolbar"
+         :tabindex="keyNav ? '0' : null"
+         @focusin.self="focusFirst"
+         @keydown.left="focusNext($event,true)"
+         @keydown.up="focusNext($event,true)"
+         @keydown.right="focusNext($event,false)"
+         @keydown.down="focusNext($event,false)"
+         @keydown.shift.left="focusFirst($event)"
+         @keydown.shift.up="focusFirst($event)"
+         @keydown.shift.right="focusLast($event)"
+         @keydown.shift.down="focusLast($event)"
+    >
+        <slot></slot>
+    </div>
+</template>
+
+<script>
+    const ITEM_SELECTOR = [
+        '.btn:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])',
+        '.form-control:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])',
+        'select:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])',
+        'input[type="checkbox"]:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])',
+        'input[type="radio"]:not(.disabled):not([disabled]):not([style*="display: none"]):not([style*="display:none"])'
+    ].join(',');
+
+    export default {
+        computed: {
+            classObject() {
+                return [
+                    'btn-toolbar,
+                    (this.justify && !this.vertical) ? 'justify-content-between' : '',
+                    this.size ? ('btn-group-' + this.size) : ''
+                ];
+            }
+        },
+        props: {
+            justify: {
+                type: Boolean,
+                default: false
+            },
+            size: {
+                type: String,
+                default: null
+            },
+            KeyNav: {
+                type: Boolean,
+                default: false
+            }
+        },
+        methods: {
+            focusNext(e, prev) {
+                if (!this.keyNav) {
+                    return;
+                }
+                e.preventDefault();
+                e.stopPropagation();
+                const items = this.getItems();
+                if (items.length < 1) {
+                    return;
+                }
+                let index = items.indexOf(e.target);
+                if (prev && index > 0) {
+                    index--;
+                } else if (!prev && index < items.length - 1) {
+                    index++;
+                }
+                if (index < 0) {
+                    index = 0;
+                }
+                items[index].focus();
+            },
+            focusFirst(e) {
+                if (!this.keyNav) {
+                    return;
+                }
+                e.preventDefault();
+                e.stopPropagation();
+                const items = this.getItems();
+                if (items.length > 0) {
+                    items[0].focus();
+                }
+            },
+            focusLast(e) {
+                if (!this.keyNav) {
+                    return;
+                }
+                e.preventDefault();
+                e.stopPropagation();
+                const items = this.getItems();
+                if (items.length > 0) {
+                    items[items.length - 1].focus();
+                }
+            },
+            getItems() {
+                const items = Array.prototype.slice.call(this.$el.querySelectorAll(ITEM_SELECTOR));
+                items.forEach(item => {
+                    // Ensure tabfocus is -1 on any new elements
+                    item.tabIndex = -1;
+                });
+                return items;
+            }
+        },
+        mounted() {
+            if (this.keyNav) {
+                // Pre-set the tabindexes if the markup does not include tabindex="-1" on the toolbar items
+                this.getItems();
+            }
+        }
+    };
+</script>

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -3,6 +3,7 @@ import bBreadcrumb from './breadcrumb.vue';
 import bButton from './button.vue';
 import bButtonGroup from './button-group.vue';
 import bButtonGroupDropdown from './button-group-dropdown.vue';
+import bButtonToolbar from '.button-toolbar.vue.;
 import bInputGroup from './input-group.vue';
 import bInputGroupAddon from './input-group-addon.vue';
 import bInputGroupButton from './input-group-button.vue';
@@ -51,6 +52,7 @@ export {
     bButton as bBtn,
     bButtonGroup,
     bButtonGroupDropdown,
+    bButtonToolbar,
     bInputGroup,
     bInputGroupAddon,
     bInputGroupButton,

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -1,9 +1,9 @@
 import bAlert from './alert.vue';
 import bBreadcrumb from './breadcrumb.vue';
 import bButton from './button.vue';
+import bButtonToolbar from './button-toolbar.vue';
 import bButtonGroup from './button-group.vue';
 import bButtonGroupDropdown from './button-group-dropdown.vue';
-import bButtonToolbar from '.button-toolbar.vue';
 import bInputGroup from './input-group.vue';
 import bInputGroupAddon from './input-group-addon.vue';
 import bInputGroupButton from './input-group-button.vue';
@@ -50,9 +50,9 @@ export {
     bBreadcrumb,
     bButton,
     bButton as bBtn,
+    bButtonToolbar,
     bButtonGroup,
     bButtonGroupDropdown,
-    bButtonToolbar,
     bInputGroup,
     bInputGroupAddon,
     bInputGroupButton,

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -3,7 +3,7 @@ import bBreadcrumb from './breadcrumb.vue';
 import bButton from './button.vue';
 import bButtonGroup from './button-group.vue';
 import bButtonGroupDropdown from './button-group-dropdown.vue';
-import bButtonToolbar from '.button-toolbar.vue.;
+import bButtonToolbar from '.button-toolbar.vue';
 import bInputGroup from './input-group.vue';
 import bInputGroupAddon from './input-group-addon.vue';
 import bInputGroupButton from './input-group-button.vue';


### PR DESCRIPTION
Wrapper component for creating toolbars comprised of button-groups and/or input-groups.

Direct children elements should be `b-button-group` and `b-input-group` components.

Allows for optional keyboard navigation by setting prop `keyNav` to `true` (defaults to `false`)

