### PR TITLE
fix(docs): form-select docs typo fix

### DIFF
--- a/docs/components/form-select/README.md
+++ b/docs/components/form-select/README.md
@@ -7,7 +7,7 @@
 <div>
    <b-form-select v-model="selected" 
                    :options="options"
-                   calss="mb-3"
+                   class="mb-3"
     ></b-form-select>
 
   <div>Selected: <strong>{{selected}}</strong></div>


### PR DESCRIPTION
Typos have no place in a readme.