### PR TITLE
feat(button): Add pressed prop to place button in active state

### DIFF
--- a/__tests__/components/button.spec.js
+++ b/__tests__/components/button.spec.js
@@ -1,4 +1,4 @@
-import { loadFixture, testVM } from '../helpers'
+import {loadFixture, testVM, setData, nextTick} from '../helpers';
 import { bLink } from '../../lib/components'
 import Vue from 'vue/dist/vue.common';
 
@@ -8,10 +8,11 @@ import Vue from 'vue/dist/vue.common';
  * - Sizes: [ 'sm','','lg' ]
  * - Props: [ disabled, block ]
  * - elements: [ <button/>, <a/> ]
+ * - pressed state, toggling state
  */
 
-const variants = ['primary', 'secondary', 'success', 'outline-success', 'warning', 'danger', 'link']
-const sizes = ['sm', '', 'lg']
+const variants = ['primary', 'secondary', 'success', 'outline-success', 'warning', 'danger', 'link'];
+const sizes = ['sm', '', 'lg'];
 const btnRefs = variants.reduce((memo, variant) => [
     ...memo,
     ...sizes.map(size => {
@@ -21,70 +22,131 @@ const btnRefs = variants.reduce((memo, variant) => [
             ref: `btn${size ? `_${size}` : ''}_${variant.replace(/-/g, '_')}`
         }
     })
-], [])
+], []);
 
 describe('button', async() => {
-    beforeEach(loadFixture('button'))
-    testVM()
+    beforeEach(loadFixture('button'));
+    testVM();
 
     it('should contain class names', async() => {
-        const { app: { $refs, $el } } = window
+        const {app: {$refs, $el}} = window;
 
         btnRefs.forEach(({ ref, variant, size }) => {
             // ref will contain an array of children because of v-for
-            const vm = $refs[ref][0]
+            const vm = $refs[ref][0];
 
-            let classList = ['btn', `btn-${variant}`]
-            if (size) classList.push(`btn-${size}`)
+            let classList = ['btn', `btn-${variant}`];
+            if (size) classList.push(`btn-${size}`);
 
             expect(vm).toHaveAllClasses(classList)
-        })
+        });
 
-        const vmBlockDisabled = $refs.btn_block_disabled
+        const vmBlockDisabled = $refs.btn_block_disabled;
         expect(vmBlockDisabled).toHaveAllClasses(['btn', 'btn-block', 'disabled'])
-    })
+    });
 
     it('should use <b-link> when given href', async() => {
-        const { app: { $refs, $el } } = window
-        const btnChildNode = $refs.btn_href.$children[0]
+        const {app: {$refs, $el}} = window;
+        const btnChildNode = $refs.btn_href.$children[0];
 
-        expect(btnChildNode).toBeInstanceOf(Vue)
-        expect(btnChildNode).toBeComponent('b-link')
+        expect(btnChildNode).toBeInstanceOf(Vue);
+        expect(btnChildNode).toBeComponent('b-link');
         expect(btnChildNode.href).toBe('https://github.com/bootstrap-vue/bootstrap-vue')
-    })
+    });
 
     it('should emit "click" event when clicked', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.btn_click
+        const {app: {$refs, $el}} = window;
+        const vm = $refs.btn_click;
         const spy = jest.fn();
 
-        vm.$on('click', spy)
-        vm.$el.click()
+        vm.$on('click', spy);
+        vm.$el.click();
 
         expect(spy).toHaveBeenCalled()
-    })
+    });
 
-    it('should "click" event should emit with native event object', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.btn_click
+    it('"click" event should emit with native event object', async () => {
+        const {app: {$refs, $el}} = window;
+        const vm = $refs.btn_click;
         let event = null;
 
-        vm.$on('click', e => event = e)
-        vm.$el.click()
+        vm.$on('click', e => event = e);
+        vm.$el.click();
 
         expect(event).toBeInstanceOf(MouseEvent)
-    })
+    });
 
     it('should be disabled and not emit click event with `disabled` prop true', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.btn_block_disabled
+        const {app: {$refs, $el}} = window;
+        const vm = $refs.btn_block_disabled;
         const spy = jest.fn();
 
-        vm.$on('click', spy)
-        vm.$el.click()
+        vm.$on('click', spy);
+        vm.$el.click();
 
-        expect(vm.disabled).toBe(true)
-        expect(vm.$el.disabled).toBe(true)
+        expect(vm.disabled).toBe(true);
+        expect(vm.$el.disabled).toBe(true);
         expect(spy).not.toHaveBeenCalled()
+    });
+
+    it('shoud not have `.active` class and `aria-pressed` when pressed is null', async () => {
+        const {app: {$refs, $el}} = window;
+        const vm = $refs.btn_pressed;
+
+        await setData(app, 'btnToggle', null);
+        await nextTick();
+
+        expect(vm.pressed).toBeNull();
+        expect(vm).not.toHaveClass('active');
+        expect(vm.$el.getAttribute('aria-pressed')).toBeNull();
+        vm.$el.click();
+        expect(vm.pressed).toBeNull();
+        expect(app.btnToggle).toBeNull();
+    });
+
+    it('shoud not have `.active` class and have `aria-pressed="false"` when pressed is false', async () => {
+        const {app: {$refs, $el}} = window;
+        const vm = $refs.btn_pressed;
+
+        await setData(app, 'btnToggle', false);
+        await nextTick();
+
+        expect(vm.pressed).toBe(false);
+        expect(vm).not.toHaveClass('active');
+        expect(vm.$el.getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('shoud have `.active` class and have `aria-pressed="true"` when pressed is true', async () => {
+        const {app: {$refs, $el}} = window;
+        const vm = $refs.btn_pressed;
+
+        await setData(app, 'btnToggle', true);
+        await nextTick();
+
+        vm.$el.click();
+
+        expect(vm.pressed).toBe(true);
+        expect(vm).toHaveClass('active');
+        expect(vm.$el.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('shoud emit `update:pressed` event on click and toggle pressed prop when pressed in not null', async () => {
+        const {app: {$refs, $el}} = window;
+        const vm = $refs.btn_pressed;
+        const spy = jest.fn();
+
+        await setData(app, 'btnToggle', false);
+        await nextTick();
+        vm.$on('update:pressed', spy);
+
+        expect(vm.pressed).toBe(false);
+        expect(vm).not.toHaveClass('active');
+        expect(vm.$el.getAttribute('aria-pressed')).toBe('false');
+        vm.$el.click();
+        await nextTick();
+        expect(vm).toHaveClass('active');
+        expect(vm.$el.getAttribute('aria-pressed')).toBe('true');
+        expect(vm.pressed).toBe(true);
+        expect(spy).toHaveBeenCalled();
     })
-})
+});

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -5,12 +5,12 @@
 
 ```html
 <div class="row">
-<template v-for="variant in ['primary','secondary','success','outline-success','warning','danger','link']">
-    <div class="col-md-4 pb-2" v-for="size in ['sm','','lg']">
-    <b-button :size="size" :variant="variant" href="">
-        {{variant}} {{size}}
+<template v-for="var in ['primary','secondary','success','outline-success','warning','danger','link']">
+  <div class="col-md-4 pb-2" v-for="size in ['sm','','lg']">
+    <b-button :size="size" :variant="var">
+      {{variant}} {{size}}
     </b-button>
-    </div>
+  </div>
 </template>
 </div>
 
@@ -90,17 +90,33 @@ the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
 ```html
 <template>
   <div>
+    <h5>Pressed and un-pressed state</h5>
     <b-button :pressed="true" variant="success">Always Pressed</b-button>
     <b-button :pressed="false" variant="success">Not Pressed</b-button>
-    <br><br>
-    <b-button :pressed.sync="myToggle" variant="primary">Toggle Me</b-button>
+
+    <h5>Toggleable Button</h5>
+    <b-button :pressed.sync="myToggle0" variant="primary">Toggle Me</b-button>
+    <p>Pressed State: {{myToggle0}}</p>
+
+    <h5>In a button group</h5>
+    <b-button-group>
+      <b-button :pressed.sync="myToggle1" variant="primary">Toggle 1</b-button>
+      <b-button :pressed.sync="myToggle2" variant="danger">Toggle 2</b-button>
+      <b-button :pressed.sync="myToggle3" variant="warning">Toggle 3</b-button>
+      <b-button :pressed.sync="myToggle4" variant="outline-success">Toggle 4</b-button>
+    </b-button-group>
+    <p>Pressed States: [ {{myToggle1}}, {{myToggle2}}, {{myToggle3}}, {{myToggle4}} ]</p>
   </div>
 </template>
 
 <script>
   export default {
     data: {
-      myToggle: false
+      myToggle0: false,
+      myToggle1: true,
+      myToggle2: false,
+      myToggle3: true,
+      myToggle4: false
     }
   }
 </script>
@@ -115,3 +131,8 @@ Note the `tag` attribute for `<router-link>` is refered to as `router-tag` in `b
 
 ### Alias
 `<b-button>` can also be used by its shorter alias `<b-btn>`.
+
+### See also
+- [`<b-button-group>`](./button-group)
+- [`<b-button-toolbar>`](./button-toolbar)
+

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -116,7 +116,7 @@ the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
         { variant: 'primary', caption: 'Toggle 1', state: true },
         { variant: 'danger', caption: 'Toggle 2', state: false },
         { variant: 'warning', caption: 'Toggle 3', state: true },
-        { variant: 'success', caption: 'Toggle 4', state: false },
+        { variant: 'success', caption: 'Toggle 4', state: null },
         { variant: 'outline-success', caption: 'Toggle 5', state: false },
         { variant: 'outline-primary', caption: 'Toggle 6', state: false }
       ]

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -116,7 +116,7 @@ the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
         { variant: 'primary', caption: 'Toggle 1', state: true },
         { variant: 'danger', caption: 'Toggle 2', state: false },
         { variant: 'warning', caption: 'Toggle 3', state: true },
-        { variant: 'success', caption: 'Toggle 4', state: null },
+        { variant: 'success', caption: 'No Toggle', state: null },
         { variant: 'outline-success', caption: 'Toggle 5', state: false },
         { variant: 'outline-primary', caption: 'Toggle 6', state: false }
       ]

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -17,10 +17,20 @@
 <!-- button-1.vue -->
 ```
 
+### Element type
 The `<b-button>` component generally renders a `<button>` element. However, you can also
 render an `<a>` element by providing an `href` prop value. You man also generate
 `vue-router` `<router-link>` when providing a value for the `to` prop (`vue-router`
-is  required).
+is required).
+
+```html
+<div>
+  <b-button>I am a Button</b-button>
+  <b-button href="#">I am a Link</b-button>
+</div>
+
+<!-- button-2.vue -->
+```
 
 ### Button Sizing
 Fancy larger or smaller buttons? Specify `lg` or `sm` via the `size` prop.
@@ -57,7 +67,7 @@ works with buttons, rendered as `<a>` elements and `<router-link>`.
   <b-button variant="success">Not Disabled</b-button>
 </div>
 
-<!-- button-2.vue -->
+<!-- button-3.vue -->
 ```
 
 ### Button type
@@ -95,7 +105,7 @@ the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
   }
 </script>
 
-<!-- button-3.vue -->
+<!-- button-4.vue -->
 ```
 
 ### Router links

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -80,11 +80,11 @@ Buttons will appear pressed (with a darker background, darker border, and inset 
 when the prop `presed` is set to `true`.
 
 The `pressed` prop can be set to one of three values:
-- `true`: Sets the `.active` class and adds the atribute `aria-pressed="true"`.
-- `false`: Clears the `.active` class and adds the atribute `aria-pressed="false"`.
+- `true`: Sets the `.active` class and adds the attribute `aria-pressed="true"`.
+- `false`: Clears the `.active` class and adds the attribute `aria-pressed="false"`.
 - `null`: (default) Neither the class `.active` nor the attribute `aria-pressed` will be set.
 
-To create a button that can be toggled between avtive and non-active states, use
+To create a button that can be toggled between active and non-active states, use
 the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
 
 ```html

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -14,7 +14,7 @@
 </template>
 </div>
 
-<!-- button.vue -->
+<!-- button-1.vue -->
 ```
 
 The `<b-button>` component generally renders a `<button>` element. However, you can also
@@ -55,6 +55,35 @@ works with buttons, rendered as `<a>` elements and `<router-link>`.
 When neither `href` nor `to` props are provided, `<b-button>` renders an html `<button>`
 element.  You can specify the button's type by setting the prop `type` to `button`,
 `submit` or `reset`.  The default type is `button`.
+
+### Pressed state and toggling
+Buttons will appear pressed (with a darker background, darker border, and inset shadow)
+when the prop `presed` is set to `true`.
+
+The `pressed` prop can be set to one of three values:
+- `true`: Sets the `.active` classs and adds the atribute `aria-pressed="true"`.
+- `false`: Clears the `.active` classs and adds the atribute `aria-pressed="false"`.
+- `null`: (default) Neither the class `.active` nor the attribute `aria-pressed` will be set.
+
+To create a button that can be toggled between avtive and non-active states, use
+the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
+
+```html
+<template>
+  <b-button :pressed="true" variant="success">Always Pressed</b-button>
+  <b-button :pressed.sync="myToggle" variant="primary">Toggle Me</b-button>
+</template>
+
+<script>
+  export default {
+    data: {
+      myToggle: false
+    }
+  }
+</script>
+
+<!-- button-2.vue -->
+```
 
 ### Router links
 Refer to [`vue-router`](https://router.vuejs.org/) docs for the various `<router-link>` related props.

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -96,27 +96,35 @@ the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
 
     <h5>Toggleable Button</h5>
     <b-button :pressed.sync="myToggle0" variant="primary">Toggle Me</b-button>
-    <p>Pressed State: {{myToggle0}}</p>
+    <p>Pressed State: <strong>{{ myToggle }}</strong></p>
 
     <h5>In a button group</h5>
-    <b-button-group>
-      <b-button :pressed.sync="myToggle1" variant="primary">Toggle 1</b-button>
-      <b-button :pressed.sync="myToggle2" variant="danger">Toggle 2</b-button>
-      <b-button :pressed.sync="myToggle3" variant="warning">Toggle 3</b-button>
-      <b-button :pressed.sync="myToggle4" variant="outline-success">Toggle 4</b-button>
+    <b-button-group size="sm">
+      <b-button v-for="btn in buttons" :pressed.sync="btn.state" :variant="btn.variant">
+        {{ btn.caption }}
+      </b-button>
     </b-button-group>
-    <p>Pressed States: [ {{myToggle1}}, {{myToggle2}}, {{myToggle3}}, {{myToggle4}} ]</p>
+    <p>Pressed States: <strong>{{ btnStates }}</strong></p>
   </div>
 </template>
 
 <script>
   export default {
     data: {
-      myToggle0: false,
-      myToggle1: true,
-      myToggle2: false,
-      myToggle3: true,
-      myToggle4: false
+      myToggle: false,
+      buttons: [
+        { variant: 'primary', caption: 'Toggle 1', state: true },
+        { variant: 'danger', caption: 'Toggle 2', state: false },
+        { variant: 'warning', caption: 'Toggle 3', state: true },
+        { variant: 'success', caption: 'Toggle 4', state: false },
+        { variant: 'outline-success', caption: 'Toggle 5', state: false },
+        { variant: 'outline-primary', caption: 'Toggle 6', state: false }
+      ]
+    },
+    computed: {
+      btnStates() {
+        return this.buttons.map(btn => btn.state);
+      }
     }
   }
 </script>

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -51,6 +51,15 @@ default padding and size of a button.
 Set the `disabled` prop to disable button default funtionality. `disabled` also 
 works with buttons, rendered as `<a>` elements and `<router-link>`.
 
+```html
+<div>
+  <b-button disabled variant="success">Disabled</b-button>
+  <b-button variant="success">Not Disabled</b-button>
+</div>
+
+<!-- button-2.vue -->
+```
+
 ### Button type
 When neither `href` nor `to` props are provided, `<b-button>` renders an html `<button>`
 element.  You can specify the button's type by setting the prop `type` to `button`,
@@ -70,8 +79,12 @@ the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
 
 ```html
 <template>
-  <b-button :pressed="true" variant="success">Always Pressed</b-button>
-  <b-button :pressed.sync="myToggle" variant="primary">Toggle Me</b-button>
+  <div>
+    <b-button :pressed="true" variant="success">Always Pressed</b-button>
+    <b-button :pressed="false" variant="success">Not Pressed</b-button>
+    <br><br>
+    <b-button :pressed.sync="myToggle" variant="primary">Toggle Me</b-button>
+  </div>
 </template>
 
 <script>
@@ -82,7 +95,7 @@ the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
   }
 </script>
 
-<!-- button-2.vue -->
+<!-- button-3.vue -->
 ```
 
 ### Router links

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -61,8 +61,8 @@ Buttons will appear pressed (with a darker background, darker border, and inset 
 when the prop `presed` is set to `true`.
 
 The `pressed` prop can be set to one of three values:
-- `true`: Sets the `.active` classs and adds the atribute `aria-pressed="true"`.
-- `false`: Clears the `.active` classs and adds the atribute `aria-pressed="false"`.
+- `true`: Sets the `.active` class and adds the atribute `aria-pressed="true"`.
+- `false`: Clears the `.active` class and adds the atribute `aria-pressed="false"`.
 - `null`: (default) Neither the class `.active` nor the attribute `aria-pressed` will be set.
 
 To create a button that can be toggled between avtive and non-active states, use

--- a/examples/button/demo.html
+++ b/examples/button/demo.html
@@ -36,5 +36,12 @@
                 Can't touch this
             </b-btn>
         </div>
+        <div class="col-md-4 pb-2">
+            <b-btn variant="primary"
+                   ref="btn_pressed"
+                   :pressed.sync="btnToggle">
+                Toggle Me
+            </b-btn>
+        </div>
     </div>
 </div>

--- a/examples/button/demo.js
+++ b/examples/button/demo.js
@@ -4,5 +4,8 @@ window.app = new Vue({
         handleClick(event) {
             alert('You clicked, I listened.')
         },
+    },
+    data: {
+        btnToggle: null
     }
 });

--- a/lib/components/button.vue
+++ b/lib/components/button.vue
@@ -5,7 +5,7 @@
             :aria-pressed="ariaPressed"
             :type="btnType"
             :disabled="disabled"
-            :tabindex="(disabled && this.componentType !== 'button') ? '-1' : null"
+            :tabindex="(disabled && componentType !== 'button') ? '-1' : null"
             @click="onClick"
             @focusin="onFocus(true)"
             @focusout="onFocus(false)">

--- a/lib/components/button.vue
+++ b/lib/components/button.vue
@@ -31,7 +31,7 @@ export default {
     components: { bLink },
     data() {
         return {
-            hasFocus: false;
+            hasFocus: false
         };
     },
     computed: {

--- a/lib/components/button.vue
+++ b/lib/components/button.vue
@@ -20,7 +20,7 @@ import { assign } from '../utils/object';
 // focus handler for data-toggle="button"
 function handleToggleFocus(evt) {
     const el = evt.target;
-    if (el && el.classList.contains('btn') && el.getAttribute('data-toggle') === 'button')) {
+    if (el && el.classList.contains('btn') && el.getAttribute('data-toggle') === 'button') {
         if (evt.type === 'focusin') {
             el.classList.add('focus');
         } else if (evt.type === 'focusout') {

--- a/lib/components/button.vue
+++ b/lib/components/button.vue
@@ -2,6 +2,7 @@
     <button v-bind="conditionalLinkProps"
             :is="componentType"
             :class="classList"
+            :aria-pressed="ariaPressed"
             :type="btnType"
             :disabled="disabled"
             @click="onClick">
@@ -33,7 +34,8 @@ export default {
                 this.btnVariant,
                 this.btnSize,
                 this.btnBlock,
-                this.btnDisabled
+                this.btnDisabled,
+                this.btnPressed
             ];
         },
         componentType() {
@@ -53,6 +55,18 @@ export default {
         },
         btnType() {
             return (this.href || this.to) ? null : this.type;
+        },
+        btnPressed() {
+            return this.pressed ? 'active' : '';
+        },
+        ariaPressed() {
+            if (this.pressed === true) {
+                return 'true';
+            } else if (this.pressed === false) {
+                return 'false';
+            }
+            // Remove aria-pressed attribute
+            return null;
         },
         conditionalLinkProps() {
             return this.componentType === 'button' ? {} : this.linkProps;
@@ -79,6 +93,11 @@ export default {
         type: {
             type: String,
             default: 'button'
+        },
+        pressed: {
+            // tri-state prop: true, false or null
+            type: Boolean,
+            default: null
         }
     }),
     methods: {
@@ -88,6 +107,10 @@ export default {
                 e.preventDefault();
             } else {
                 this.$emit('click', e);
+                if (this.pressed === true || this.pressed === false) {
+                    // Emit .sync notification about pressed prop state changing
+                    this.$emit('update:pressed', !this.pressed);
+                }
             }
         }
     }

--- a/lib/components/navbar-brand.vue
+++ b/lib/components/navbar-brand.vue
@@ -5,7 +5,7 @@
              @click="$emit('click', $event)">
         <slot></slot>
     </b-link>
-    <componentv-else :is="tag" class="navbar-brand">
+    <component v-else :is="tag" class="navbar-brand">
         <slot></slot>
     </component>
 </template>


### PR DESCRIPTION
Adds a new prop `pressed`, which defaults to null.

- If `pressed === true` then the `.active` class is added to the button and sets `aria-pressed="true"` attribute.
- If `pressed === false` then  the attribute `aria-pressed="false"` is set.
- If `pressed === null` (the default, or any other value) then neither the class `.active` nor the attribute `aria-pressed` are set.

Useful when creating toggleable buttons.

The pressed state can be synced by setting the `.sync` modifier on the prop:

```html
<template>
  <b-btn :pressed.sync="myPressedState">Toggle Me</b-btn>
</template>
<script>
export default {
  data: {
    myPressedState: false
  }
}
</script>
```


