### PR TITLE
[button] Add support for button type attribute

### DIFF
--- a/lib/components/button.vue
+++ b/lib/components/button.vue
@@ -2,6 +2,7 @@
     <button v-bind="conditionalLinkProps"
             :is="componentType"
             :class="classList"
+            :type="btnType"
             :disabled="disabled"
             @click="onClick">
         <slot></slot>
@@ -56,10 +57,14 @@ export default {
         btnDisabled() {
             return this.disabled ? 'disabled' : '';
         },
+        
+        btnType() {
+            return (this.href || this.to) ? null : this.type; 
+        },
 
         conditionalLinkProps() {
             return this.componentType === 'button' ? {} : this.linkProps;
-        },
+        }
     },
 
     // merge our prepared link props with button props
@@ -80,6 +85,10 @@ export default {
             type: String,
             default: null
         },
+        type: {
+            type: String,
+            default: 'button'
+        }
     }),
 
     methods: {

--- a/lib/components/button.vue
+++ b/lib/components/button.vue
@@ -24,10 +24,8 @@ const linkProps = Object.assign(omitLinkProps('href', 'to'), {
 
 export default {
     components: { bLink },
-
     computed: {
         linkProps: computed.linkProps,
-
         classList() {
             return [
                 'btn',
@@ -37,36 +35,28 @@ export default {
                 this.btnDisabled
             ];
         },
-
         componentType() {
             return (this.href || this.to) ? 'b-link' : 'button';
         },
-
         btnBlock() {
             return this.block ? `btn-block` : '';
         },
-
         btnVariant() {
             return this.variant ? `btn-${this.variant}` : `btn-secondary`;
         },
-
         btnSize() {
             return this.size ? `btn-${this.size}` : '';
         },
-
         btnDisabled() {
             return this.disabled ? 'disabled' : '';
         },
-        
         btnType() {
             return (this.href || this.to) ? null : this.type; 
         },
-
         conditionalLinkProps() {
             return this.componentType === 'button' ? {} : this.linkProps;
         }
     },
-
     // merge our prepared link props with button props
     props: Object.assign(linkProps, {
         block: {
@@ -90,7 +80,6 @@ export default {
             default: 'button'
         }
     }),
-
     methods: {
         onClick(e) {
             if (this.disabled) {


### PR DESCRIPTION
Adds new prop `type` which defaults to "button".

Only applied if neither `href` or `to` prop are provided.

Addresses issue #548 