### PR TITLE
docs: render markdown, props, events, slots tables with class 'table-sm'

### DIFF
--- a/docs/nuxt/components/componentdoc.vue
+++ b/docs/nuxt/components/componentdoc.vue
@@ -7,7 +7,7 @@
         <template v-if="props_items && props_items.length > 0">
             <h4>Properties</h4>
             <section>
-                <b-table :items="props_items" :fields="props_fields" head-variant="default" striped>
+                <b-table :items="props_items" :fields="props_fields" small head-variant="default" striped>
                     <template slot="default" scope="field">
                         <code v-if="field.value">{{field.value}}</code>
                     </template>
@@ -17,12 +17,12 @@
 
         <template v-if="slots && slots.length > 0">
             <h4>Slots</h4>
-            <b-table :items="slots" :fields="slots_fields" head-variant="default" striped></b-table>
+            <b-table :items="slots" :fields="slots_fields" small head-variant="default" striped></b-table>
         </template>
 
         <template v-if="events && events.length > 0">
             <h4>Events</h4>
-            <b-table :items="events" :fields="events_fields" head-variant="default" striped>
+            <b-table :items="events" :fields="events_fields" small head-variant="default" striped>
                 <template slot="args" scope="field">
                     <div v-for="arg in field.value" :key="arg">
                         <code v-if="arg.arg">{{arg.arg}}</code>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,7 +7,8 @@ const renderer = new marked.Renderer();
 const originalTable = renderer.table
 renderer.table = function renderTable(header, body) {
     let r = originalTable.apply(this, arguments)
-    return r.replace('<table>', '<table class="table b-table table-striped">')
+    return r.replace('<table>', '<table class="table b-table table-sm table-striped">')
+        .replace('<thead>', '<thead class="thead-default">')
 }
 
 module.exports = {


### PR DESCRIPTION
Reduces the amount of padding in the tables to make more information fit on the screen at once (less scrolling)

This is just a personal taste, but I find it more pleasing to the eye when reading.

Feel free to comment :smile: 