### PR TITLE
fix(docs.vue): Fix link to edit setup doc

### DIFF
--- a/docs/nuxt/layouts/docs.vue
+++ b/docs/nuxt/layouts/docs.vue
@@ -46,6 +46,8 @@ export default {
                 path = '';
             } else if (path === '/docs/setup') {
                 return base + '/SETUP.md';
+            } else if (/\/$/.test(path)) {
+                return base + path;
             }
             return base + path + '/README.md';
         },

--- a/docs/nuxt/layouts/docs.vue
+++ b/docs/nuxt/layouts/docs.vue
@@ -44,6 +44,8 @@ export default {
             let path = this.$route.path;
             if (path === '/') {
                 path = '';
+            } else if (path === '/docs/setup') {
+                return base + '/SETUP.md';
             }
             return base + path + '/README.md';
         },

--- a/docs/nuxt/layouts/docs.vue
+++ b/docs/nuxt/layouts/docs.vue
@@ -45,7 +45,9 @@ export default {
             if (path === '/') {
                 path = '';
             } else if (path === '/docs/setup') {
-                return base + '/SETUP.md';
+                return base + '/docs/SETUP.md';
+            } else if (path === '/docs/contributing') {
+                return base + '/CONTRIBUTING.md';
             } else if (/\/$/.test(path)) {
                 return base + path;
             }


### PR DESCRIPTION
Fixes  #639

"Edit this page" link broken for /docs/setup

Also when on '/docs/components/' links to erroneous `/docs/components//README.md`