### PR TITLE
feat(form-radio): Add support for aria-invalid

### DIFF
--- a/docs/components/form-input/README.md
+++ b/docs/components/form-input/README.md
@@ -52,10 +52,10 @@ The `formatter` function receives a single argument which is the control's curre
 should return the formatted value.
 
 ### Textarea
-Render a `textarea` control by setting the `textarea` prop to `true`. The
+Render a `<textarea>` element by setting the `textarea` prop to `true`. The
 `type` prop is ignored when prop `textarea` is set.
 
-By default `textarea` will automatically size its height based on on the number
+By default the `<textarea>` will automatically size its height based on on the number
 lines (separated by newlines) of text it contains. You can override this behaviour by supplying
 a numeric value to the `rows` prop. The `rows` prop has no effect on other input types.
 
@@ -105,10 +105,10 @@ providing an additional help text block. Specifically for assistive technologies
 invalid form controls can also be assigned an `aria-invalid="true"` attribute.
 
 ### ARIA `aria-invalid` attribute
-When `form-input` has an invalid contextual state (i.e. `danger`) you may also
+When `<form-input>` has an invalid contextual state (i.e. `danger`) you may also
 want to set the `<b-form-input>` prop `invalid` to `true`, or a string value.
 
-Supported `invaid` values are:
+Supported `invalid` values are:
 - `false` (default) No errors detected
 - `true` The value has failed validation.
 - `grammar` A grammatical error has been detected.

--- a/docs/components/form-radio/README.md
+++ b/docs/components/form-radio/README.md
@@ -1,6 +1,6 @@
 # Form Radio Input
 
-> For cross browser consistency, `b-form-radio` uses Bootstrap's custom
+> For cross browser consistency, `<b-form-radio>` uses Bootstrap's custom
 radio input to replace the browser default radio input. It is built on top of
 semantic and accessible markup, so it is a solid replacement for the default radio input.
 
@@ -42,7 +42,7 @@ export default {
 ### Options
 
 Please see options in [`<b-form-select>`](./form-select) docs for details on passing options
-to `b-form-radio`
+to `<b-form-radio>`
 
 ### Control sizing
 Set heights using thw `size` prop to `sm` or `lg` for small or large respectively. 
@@ -58,8 +58,9 @@ soft validation before a user attempts to submit a form.
 - `success` is ideal for situations when you have per-field validation throughout a form
 and want to encourage a user through the rest of the fields.
 
-To apply one of the contextual steates on `b-form-radio`, set the `state` prop
-to `danger`, `warning`, or `success`.
+To apply one of the contextual states on `b-form-radio`, set the `state` prop
+to `danger`, `warning`, or `success`.  You may also wrap `<b-form-radio>` in a
+`<b-form-fieldset>` and set the contextual `state` prop on `<b-form-fieldset>` instead.
 
 #### Conveying contextual validation state to assistive technologies and colorblind users:
 Using these contextual states to denote the state of a form control only provides
@@ -69,7 +70,15 @@ technologies - such as screen readers - or to colorblind users.
 Ensure that an alternative indication of state is also provided. For instance, you
 could include a hint about state in the form control's `<label>` text itself, or by
 providing an additional help text block. Specifically for assistive technologies, 
-invalid form controls can also be assigned an `aria-invalid="true"` attribute.
+invalid form controls can also be assigned an `aria-invalid="true"` attribute (see below).
+
+### ARIA `aria-invalid` attribute
+When `<b-form-radio>` has an invalid contextual state (i.e. `danger`) you may also
+want to set the `<b-form-radio>` prop `invalid` to `true`.
+
+Supported `invalid` values are:
+- `false` (default) No errors detected
+- `true` The value has failed validation.
 
 ### Non custom radio inputs
 You can have `b-form-radio` render a browser native radio input by setting the `plain` prop.

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :id="id || null" :class="inputClass" role="radiogroup">
+    <div :id="id || null" :class="inputClass" role="radiogroup" :aria-invalid="ariaInvalid">
         <label :class="[checkboxClass, custom?'custom-radio':null]"
                v-for="option in formOptions"
         >
@@ -39,6 +39,12 @@
                     this.state ? `has-${this.state}` : '',
                     this.stacked ? 'custom-controls-stacked' : ''
                  ];
+            },
+            ariaInvalid() {
+                if (this.invalid === true || this.invalid === 'true') {
+                    return 'true';
+                }
+                return null;
             }
         },
         props: {
@@ -55,6 +61,10 @@
             state: {
                 type: String,
                 default: null
+            },
+            invalid: {
+                type: [Boolean, String],
+                default: false
             },
             stacked: {
                 type: Boolean,


### PR DESCRIPTION
Adds  a new prop `invalid` to control the `aria-invalid` attribute