### PR TITLE
feat(table): Emit event when local filtering changes number of result items - issue #650

### DIFF
--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -131,7 +131,7 @@ export default {
 
 ### `fields` prop
 The `fields` prop is used to display table columns. 
-keys are used to extract real value from each row.
+Keys are used to extract real value from each row.
 Example format:
 ```js
 {
@@ -358,7 +358,7 @@ possible to filter data based on custom rendering of virtual columns. The items 
 is stringified and the filter searches that stringified data (excluding any properties
 that begin with an underscore (`_`) and the deprecated property `state`.
 
-Thw `filter` can be a string, a `RegExp` or a `function` reference.  If a function
+The `filter` can be a string, a `RegExp` or a `function` reference.  If a function
 is provided, the first argument is the original item record data object. The
 function should return `true` if the record matches your criteria or `false` if
 the record is to be filtered out.
@@ -372,7 +372,7 @@ The built-in default `sort-compare` function sorts the specified field `key` bas
 on the data in the underlying record object. The field value is first stringified
 if it is an object, and then sorted.
 
-The default `sort-compare` routine **cannot** sort virtual columns, nor can it sort
+The default `sort-compare` routine **cannot** sort neither virtual columns, nor 
 based on the custom rendering of the field data (which is used only for presentation).
 For this reason, you can provide your own custom sort compare routine by passing a
 function reference to the prop `sort-compare`.
@@ -514,7 +514,7 @@ following `b-table` prop(s) to `true`:
 When `no-provider-paging` is `false` (default), you should only return at
 maximum, `perPage` number of records.
 
-Note that `<b-table>` needs refernce to your pagination and filtering values in order to
+Note that `<b-table>` needs reference to your pagination and filtering values in order to
 trigger the calling of the provider function.  So be sure to bind to the `per-page`,
 `current-page` and `filter` props on `b-table` to trigger the provider update function call
 (unless you have the respective `no-provider-*` prop set to `true`).

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -32,16 +32,18 @@
            :filter="filter"
            @repaginate="repaginate"
   >
-    <template slot="name" scope="item">
-      {{item.value.first}} {{item.value.last}}
-    </template>
-    <template slot="isActive" scope="item">
-      {{item.value?'Yes :)':'No :('}}
-    </template>
-    <template slot="actions" scope="item">
-      <b-btn size="sm" @click="details(item.item)">Details</b-btn>
+    <template slot="name" scope="row">{{row.value.first}} {{row.value.last}}</template>
+    <template slot="isActive" scope="row">{{row.value?'Yes :)':'No :('}}</template>
+    <template slot="actions" scope="row">
+      <b-btn size="sm" @click="details(row.item,row.index,$event.target)">Details</b-btn>
     </template>
   </b-table>
+
+  <!-- Details modal -->
+  <b-modal id="modal1" @hide="resetDetails" ok-only>
+    <h4 class="my-1 py-1" slot="modal-header">Index: {{ modalDetails.index }}</h4>
+    <pre>{{ modalDetails.data }}</pre>
+  </b-modal>
 
  </div> 
 </template>
@@ -99,11 +101,18 @@ export default {
     },
     currentPage: 1,
     perPage: 5,
-    filter: null
+    filter: null,
+    modalDetails: { index:'', data:'' }
   },
   methods: {
-    details(item) {
-      alert(JSON.stringify(item));
+    details(item, index, button) {
+      this.modalDetails.data = JSON.stringify(item, null, 2);
+      this.modalDetails.index = index;
+      this.$root.$emit('show::modal','modal1', button);
+    },
+    resetModal() {
+      this.modalDetails.data = '';
+      this.modalDetails.index = '';
     },
     repaginate(filteredRows) {
       // Trigger pagination to update the number of buttons/pages due to filtering

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -19,8 +19,8 @@
     </div>
   </div>
 
-  <div class="justify-content-center my-1">
-    <b-pagination size="md" :total-rows="items.length" :per-page="perPage" v-model="currentPage" />
+  <div class="justify-content-center row my-1">
+    <b-pagination size="md" :total-rows="totalRows" :per-page="perPage" v-model="currentPage" />
   </div>
 
   <!-- Main table element -->
@@ -30,6 +30,7 @@
            :current-page="currentPage"
            :per-page="perPage"
            :filter="filter"
+           @repaginate="repaginate"
   >
     <template slot="name" scope="item">
       {{item.value.first}} {{item.value.last}}
@@ -46,37 +47,40 @@
 </template>
 
 <script>
+const items = [
+   {
+     isActive: true,  age: 40, name: { first: 'Dickerson', last: 'Macdonald' }
+   }, {
+     isActive: false, age: 21, name: { first: 'Larsen', last: 'Shaw' }
+   }, {
+     _rowVariant: 'success',
+     isActive: false, age: 9,  name: { first: 'Mitzi', last: 'Navarro' }
+   }, {
+     isActive: false, age: 89, name: { first: 'Geneva', last: 'Wilson' }
+   }, {
+     isActive: true,  age: 38, name: { first: 'Jami', last: 'Carney' }
+   }, {
+     isActive: false, age: 27, name: { first: 'Essie', last: 'Dunlap' }
+   }, {
+     isActive: true,  age: 40, name: { first: 'Dickerson', last: 'Macdonald' }
+   }, {
+     _cellVariants: { age: 'danger', isActive: 'warning' },
+     isActive: true,  age: 87, name: { first: 'Larsen', last: 'Shaw' }
+   }, {
+     isActive: false, age: 26, name: { first: 'Mitzi', last: 'Navarro' }
+   }, {
+     isActive: false, age: 22, name: { first: 'Geneva', last: 'Wilson' }
+   }, {
+     isActive: true,  age: 38, name: { first: 'Jami', last: 'Carney' }
+   }, {
+     isActive: false, age: 27, name: { first: 'Essie', last: 'Dunlap' }
+   }
+];
+
 export default {
   data: {
-    items: [
-      {
-        isActive: true, age: 40, name: { first: 'Dickerson', last: 'Macdonald' }
-      }, {
-        isActive: false, age: 21, name: { first: 'Larsen', last: 'Shaw' }
-      }, {
-        _rowVariant: 'success',
-        isActive: false, age: 9, name: { first: 'Mitzi', last: 'Navarro' }
-      }, {
-        isActive: false, age: 89, name: { first: 'Geneva', last: 'Wilson' }
-      }, {
-        isActive: true, age: 38, name: { first: 'Jami', last: 'Carney' }
-      }, {
-        isActive: false, age: 27, name: { first: 'Essie', last: 'Dunlap' }
-      }, {
-        isActive: true, age: 40, name: { first: 'Dickerson', last: 'Macdonald' }
-      }, {
-        _cellVariants: { age: 'danger', name: 'success' },
-        isActive: false, age: 21, name: { first: 'Larsen', last: 'Shaw' }
-      }, {
-        isActive: false, age: 26, name: { first: 'Mitzi', last: 'Navarro' }
-      }, {
-        isActive: false, age: 22, name: { first: 'Geneva', last: 'Wilson' }
-      }, {
-        isActive: true, age: 38, name: { first: 'Jami', last: 'Carney' }
-      }, {
-        isActive: false, age: 27, name: { first: 'Essie', last: 'Dunlap' }
-      }
-    ],
+    items: items,
+    totalRows: items.length,
     fields: {
       name: {
         label: 'Person Full name',
@@ -100,6 +104,10 @@ export default {
   methods: {
     details(item) {
       alert(JSON.stringify(item));
+    },
+    repaginate(filteredRows) {
+      // Trigger pagination to update the number of buttons/pages due to filtering
+      this.totalRows = filteredRows;
     }
   }
 }

--- a/docs/components/table/meta.json
+++ b/docs/components/table/meta.json
@@ -55,12 +55,12 @@
       ]
     },
     {
-      "event": "repaginate",
-      "description": "Emitted when local fitering causes a change in the total number of pages.",
+      "event": "filtered",
+      "description": "Emitted when local fitering causes a change in the number of items.",
       "args": [
         {
-          "arg": "filteredRows",
-          "description": "Total number of data rows after filtering (before pagination)."
+          "arg": "filteredItems",
+          "description": "Array of items after filtering (before pagination occurs)."
         }
       ]
     },

--- a/docs/components/table/meta.json
+++ b/docs/components/table/meta.json
@@ -55,6 +55,16 @@
       ]
     },
     {
+      "event": "repaginate",
+      "description": "Emitted when local fitering causes a change in the total number of pages.",
+      "args": [
+        {
+          "arg": "filteredRows",
+          "description": "Total number of data rows after filtering (before pagination)."
+        }
+      ]
+    },
+    {
       "event": "refreshed",
       "description": "Emitted when the items provider function has returned data."
     }

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -119,6 +119,11 @@
         }
     };
 
+    const calcNumPages = (rows, perPage) => {
+        const result = Math.ceil(rows / perPage);
+        return (result < 1) ? 1 : result;
+    };
+
     export default {
         data() {
             return {
@@ -137,7 +142,7 @@
                 default() {
                     if (this && this.itemsProvider) {
                         // Deprecate itemsProvider
-                        warn('b-table: prop items-provider has been deprecated. Pass a function to items instead');
+                        warn("b-table: prop 'items-provider' has been deprecated. Pass a function to 'items' instead");
                         return this.itemsProvider;
                     }
                     return [];
@@ -344,6 +349,7 @@
                     return [];
                 }
 
+                // Shallow copy of items, so we don't mutate thd original array
                 items = items.slice();
 
                 // Apply local filter
@@ -375,11 +381,18 @@
 
                 // Apply local pagination
                 if (perPage && !this.providerPaging) {
+                    // Calculate total possibly filtered items and number of pages
+                    const numItems = items.length;
+                    const numPages = calcNumPages(numItems, perPage);
+                    // Grab the current page
                     items = items.slice((currentPage - 1) * perPage, currentPage * perPage);
+                    // Emit a pagination notification event
+                    this.$emit('paginated', numItems, perPage, currentPage > numPages ? numPages : currentPage);
                 }
 
                 // Update the value model with the filtered/sorted/paginated data set
                 this.$emit('input', items);
+
                 return items;
             }
         },

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -349,8 +349,17 @@
                     return [];
                 }
 
-                // Shallow copy of items, so we don't mutate thd original array
+                // Shallow copy of items, so we don't mutate the original array order/size
                 items = items.slice();
+
+                // Number of pages before filtering
+                let numOriginalPages = calcNumPages(items.length, perPage);
+
+                // Number of pages after filtering (recalculated once filtering completes)
+                let numFilteredPages = numOriginalPages;
+
+                // Number of Items after filtering (recalculated after filtering completes)
+                let numFilteredItems = items.length;
 
                 // Apply local filter
                 if (filter && !this.providerFiltering) {
@@ -369,6 +378,12 @@
                             return test;
                         });
                     }
+
+                    // Recalculate the number of items after filtering
+                    numFilteredItems = items.length;
+
+                    // Calculate number of pages after filtering
+                    numFilteredPages = calcNumPages(numFilteredItems, perPage);
                 }
 
                 // Apply local Sort
@@ -381,17 +396,17 @@
 
                 // Apply local pagination
                 if (perPage && !this.providerPaging) {
-                    // Calculate total possibly filtered items and number of pages
-                    const numItems = items.length;
-                    const numPages = calcNumPages(numItems, perPage);
-                    // Grab the current page
+                    // Grab the current page of data (which may be past filtered items)
                     items = items.slice((currentPage - 1) * perPage, currentPage * perPage);
-                    // Emit a pagination notification event
-                    this.$emit('paginated', numItems, perPage, currentPage > numPages ? numPages : currentPage);
                 }
 
                 // Update the value model with the filtered/sorted/paginated data set
                 this.$emit('input', items);
+
+                if (numOriginalPages !== numFilteredPages);
+                    // Emit a repaginate notification event, as number of pages has changed
+                    this.$emit('repaginate', numFilteredItems);
+                }
 
                 return items;
             }

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -119,11 +119,6 @@
         }
     };
 
-    const calcNumPages = (rows, perPage) => {
-        const result = Math.ceil(rows / perPage);
-        return (result < 1) ? 1 : result;
-    };
-
     export default {
         data() {
             return {
@@ -352,17 +347,11 @@
                 // Shallow copy of items, so we don't mutate the original array order/size
                 items = items.slice();
 
-                // Number of pages before filtering
-                let numOriginalPages = calcNumPages(items.length, perPage);
-
-                // Number of pages after filtering (recalculated once filtering completes)
-                let numFilteredPages = numOriginalPages;
-
-                // Number of Items after filtering (recalculated after filtering completes)
-                let numFilteredItems = items.length;
-
                 // Apply local filter
                 if (filter && !this.providerFiltering) {
+                    // Number of Items before filtering
+                    let numOriginalItems = items.length;
+
                     if (filter instanceof Function) {
                         items = items.filter(filter);
                     } else {
@@ -379,11 +368,10 @@
                         });
                     }
 
-                    // Recalculate the number of items after filtering
-                    numFilteredItems = items.length;
-
-                    // Calculate number of pages after filtering
-                    numFilteredPages = calcNumPages(numFilteredItems, perPage);
+                    if (numOriginalItems !== items.length) {
+                        // Emit a filtered notification event, as number of items has changed
+                        this.$emit('filtered', items);
+                    }
                 }
 
                 // Apply local Sort
@@ -402,11 +390,6 @@
 
                 // Update the value model with the filtered/sorted/paginated data set
                 this.$emit('input', items);
-
-                if (numOriginalPages !== numFilteredPages) {
-                    // Emit a repaginate notification event, as number of pages has changed
-                    this.$emit('repaginate', numFilteredItems);
-                }
 
                 return items;
             }

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -347,8 +347,8 @@
 
                 // Apply local filter
                 if (filter && !this.providerFiltering) {
-                    // Number of Items before filtering
-                    let numOriginalItems = items.length;
+                    // Number of items before filtering
+                    const numOriginalItems = items.length;
 
                     if (filter instanceof Function) {
                         items = items.filter(filter);

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -93,14 +93,12 @@
             return '';
         }
 
-        // Exclude these fields from record stringification
-        const exclude = { state: true, _rowVariant: true };
-
         return toString(Object.keys(obj).reduce((o, k) => {
-          if (!exclude[k]) {
-            o[k] = obj[k];
-          }
-          return o;
+            // Ignore fields 'state' and ones that start with _
+            if (!(/^_/.test(k) || k === 'state')) {
+                o[k] = obj[k];
+            }
+            return o;
         }, {}));
     };
 

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -403,7 +403,7 @@
                 // Update the value model with the filtered/sorted/paginated data set
                 this.$emit('input', items);
 
-                if (numOriginalPages !== numFilteredPages);
+                if (numOriginalPages !== numFilteredPages) {
                     // Emit a repaginate notification event, as number of pages has changed
                     this.$emit('repaginate', numFilteredItems);
                 }


### PR DESCRIPTION
Addresses issue #650 

When local filtering causes the number of pages to change, emits a `repaginate` event with a single argument of the total number of records after filtering (and before pagination slices the data).

Can be used to re-set an associated `<b-pagination>` so that it adjusts to the new number of pages.

This PR includes documentation of the new event in `meta.json`, and updates live example in docs