### PR TITLE
fix(modal): use listenOnRoot mixin

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -88,6 +88,7 @@
 
 <script>
     import bBtn from './button.vue';
+    import listenOnRoot from '../mixins/listen-on-root';
 
     const FOCUS_SELECTOR = [
         'button:not([disabled])',
@@ -122,6 +123,7 @@
     }
 
     export default {
+        mixins: [listenOnRoot],
         components: {bBtn},
         data() {
             return {
@@ -358,14 +360,14 @@
             }
         },
         created() {
-            this.$root.$on('show::modal', (id, triggerEl) => {
+            this.listenOnRoot('show::modal', (id, triggerEl) => {
                 if (id === this.id) {
                     this.return_focus = triggerEl || null;
                     this.show();
                 }
             });
 
-            this.$root.$on('hide::modal', id => {
+            this.listenOnRoot('hide::modal', id => {
                 if (id === this.id) {
                     this.hide();
                 }

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -357,21 +357,22 @@
                     !this.$refs.content.contains(e.target)) {
                     this.$refs.content.focus();
                 }
-            }
-        },
-        created() {
-            this.listenOnRoot('show::modal', (id, triggerEl) => {
+            },
+            showHandler(id, triggerEl) {
                 if (id === this.id) {
                     this.return_focus = triggerEl || null;
                     this.show();
                 }
-            });
-
-            this.listenOnRoot('hide::modal', id => {
+            },
+            hideHandler(id) {
                 if (id === this.id) {
                     this.hide();
                 }
-            });
+            }
+        },
+        created() {
+            this.listenOnRoot('show::modal', this.showHandler);
+            this.listenOnRoot('hide::modal', this.hideHandler);
         },
         mounted() {
             if (this.visible === true) {


### PR DESCRIPTION
Uses new listenOnRoot mixin by @alexsasharegan to ensure `$root` event listeners are removed on destroy