### PR TITLE
fix(form-options mixin): Pull out custom text field for object notation

### DIFF
--- a/lib/mixins/form-options.js
+++ b/lib/mixins/form-options.js
@@ -30,6 +30,9 @@ export default {
 
                     // Resolve value (uses key as value if not provided)
                     option.value = option[this.valueField] || value;
+                    
+                    // Resolve text field (uses key as value if not provided)
+                    option.text = option[this.textField] || value;
 
                     return option;
                 });


### PR DESCRIPTION
Fix for issue #622