### PR TITLE
[navbar] sticky property should be a boolean, not a string

### DIFF
--- a/lib/components/navbar.vue
+++ b/lib/components/navbar.vue
@@ -48,7 +48,8 @@
                 type: String
             },
             sticky: {
-                type: String
+                type: Boolean,
+                default: false
             }
         }
     };


### PR DESCRIPTION
The sticky property could/should be just a boolean, now you have to type `sticky="blalal"` but just `sticky` should be sufficient. Looking at the bootstrap docs there is no other implementation then `sticky-top` at the moment.