### PR TITLE
[breadcrumb] ARIA changes

### DIFF
--- a/__tests__/components/breadcrumb.spec.js
+++ b/__tests__/components/breadcrumb.spec.js
@@ -23,8 +23,6 @@ describe('breadcrumb', async() => {
         const vm = $refs.breadcrumb1
         const $ol = vm.$el
 
-        expect($ol.getAttribute('role')).toBe('navigation')
-
         Array.from($ol.children).forEach($li => {
             if ($li.tagName === 'LI') {
                 expect($li.getAttribute('role')).toBe('presentation')
@@ -40,6 +38,18 @@ describe('breadcrumb', async() => {
         app.items2.forEach((item, i) => {
             if (item.active) {
                 expect($listItems[i].classList.contains('active')).toBe(true)
+            }
+        })
+    })
+
+    it('should apply aria-current to active class', async() => {
+        const { app: { $refs, $el } } = window
+        const vm = $refs.breadcrumb2
+        const $listItems = Array.from(vm.$el.children)
+
+        app.items2.forEach((item, i) => {
+            if (item.active) {
+                expect($listItems[i].getAttribute('aria-current')).toBe('true')
             }
         })
     })

--- a/__tests__/components/breadcrumb.spec.js
+++ b/__tests__/components/breadcrumb.spec.js
@@ -49,7 +49,7 @@ describe('breadcrumb', async() => {
 
         app.items2.forEach((item, i) => {
             if (item.active) {
-                expect($listItems[i].firstElementChild.getAttribute('aria-current')).toBe('true')
+                expect($listItems[i].firstElementChild.getAttribute('aria-current')).toBe('location')
             } else {
                 expect($listItems[i].firstElementChild.getAttribute('aria-current')).toBe(null)
             }

--- a/__tests__/components/breadcrumb.spec.js
+++ b/__tests__/components/breadcrumb.spec.js
@@ -42,14 +42,16 @@ describe('breadcrumb', async() => {
         })
     })
 
-    it('should apply aria-current to active class', async() => {
+    it('should apply aria-current to active class element', async() => {
         const { app: { $refs, $el } } = window
         const vm = $refs.breadcrumb2
         const $listItems = Array.from(vm.$el.children)
 
         app.items2.forEach((item, i) => {
             if (item.active) {
-                expect($listItems[i].getAttribute('aria-current')).toBe('true')
+                expect($listItems[i].firstElementChild.getAttribute('aria-current')).toBe('true')
+            } else {
+                expect($listItems[i].firstElementChild.getAttribute('aria-current')).toBe(null)
             }
         })
     })

--- a/__tests__/components/breadcrumb.spec.js
+++ b/__tests__/components/breadcrumb.spec.js
@@ -49,9 +49,9 @@ describe('breadcrumb', async() => {
 
         app.items2.forEach((item, i) => {
             if (item.active) {
-                expect($listItems[i].firstElementChild.getAttribute('aria-current')).toBe('location')
+                expect($listItems[i].firstElementChild.hasAttribute('aria-current')).toBe(true)
             } else {
-                expect($listItems[i].firstElementChild.getAttribute('aria-current')).toBe(null)
+                expect($listItems[i].firstElementChild.hasAttribute('aria-current')).toBe(false)
             }
         })
     })

--- a/lib/components/breadcrumb.vue
+++ b/lib/components/breadcrumb.vue
@@ -6,7 +6,7 @@
             role="presentation"
         >
             <span v-if="item.active"
-                  aria-current="true"
+                  aria-current="location"
                   v-html="item.text"></span>
             <b-link v-else
                     :to="item.to"
@@ -59,6 +59,10 @@
                 type: Array,
                 default: () => [],
                 required: true
+            },
+            aria-current: {
+                type: String,
+                default: 'location'
             }
         },
         methods: {

--- a/lib/components/breadcrumb.vue
+++ b/lib/components/breadcrumb.vue
@@ -6,7 +6,7 @@
             role="presentation"
         >
             <span v-if="item.active"
-                  aria-current="location"
+                  aria-current="ariaCurrent"
                   v-html="item.text"></span>
             <b-link v-else
                     :to="item.to"
@@ -60,7 +60,7 @@
                 default: () => [],
                 required: true
             },
-            aria-current: {
+            ariaCurrent: {
                 type: String,
                 default: 'location'
             }

--- a/lib/components/breadcrumb.vue
+++ b/lib/components/breadcrumb.vue
@@ -1,11 +1,12 @@
 <template>
-    <ol class="breadcrumb"
-        role="navigation">
-        <li v-for="item in normalizedItems"
+    <ol class="breadcrumb">
+        <li v-for="(item, idx) in normalizedItems"
             :class="['breadcrumb-item', item.active ? 'active' : null]"
             @click="onClick(item)"
-            role="presentation">
+            role="presentation"
+        >
             <span v-if="item.active"
+                  aria-current="true"
                   v-html="item.text"></span>
             <b-link v-else
                     :to="item.to"


### PR DESCRIPTION
Removed role="navigation" per https://github.com/bootstrap-vue/bootstrap-vue/issues/333#issuecomment-309303101

Added `aria-current` attribute on active item. Allow user to specify `aria-current` value via prop (defaults to `"location"`)

Updated unit tests to reflect changes