### PR TITLE
feat(docs): Native event capturing docs

### DIFF
--- a/docs/nuxt/components/componentdoc.vue
+++ b/docs/nuxt/components/componentdoc.vue
@@ -33,16 +33,6 @@
         </template>
     </div>
 
-    <b-card class="my-4">
-        <small class="font-italic">
-            Trying to get native browser events working on your component? Use the <code>.native</code>
-            modifier to capture browser native events such as: <code>@click.native="..."</code>,
-            <code>@mouseover.native="..."</code>, etc. See the the official
-            <a href="https://vuejs.org/v2/guide/components.html#Binding-Native-Events-to-Components">Vue.js docuementation</a>
-            for more information.
-        </small>
-    </b-card>
-
 </template>
 
 <style scoped>

--- a/docs/nuxt/pages/docs/components/_component.vue
+++ b/docs/nuxt/pages/docs/components/_component.vue
@@ -5,6 +5,16 @@
 
         <componentdoc :component="meta.component" :events="meta.events" :slots="meta.slots"></componentdoc>
 
+        <b-card class="my-4">
+            <small class="font-italic">
+                Trying to get native browser events working on your component? Use the <code>.native</code>
+                modifier to capture browser native events such as: <code>@click.native="..."</code>,
+                <code>@mouseover.native="..."</code>, etc. See the the official
+                <a href="https://vuejs.org/v2/guide/components.html#Binding-Native-Events-to-Components">Vue.js docuementation</a>
+                for more information.
+            </small>
+        </b-card>
+
         <componentdoc :component="component" :key="component" v-for="component in meta.components"></componentdoc>
     </div>
 </template>


### PR DESCRIPTION
Moved b-card from `componentdoc.vue` to `_component.vue`, so that it will only appear once per page, rather than one per component (for multi-component pages)