### PR TITLE
modal: change event order

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -214,15 +214,15 @@
                     }
                 };
 
-                // Emit events
-                this.$emit('change', false);
-                this.$emit('hidden', e);
-
+                // Emit `ok` and `cancel` events
                 if (isOK === true) {
                     this.$emit('ok', e);
                 } else if (isOK === false) {
                     this.$emit('cancel', e);
                 }
+
+                // Call `change` event after we know what we did
+                this.$emit('change', false);
 
                 // Hide if not canceled
                 if (!canceled) {
@@ -234,6 +234,7 @@
                     }
                     this.is_visible = false;
                     this.$root.$emit('hidden::modal', this.id);
+                    this.$emit('hidden', e);
                     this.body.classList.remove('modal-open');
                 }
             },

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -188,6 +188,7 @@
                 if (this.is_visible) {
                     return;
                 }
+                this.$emit('show');
                 this.is_visible = true;
                 this.$root.$emit('shown::modal', this.id);
                 this.body.classList.add('modal-open');
@@ -214,15 +215,15 @@
                     }
                 };
 
-                // Emit `ok` and `cancel` events
+                // Emit events
+                this.$emit('change', false);
+                this.$emit('hide',e);
+
                 if (isOK === true) {
                     this.$emit('ok', e);
                 } else if (isOK === false) {
                     this.$emit('cancel', e);
                 }
-
-                // Call `change` event after we know what we did
-                this.$emit('change', false);
 
                 // Hide if not canceled
                 if (!canceled) {


### PR DESCRIPTION
There are no issue about it (but i think we can discus this little fix here)

The chain of events in hide method of modal now looks like this:
`click smth (ok / cancel) -> trigger(change, hidden) -> trigger(ok/cancel)`
It means that 'hidden' (or 'change') is triggered even before we start to process the 'ok' or 'cancel' methods. (so if we e.cancel() in ok, we will anyway see hidden trigger)

After commit it will be work in this way:
`click smth (ok / cancel ) -> trigger(ok / cancel) -> trigger(change) -> trigger(hidden) (if event not canceled)`

Also, can i add "beforechange" emit, that triggers before "ok" / "cancel" ?