### PR TITLE
[tooltip] fix - inline-block element for wrappers (issue #571)

### DIFF
--- a/lib/components/tooltip.vue
+++ b/lib/components/tooltip.vue
@@ -1,6 +1,6 @@
 <template>
-    <div>
-        <span ref="trigger"><slot></slot></span>
+    <div class="d-inline-block">
+        <span class="d-inline-block" ref="trigger"><slot></slot></span>
         <div :class="['tooltip','tooltip-' + this.placement]"
              :style="{opacity:showState?1:0}"
              tabindex="-1"


### PR DESCRIPTION
Adds class `d-inline-block` to the outer wrapper and trigger element wrapper as to not interfere with in-line elements/layout.

May address issue #571