### PR TITLE
fix(dropdowns): Change how dropdown items are highlighted

### DIFF
--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -45,7 +45,8 @@
 
 <style scoped>
     .dropdown-item:focus,
-    .dropdown-item:hover {
+    .dropdown-item:hover,
+    .dropdown-header:focus {
         background-color: #eaeaea;
         outline: none;
     }

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -46,8 +46,6 @@
 <style scoped>
     .dropdown-item:focus,
     .dropdown-item:hover {
-        color: #1d1e1f;
-        text-decoration: none;
         background-color: #eaeaea;
         outline: none;
     }

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -36,13 +36,22 @@
              @keydown.tab="onTab"
              @keydown.up="focusNext($event,true)"
              @keydown.down="focusNext($event,false)"
-             @mouseover="focusHovered($event)"
         >
             <slot></slot>
         </div>
 
     </div>
 </template>
+
+<style scoped>
+    .dropdown-item:focus,
+    .dropdown-item:hover {
+        color: #1d1e1f;
+        text-decoration: none;
+        background-color: #eaeaea;
+        outline: none;
+    }
+</style>
 
 <script>
     import { dropdownMixin } from '../mixins';

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -23,13 +23,20 @@
              @keydown.tab="onTab"
              @keydown.up="focusNext($event,true)"
              @keydown.down="focusNext($event,false)"
-             @mouseover="focusHovered($event)"
         >
             <slot></slot>
         </div>
 
     </li>
 </template>
+
+<style scoped>
+    .dropdown-item:focus,
+    .dropdown-item:hover {
+        background-color: #eaeaea;
+        outline: none;
+    }
+</style>
 
 <script>
     import { dropdownMixin } from '../mixins';

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -32,7 +32,8 @@
 
 <style scoped>
     .dropdown-item:focus,
-    .dropdown-item:hover {
+    .dropdown-item:hover,
+    .dropdown-header:focus {
         background-color: #eaeaea;
         outline: none;
     }

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -123,8 +123,6 @@ export default {
             this.visible = !this.visible;
             if (this.visible) {
                 this.$nextTick(function () {
-                    // Clear any items that may have active state left
-                    this.clearItems();
                     // Focus first visible non-disabled item
                     const item = this.getFirstItem();
                     if (item) {
@@ -180,37 +178,11 @@ export default {
                 this.focusItem(index, items);
             });
         },
-        focusHovered(e) {
-            if (!this.visible) {
-                return;
-            }
-            this.$nextTick(() => {
-                const items = this.getItems();
-                if (items.length < 1) {
-                    return;
-                }
-                const index = items.indexOf(e.target);
-                if (index > -1) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    this.focusItem(index, items);
-                }
-            });
-        },
         focusItem(idx, items) {
             items.forEach((el, i) => {
                 if (i === idx) {
-                    el.classList.add('active');
                     el.focus();
-                } else {
-                    el.classList.remove('active');
                 }
-            });
-        },
-        clearItems() {
-            const items = this.getItems();
-            items.forEach(el => {
-                el.classList.remove('active');
             });
         },
         getItems() {

--- a/lib/mixins/listen-on-root.js
+++ b/lib/mixins/listen-on-root.js
@@ -1,4 +1,4 @@
-import { isArray } from "../utils/array"
+import { isArray } from '../utils/array';
 /**
  * Issue #569: collapse::toggle::state triggered too many times
  * @link https://github.com/bootstrap-vue/bootstrap-vue/issues/569


### PR DESCRIPTION
Changes the highlighting method of focused items (instead of using `active` class state).

Slight tweaks to the `:hover` and `:focus` states CSS to remove ugly blue-line outline on focus and add slightly darker background color (default BS V4 contrast ratio is waaay too low to notice the hover/focus state)
