### PR TITLE
[modal] Do not change focus if activeComponent is in modal content.

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -236,6 +236,11 @@
                 }
             },
             focusFirst() {
+                // If activeElement is child of content, no need to change focus
+                if (document.activeElement && this.$refs.content.contains(document.activeElement)) {
+                    return;
+                }
+
                 // Focus the modal's first focusable item, searching footer, then body, then header, else the modal
                 let el;
                 if (this.$refs.footer) {


### PR DESCRIPTION
This allows focus to be set in @shown handler of a modal without
the focusFirst handler overriding.