### PR TITLE
fix(dropdown): clear active state on menu open (fixes #664)

### DIFF
--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -125,8 +125,10 @@ export default {
             this.visible = !this.visible;
             if (this.visible) {
                 this.$nextTick(function () {
+                    // Clear any items that may have active state left
+                    this.clearItems();
                     // Focus first visible non-disabled item
-                    let item = this.getFirstItem();
+                    const item = this.getFirstItem();
                     if (item) {
                         this.focusItem(0, [item]);
                     }
@@ -205,6 +207,12 @@ export default {
                 } else {
                     el.classList.remove('active');
                 }
+            });
+        },
+        clearItems() {
+            const items = this.getItems();
+            items.forEach(el => {
+                el.classList.remove('active');
             });
         },
         getItems() {


### PR DESCRIPTION
Addresses issue #664 

Clears any items that may have the  `active` CSS class on them when opened. Then focuses the first item.