### PR TITLE
feat(modal) Make enforceFocus configurable

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -197,6 +197,10 @@
                 type: Boolean,
                 default: false
             },
+            noEnforceFocus: {
+                type: Boolean,
+                default: false
+            },
             hideHeader: {
                 type: Boolean,
                 default: false
@@ -359,7 +363,8 @@
             enforceFocus(e) {
                 // If focus leaves modal, bring it back
                 // Event Listener bound on document
-                if (this.is_visible &&
+                if (!this.noEnforceFocus &&
+                    this.is_visible &&
                     document !== e.target &&
                     this.$refs.content &&
                     this.$refs.content !== e.target &&


### PR DESCRIPTION
In our project, we needed to launch a secondary modal with some form inputs from a Bootstrap-Vue Modal. Due to the "enforceFocus", this was not possible.

If we make this feature configurable, we can use the <b-modal> also when used with a secondary form modal launched from within the first modal.