### PR TITLE
feat(listen-on-root): Use a constant for private property name

### DIFF
--- a/lib/mixins/listen-on-root.js
+++ b/lib/mixins/listen-on-root.js
@@ -3,6 +3,9 @@ import { isArray } from "../utils/array"
  * Issue #569: collapse::toggle::state triggered too many times
  * @link https://github.com/bootstrap-vue/bootstrap-vue/issues/569
  */
+
+const BVRL = '__BV_root_listeners__';
+
 export default {
     methods: {
         /**
@@ -21,13 +24,12 @@ export default {
          * @chainable
          */
         listenOnRoot(event, callback) {
-            if (!this.__bv_root_listeners || !isArray(this.__bv_root_listeners)) {
-                this.__bv_root_listeners = []
+            if (!this[BVRL] || !isArray(this[BVRL])) {
+                this[BVRL] = [];
             }
-            this.__bv_root_listeners.push({ event, callback })
-            this.$root.$on(event, callback)
-
-            return this
+            this[BVRL].push({ event, callback });
+            this.$root.$on(event, callback);
+            return this;
         },
 
         /**
@@ -37,18 +39,17 @@ export default {
          * @chainable
          */
         emitOnRoot(event, ...args) {
-            this.$root.$emit(event, ...args)
-
-            return this
+            this.$root.$emit(event, ...args);
+            return this;
         }
     },
 
     destroyed() {
-        if (this.__bv_root_listeners && isArray(this.__bv_root_listeners)) {
-            while (this.__bv_root_listeners.length > 0) {
+        if (this[BVRL] && isArray(this[BVRL])) {
+            while (this[BVRL].length > 0) {
                 // shift to process in order
-                const { event, callback } = this.__bv_root_listeners.shift()
-                this.$root.$off(event, callback)
+                const { event, callback } = this[BVRL].shift();
+                this.$root.$off(event, callback);
             }
         }
     }


### PR DESCRIPTION
Minor adjustment to use a constant to define the private property name used for storing the root listeners array.
