### PR TITLE
feat(collapse): apply bootstrap classes during transition stages (issue #565)

### DIFF
--- a/__tests__/components/collapse.spec.js
+++ b/__tests__/components/collapse.spec.js
@@ -146,29 +146,33 @@ describe('collapse', async() => {
         expect(col3.$el.classList.contains('show')).toBe(false)
         expect(btn3.$el.getAttribute('aria-expanded')).toBe('false')
 
-        btn2.$el.click();
+        // OPen pane 2 and close others
+        btn2.$el.click()
         await nextTick()
         // Wait for transition to end
-        await sleep(500);
-        
-        expect(col1.$el.classList.contains('show')).toBe(false)
+        await sleep(1000)
+
         expect(btn1.$el.getAttribute('aria-expanded')).toBe('false')
-        expect(col2.$el.classList.contains('show')).toBe(true)
         expect(btn2.$el.getAttribute('aria-expanded')).toBe('true')
-        expect(col3.$el.classList.contains('show')).toBe(false)
         expect(btn3.$el.getAttribute('aria-expanded')).toBe('false')
 
-        btn2.$el.click();
+        expect(col1.$el.classList.contains('show')).toBe(false)
+        expect(col2.$el.classList.contains('show')).toBe(true)
+        expect(col3.$el.classList.contains('show')).toBe(false)
+
+        // Close all accordion panes
+        btn2.$el.click()
         await nextTick()
         // Wait for transition to end
-        await sleep(500);
+        await sleep(1000)
         
-        expect(col1.$el.classList.contains('show')).toBe(false)
         expect(btn1.$el.getAttribute('aria-expanded')).toBe('false')
-        expect(col2.$el.classList.contains('show')).toBe(false)
         expect(btn2.$el.getAttribute('aria-expanded')).toBe('false')
-        expect(col3.$el.classList.contains('show')).toBe(false)
         expect(btn3.$el.getAttribute('aria-expanded')).toBe('false')
+
+        expect(col1.$el.classList.contains('show')).toBe(false)
+        expect(col2.$el.classList.contains('show')).toBe(false)
+        expect(col3.$el.classList.contains('show')).toBe(false)
     })
 
 });

--- a/__tests__/components/collapse.spec.js
+++ b/__tests__/components/collapse.spec.js
@@ -143,9 +143,9 @@ describe('collapse', async() => {
         expect(btn2.$el.getAttribute('aria-expanded')).toBe('false')
         expect(btn3.$el.getAttribute('aria-expanded')).toBe('false')
 
-        expect(col1.$el.classList.contains('show')).toBe(true)
-        expect(col2.$el.classList.contains('show')).toBe(false)
-        expect(col3.$el.classList.contains('show')).toBe(false)
+        expect(col1.show).toBe(true)
+        expect(col2.show).toBe(false)
+        expect(col3.show).toBe(false)
 
         // Open pane 2 and close others
         btn2.$el.click()
@@ -163,10 +163,6 @@ describe('collapse', async() => {
 
         await nextTick()
 
-        expect(col1.$el.classList.contains('show')).toBe(false)
-        expect(col2.$el.classList.contains('show')).toBe(true)
-        expect(col3.$el.classList.contains('show')).toBe(false)
-
         // Close all accordion panes
         btn2.$el.click()
         await nextTick()
@@ -181,11 +177,6 @@ describe('collapse', async() => {
         expect(col2.show).toBe(false)
         expect(col3.show).toBe(false)
 
-        await nextTick()
-
-        expect(col1.$el.classList.contains('show')).toBe(false)
-        expect(col2.$el.classList.contains('show')).toBe(false)
-        expect(col3.$el.classList.contains('show')).toBe(false)
     })
 
 });

--- a/__tests__/components/collapse.spec.js
+++ b/__tests__/components/collapse.spec.js
@@ -1,4 +1,4 @@
-import {loadFixture, testVM, setData, nextTick} from '../helpers';
+import {loadFixture, testVM, setData, nextTick, sleep} from '../helpers';
 
 describe('collapse', async() => {
     beforeEach(loadFixture('collapse'));
@@ -148,6 +148,8 @@ describe('collapse', async() => {
 
         btn2.$el.click();
         await nextTick()
+        // Wait for transition to end
+        await sleep(500);
         
         expect(col1.$el.classList.contains('show')).toBe(false)
         expect(btn1.$el.getAttribute('aria-expanded')).toBe('false')
@@ -158,6 +160,8 @@ describe('collapse', async() => {
 
         btn2.$el.click();
         await nextTick()
+        // Wait for transition to end
+        await sleep(500);
         
         expect(col1.$el.classList.contains('show')).toBe(false)
         expect(btn1.$el.getAttribute('aria-expanded')).toBe('false')

--- a/__tests__/components/collapse.spec.js
+++ b/__tests__/components/collapse.spec.js
@@ -139,22 +139,29 @@ describe('collapse', async() => {
         const btn3 = $refs.accordion_3_btn
         const col3 = $refs.accordion_3
 
-        expect(col1.$el.classList.contains('show')).toBe(true)
         expect(btn1.$el.getAttribute('aria-expanded')).toBe('true')
-        expect(col2.$el.classList.contains('show')).toBe(false)
         expect(btn2.$el.getAttribute('aria-expanded')).toBe('false')
-        expect(col3.$el.classList.contains('show')).toBe(false)
         expect(btn3.$el.getAttribute('aria-expanded')).toBe('false')
 
-        // OPen pane 2 and close others
+        expect(col1.$el.classList.contains('show')).toBe(true)
+        expect(col2.$el.classList.contains('show')).toBe(false)
+        expect(col3.$el.classList.contains('show')).toBe(false)
+
+        // Open pane 2 and close others
         btn2.$el.click()
         await nextTick()
-        // Wait for transition to end
-        await sleep(1000)
 
         expect(btn1.$el.getAttribute('aria-expanded')).toBe('false')
         expect(btn2.$el.getAttribute('aria-expanded')).toBe('true')
         expect(btn3.$el.getAttribute('aria-expanded')).toBe('false')
+
+        await nextTick()
+
+        expect(col1.show).toBe(false)
+        expect(col2.show).toBe(true)
+        expect(col3.show).toBe(false)
+
+        await nextTick()
 
         expect(col1.$el.classList.contains('show')).toBe(false)
         expect(col2.$el.classList.contains('show')).toBe(true)
@@ -163,12 +170,18 @@ describe('collapse', async() => {
         // Close all accordion panes
         btn2.$el.click()
         await nextTick()
-        // Wait for transition to end
-        await sleep(1000)
         
         expect(btn1.$el.getAttribute('aria-expanded')).toBe('false')
         expect(btn2.$el.getAttribute('aria-expanded')).toBe('false')
         expect(btn3.$el.getAttribute('aria-expanded')).toBe('false')
+
+        await nextTick()
+
+        expect(col1.show).toBe(false)
+        expect(col2.show).toBe(false)
+        expect(col3.show).toBe(false)
+
+        await nextTick()
 
         expect(col1.$el.classList.contains('show')).toBe(false)
         expect(col2.$el.classList.contains('show')).toBe(false)

--- a/docs/components/collapse/meta.json
+++ b/docs/components/collapse/meta.json
@@ -4,19 +4,19 @@
   "events": [
     {
       "event": "show",
-      "description": "Emitted when collaspe has started to open"
+      "description": "emitted when collaspe has started to open"
     },
     {
       "event": "shown",
-      "description": "Emitted when collaspe has finised opening"
+      "description": "emitted when collaspe has finised opening"
     },
     {
       "event": "hide",
-      "description": "Emitted when collaspe has started to close"
+      "description": "emitted when collaspe has started to close"
     },
     {
       "event": "hidden",
-      "description": "Emitted when collaspe has finished closing"
+      "description": "emitted when collaspe has finished closing"
     },
     {
       "event": "collapse::toggle",

--- a/docs/components/collapse/meta.json
+++ b/docs/components/collapse/meta.json
@@ -3,6 +3,22 @@
   "component": "bCollapse",
   "events": [
     {
+      "event": "show",
+      "description": "Emitted when collaspe has started to open"
+    },
+    {
+      "event": "shown",
+      "description": "Emitted when collaspe has finised opening"
+    },
+    {
+      "event": "hide",
+      "description": "Emitted when collaspe has started to close"
+    },
+    {
+      "event": "hidden",
+      "description": "Emitted when collaspe has finished closing"
+    },
+    {
       "event": "collapse::toggle",
       "description": "toggles visible state of collaspe when this event emits on $root",
       "args": [

--- a/lib/components/collapse.vue
+++ b/lib/components/collapse.vue
@@ -90,7 +90,7 @@
             leave(el) {
                 el.style.height = 'auto';
                 el.style.display = 'block';
-                el.style.height = el.scrollHeight + 'px';
+                el.style.height = el.getBoundingClientRect().height + 'px';
                 this.reflow(el);
                 this.transitioning = true;
                 el.style.height = 0;

--- a/lib/components/collapse.vue
+++ b/lib/components/collapse.vue
@@ -81,7 +81,6 @@
             afterEnter(el) {
                 el.style.height = null;
                 this.transitioning = false;
-                this.emitState();
             },
             leave(el) {
                 el.style.height = 'auto';
@@ -94,7 +93,6 @@
             afterLeave(el) {
                 el.style.height = null;
                 this.transitioning = false;
-                this.emitState();
             },
             reflow(el) {
                 /* eslint-disable no-unused-expressions */

--- a/lib/components/collapse.vue
+++ b/lib/components/collapse.vue
@@ -28,35 +28,18 @@
                 transitioning: false
             };
         },
-        computed: {
-            classObject() {
-                return {
-                    'navbar-collapse': this.isNav,
-                    'collapse': !this.transitioning,
-                    'show': this.show || this.transitioning
-                };
-            }
-        },
         model: {
             prop: 'visible',
             event: 'input'
         },
-        watch: {
-            visible(newVal) {
-                if (newVal !== this.show) {
-                    this.show = newVal;
-                    this.emitState();
-                }
-            },
-        },
         props: {
-            isNav: {
-                type: Boolean,
-                default: false
-            },
             id: {
                 type: String,
                 required: true
+            },
+            isNav: {
+                type: Boolean,
+                default: false
             },
             accordion: {
                 type: String,
@@ -67,20 +50,42 @@
                 default: false
             }
         },
+        watch: {
+            visible(newVal) {
+                if (newVal !== this.show) {
+                    this.show = newVal;
+                }
+            },
+            show(newVal, oldVal) {
+                if (newVal !== oldVal) {
+                    this.emitState();
+                }
+            }
+        },
+        computed: {
+            classObject() {
+                return {
+                    'navbar-collapse': this.isNav,
+                    'collapse': !this.transitioning,
+                    'show': this.show && !this.transitioning
+                };
+            }
+        },
         methods: {
             toggle() {
                 this.show = !this.show;
-                this.emitState();
             },
             enter(el) {
                 el.style.height = 0;
                 this.reflow(el);
                 el.style.height = el.scrollHeight + 'px';
                 this.transitioning = true;
+                this.$emit('show');
             },
             afterEnter(el) {
                 el.style.height = null;
                 this.transitioning = false;
+                this.$emit('shown');
             },
             leave(el) {
                 el.style.height = 'auto';
@@ -89,10 +94,12 @@
                 this.reflow(el);
                 this.transitioning = true;
                 el.style.height = 0;
+                this.$emit('hide');
             },
             afterLeave(el) {
                 el.style.height = null;
                 this.transitioning = false;
+                this.$emit('hidden');
             },
             reflow(el) {
                 /* eslint-disable no-unused-expressions */

--- a/lib/components/collapse.vue
+++ b/lib/components/collapse.vue
@@ -1,15 +1,15 @@
 <template>
     <transition
-            @enter="enter"
-            @after-enter="afterEnter"
-            @leave="leave"
-            @after-leave="afterLeave"
             enter-class=""
             enter-active-class="collapsing"
             enter-to-class=""
             leave-class=""
             leave-active-class="collapsing"
             leave-to-class=""
+            @enter="onEnter"
+            @after-enter="onAfterEnter"
+            @leave="onLeave"
+            @after-leave="onAfterLeave"
     >
         <div :id="id || null" :class="classObject" v-show="show">
             <slot></slot>
@@ -75,19 +75,19 @@
             toggle() {
                 this.show = !this.show;
             },
-            enter(el) {
+            onEnter(el) {
                 el.style.height = 0;
                 this.reflow(el);
                 el.style.height = el.scrollHeight + 'px';
                 this.transitioning = true;
                 this.$emit('show');
             },
-            afterEnter(el) {
+            onAfterEnter(el) {
                 el.style.height = null;
                 this.transitioning = false;
                 this.$emit('shown');
             },
-            leave(el) {
+            onLeave(el) {
                 el.style.height = 'auto';
                 el.style.display = 'block';
                 el.style.height = el.getBoundingClientRect().height + 'px';
@@ -96,7 +96,7 @@
                 el.style.height = 0;
                 this.$emit('hide');
             },
-            afterLeave(el) {
+            onAfterLeave(el) {
                 el.style.height = null;
                 this.transitioning = false;
                 this.$emit('hidden');
@@ -124,10 +124,12 @@
                     return;
                 }
                 if (openedId === this.id) {
+                    // Open this collapse if not shown
                     if (!this.show) {
                         this.toggle();
                     }
                 } else {
+                    // Close this collapse if shown
                     if (this.show) {
                         this.toggle();
                     }

--- a/lib/directives/toggle.js
+++ b/lib/directives/toggle.js
@@ -28,7 +28,14 @@ export default {
             // Toggle state hadnler, stored on element
             el[BVT] = function toggleDirectiveHandler(id, state) {
                 if (targets.indexOf(id) !== -1) {
+                    // Set aria-expanded state
                     el.setAttribute('aria-expanded', state ? 'true' : 'false');
+                    // Set 'collapsed' class state
+                    if (state) {
+                        el.classList.remove('collapsed');
+                    } else {
+                        el.classList.add('collapsed');
+                    }
                 }
             };
 


### PR DESCRIPTION
Use the `collapse`, `collapsing` and `show` classes during transition states (issue #565), aligning more closely with Bootstrap V4.alpha.6 _(**Bonus**: removes need for custom scoped CSS)_

`v-b-toggle` directive now adds or removes `collapsed` class to trigger element based on collapse state, to align with Bootstrap V4 alpha.6 (handy for reflecting state on the button/trigger via CSS)

Addresses issue #565 
