### PR TITLE
fix(nav-item-dropdown): Prevent click from scrolling page (Issue #705)

### DIFF
--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -8,9 +8,9 @@
            aria-haspopup="true"
            :aria-expanded="visible ? 'true' : 'false'"
            :disabled="disabled"
-           @click.stop.prevent="toggle($event)"
-           @keydown.enter.stop.prevent="toggle($event)"
-           @keydown.space.stop.prevent="toggle($event)"
+           @click.stop.prevent="toggle"
+           @keydown.enter.stop.prevent="toggle"
+           @keydown.space.stop.prevent="toggle"
         >
             <slot name="button-content"><slot name="text"><span v-html="text"></span></slot></slot>
         </a>

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -110,12 +110,15 @@ export default {
             }
             if (this.split) {
                 this.$emit('click', e);
-                this.emitOnRoot('shown::dropdown', this);
             } else {
-                this.toggle();
+                this.toggle(e);
             }
         },
-        toggle() {
+        toggle(e) {
+            if (e && e.preventDefault) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
             if (this.disabled) {
                 this.visible = false;
                 return;


### PR DESCRIPTION
Prevent click of trigger button of nav-item-dropdown from scrolling page to top.

Addresses Issue #705