### PR TITLE
[docs] Fixes small typo in table component docs

### DIFF
--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -365,10 +365,10 @@ the `v-model` binding.
 As mentioned under the `items` prop section, it is possible to use a function to provide 
 the row data (items), by specifying a function reference via the `items` prop.
 
-**Note:** The `items-provider` prop has been deprecaated in favour of providing a function
+**Note:** The `items-provider` prop has been deprecated in favour of providing a function
 reference to the `items` prop. A console warning will be issued if `items-provider` is used.
 
-The providerfunction is called with the following signature:
+The provider function is called with the following signature:
 
 ```js
     provider(ctx, [callback])


### PR DESCRIPTION
Small typo fixes in the `Table` component docs.