### PR TITLE
[form-file] reset() method for clearing file value

### DIFF
--- a/docs/components/form-file/README.md
+++ b/docs/components/form-file/README.md
@@ -39,4 +39,31 @@ Also it is advised to use [:lang()](https://developer.mozilla.org/en-US/docs/Web
 }
 ```
 
+### Clearing the file selection
+Because of limitations in the value binding with `<input type="file">` elements, `v-model` for `b-form-file`is
+unidirectional, and cannot be used to set or clear the file(s) selection.  To get around this 
+limitation `b-form-file` provides a `reset()` method that can be called to clear the file input.
+
+To take advantage of the `reset()` method, you will need to obtain a reference to the `b-form-file` component:
+
+```html
+<div id="#app">
+    <b-form-file v-model="file" ref="fileinput"></b-formfile>
+    <b-button @click="clearFiles">Reset</b-button>
+</div>
+```
+
+```js
+window.app = new Vue({
+    el: '#app',
+    data: {
+        file: null
+    },
+    methods: {
+        clearFiles() {
+            this.$refs.fileinput.reset();
+        }
+    }
+});
+```
 

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -141,7 +141,7 @@
                 this.$refs.input.type = '';
                 this.$refs.input.type = 'file';
 
-                this.selectedFile = null;
+                this.selectedFile = this.multiple ? [] : null;
             },
             onFileChange(e) {
                 // Always emit original event

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -125,6 +125,26 @@
                 } else {
                     this.$emit('input', newVal);
                 }
+            },
+            value(newVal, oldVal) {
+                if (newVal === oldVal) {
+                    return;
+                }
+
+                // User is clearing the file input
+                if (!newVal) {
+                    try {
+                        // Wrapped in try in case IE < 11 craps out
+                        this.$refs.input.value = '';
+                    } catch (e) {
+                    }
+                    // IE < 11 doesn't support setting file to null
+                    // So we use this little extra hack to reset the value, just in case
+                    this.$refs.input.type = '';
+                    this.$refs.input.type = 'file';
+                    
+                    this.selectedFile = null;
+                }
             }
         },
         methods: {
@@ -217,6 +237,10 @@
             }
         },
         props: {
+            value : {
+                type: [Object, Array],
+                default: null
+            },
             accept: {
                 type: String,
                 default: ''

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -125,29 +125,24 @@
                 } else {
                     this.$emit('input', newVal);
                 }
-            },
-            value(newVal, oldVal) {
-                if (newVal === oldVal) {
-                    return;
-                }
-
-                // User is clearing the file input
-                if (!newVal) {
-                    try {
-                        // Wrapped in try in case IE < 11 craps out
-                        this.$refs.input.value = '';
-                    } catch (e) {
-                    }
-                    // IE < 11 doesn't support setting file to null
-                    // So we use this little extra hack to reset the value, just in case
-                    this.$refs.input.type = '';
-                    this.$refs.input.type = 'file';
-                    
-                    this.selectedFile = null;
-                }
             }
         },
         methods: {
+            reset() {
+                try {
+                    // Wrapped in try in case IE < 11 craps out
+                    this.$refs.input.value = '';
+                } catch (e) {
+                }
+
+                // IE < 11 doesn't support setting input.value to '' or null
+                // So we use this little extra hack to reset the value, just in case
+                // This also appears to work on modern browsers as well.
+                this.$refs.input.type = '';
+                this.$refs.input.type = 'file';
+
+                this.selectedFile = null;
+            },
             onFileChange(e) {
                 // Always emit original event
                 this.$emit('change', e);
@@ -237,10 +232,6 @@
             }
         },
         props: {
-            value : {
-                type: [Object, Array],
-                default: null
-            },
             accept: {
                 type: String,
                 default: ''


### PR DESCRIPTION
Allow user to reset() `b-form-file` to clear the file input without resetting the entire form

Workaround for issue #493 

Users can call the component's `reset()` method to clear the input, by making a reference to the component:

i.e. `this.$refs.fileinput.reset()`

Includes workaround for IE 10 (file inputs are read-only on IE 8 to IE 10) https://stackoverflow.com/a/35323290/2744776