### PR TITLE
feat(microdata): add html5 microdata 

### DIFF
--- a/lib/components/breadcrumb.vue
+++ b/lib/components/breadcrumb.vue
@@ -12,13 +12,17 @@
                     v-html="normalizedItem.text"></b-link>
         </li>
         <slot></slot>
+
+        <script v-if="addMicrodata" type="application/ld+json">
+          {{ microdata }}
+        </script>
     </ol>
 </template>
 
 <script>
 import bLink from './link.vue';
 import { props as linkProps } from '../mixins/link';
-import {arrayIncludes} from '../utils';
+import arrayIncludes from '../utils/arrayIncludes';
 
 const bLinkPropKeys = Object.keys(linkProps);
 
@@ -70,7 +74,27 @@ export default {
 
                 return normalizedItem;
             });
+        },
+      microdata () {
+        const schema = {
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          'itemListElement' : []
         }
+        
+        this.normalizedItems.forEach((item, index) => {
+          schema.itemListElement.push({
+            '@type': 'ListItem',
+            'position': index + 1,
+            'item': {
+              '@id': item.to || item.href,
+              'name': item.text
+            }
+          })
+        })
+
+        return JSON.stringify(schema)
+      }
     },
     props: {
         items: {
@@ -81,6 +105,10 @@ export default {
         ariaCurrent: {
             type: String,
             default: 'location'
+        },
+        addMicrodata: {
+          type: Boolean,
+          default: false
         }
     },
     methods: {


### PR DESCRIPTION
This is a possible solution for #624. I believe using the `json+ld` variant instead of adding the itemscope attributes is preferable as its less intrusive. 

That said, I was looking at other components who could benefit from microdata but I couldnt find any actually. And as the `json+ld` variant can also be easily implemented by the users themselves, maybe bootstrap-vue does not need to support microdata after all?