### PR TITLE
Remove implicit Yarn dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint-fix": "xo --fix",
     "test:lint": "xo",
     "test:jest": "jest",
-    "test": "yarn test:jest"
+    "test": "npm run test:jest"
   },
   "dependencies": {
     "bootstrap": "^4.0.0-alpha.6",


### PR DESCRIPTION
This is trivial PR
The Yarn is not explicit dependency to the library.
Users are free to user Yarn or NPM, but adding Yarn into script made
it dependency. This fixes this issue while still offering both solutions to the users.

Thanks!