### PR TITLE
Remove explicit Tether dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "bootstrap": "^4.0.0-alpha.6",
-    "tether": "latest",
     "vue": "2.*.*"
   },
   "devDependencies": {


### PR DESCRIPTION
This is trivial PR:
Tether.js is always installed as part of BS 4 dependency:
https://github.com/twbs/bootstrap/blob/v4.0.0-alpha.6/package.json\#L49
This RP removes some noise from configuration.
Thanks!