### PR TITLE
fix(form): Emit native submit event on component

### DIFF
--- a/lib/components/form.vue
+++ b/lib/components/form.vue
@@ -1,5 +1,5 @@
 <template>
-    <form :class="classObject">
+    <form :class="classObject" @submit="$emit('submit',$event)">
         <slot></slot>
     </form>
 </template>


### PR DESCRIPTION
Fix for issue #588

Prevent the need to use `.native` modifier markup on submit event.