### PR TITLE
feat(form-input): support aria-invalid attribute

### DIFF
--- a/docs/components/form-input/README.md
+++ b/docs/components/form-input/README.md
@@ -104,3 +104,12 @@ could include a hint about state in the form control's `<label>` text itself, or
 providing an additional help text block. Specifically for assistive technologies, 
 invalid form controls can also be assigned an `aria-invalid="true"` attribute.
 
+### ARIA `aria-invalid` attribute
+When `form-input` has an invalid contextual state (i.e. `danger`) you may also
+want to set the `<b-form-input>` prop `invalid` to `true`, or a string value.
+
+Supported `invaid` values are:
+- `false` (default) No errors detected
+- `true` The value has failed validation.
+- `grammar` A grammatical error has been detected.
+- `spelling` A spelling error has been detected.

--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -6,6 +6,7 @@
            :name="name"
            :id="id || null"
            :disabled="disabled"
+           :aria-invalid="ariaInvalid"
            :readonly="readonly"
            :is="textarea ? 'textarea' : 'input'"
            :class="inputClass"
@@ -43,6 +44,15 @@
                     this.size ? `form-control-${this.size}` : null,
                     this.state ? `form-control-${this.state}` : null
                 ];
+            },
+            ariaInvalid() {
+                if (this.invalid === false) {
+                    return null;
+                }
+                if (this.invalid === true) {
+                    return 'true';
+                }
+                return this.invalid;
             }
         },
         methods: {
@@ -89,6 +99,10 @@
             state: {
                 type: String,
                 default: null
+            },
+            invalid: {
+                type: [Boolean, String]
+                default: false
             },
             readonly: {
                 type: Boolean,

--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -101,7 +101,7 @@
                 default: null
             },
             invalid: {
-                type: [Boolean, String]
+                type: [Boolean, String],
                 default: false
             },
             readonly: {


### PR DESCRIPTION
Adds `aria-invalid` attribute support to `b-form-input`

Addresses issue #546
