### PR TITLE
fix(alert): use v-model to update show value

### DIFF
--- a/__tests__/components/alert.spec.js
+++ b/__tests__/components/alert.spec.js
@@ -3,7 +3,7 @@ import { loadFixture, testVM, nextTick, setData } from "../helpers";
 const variants = ["success", "info", "warning", "danger"].map(v => {
     return {
         variant: v,
-        class: `alert-${v}`,
+        variantClass: `alert-${v}`,
         ref: `variant_${v}`
     };
 });
@@ -15,9 +15,9 @@ describe("alert", async () => {
     it("should contain appropriate class names", async () => {
         const { app: { $refs } } = window;
 
-        for (const ctx of variants) {
+        for (const { ref, variantClass } of variants) {
             // Use array notation due to v-for
-            expect($refs[ctx.ref][0]).toHaveAllClasses(["alert", ctx.class]);
+            expect($refs[ref][0]).toHaveAllClasses(["alert", variantClass]);
         }
     });
 

--- a/__tests__/components/alert.spec.js
+++ b/__tests__/components/alert.spec.js
@@ -44,11 +44,29 @@ describe("alert", async () => {
         expect(vm.$el.textContent).toContain("Dismissible Alert!");
     });
 
+    it("should dismiss the alert when close button clicked and no v-model given", async () => {
+        const { app: { $refs } } = window;
+        const vm = $refs.dismissible_alert;
+        // Shown with content
+        expect(vm.$el.textContent).toContain("dismissible");
+
+        const closeBtn = vm.$el.querySelector("button.close");
+        expect(closeBtn).not.toBeNull();
+
+        closeBtn.click();
+        await nextTick();
+
+        // Hidden completely
+        expect(vm.$el.textContent).not.toContain("dismissible");
+    });
+
     it("should dismiss the alert when close button clicked and update v-model", async () => {
         const { app: { $refs } } = window;
         const vm = $refs.dismiss_test;
         // Initial state is open
         expect(app.dismiss_test_show).toBe(true);
+        // Text is shown
+        expect(vm.$el.textContent).toContain("Success Alert");
 
         const closeBtn = vm.$el.querySelector("button.close");
         expect(closeBtn).not.toBeNull();

--- a/__tests__/components/alert.spec.js
+++ b/__tests__/components/alert.spec.js
@@ -1,38 +1,62 @@
-import {loadFixture, testVM, nextTick, setData} from '../helpers';
-import Vue from 'vue/dist/vue.common';
+import { loadFixture, testVM, nextTick, setData } from "../helpers";
 
-describe('alert', async () => {
-    beforeEach(loadFixture('alert'));
+const variants = ["success", "info", "warning", "danger"].map(v => {
+    return {
+        variant: v,
+        class: `alert-${v}`,
+        ref: `variant_${v}`
+    };
+});
+
+describe("alert", async () => {
+    beforeEach(loadFixture("alert"));
     testVM();
 
-    it('check class names', async () => {
-        const {app: {$refs, $el}} = window;
+    it("should contain appropriate class names", async () => {
+        const { app: { $refs } } = window;
 
-        expect($refs.default_alert).toHaveClass('alert alert-info');
-        expect($refs.success_alert).toHaveClass('alert alert-success');
+        for (const ctx of variants) {
+            // Use array notation due to v-for
+            expect($refs[ctx.ref][0]).toHaveAllClasses(["alert", ctx.class]);
+        }
     });
 
-    it('show prop', async () => {
-        const {app: {$refs, $el}} = window;
+    it("should render the dismiss button when passed the 'dismissible' attr", async () => {
+        const { app: { $refs } } = window;
+        const vm = $refs.dismissible_alert;
+        expect(vm).toHaveClass("alert-dismissible");
+
+        const closeBtn = vm.$el.querySelector("button.close");
+        expect(closeBtn).not.toBeNull();
+        expect(closeBtn).toBeElement("button");
+        expect(closeBtn).toHaveClass("close");
+    });
+
+    it("should hide/show using the show prop", async () => {
+        const { app: { $refs } } = window;
+        const vm = $refs.show_test;
 
         // Default is hidden
-        expect($el.textContent).not.toContain('Dismissible Alert!');
+        expect(vm.$el.textContent).not.toContain("Dismissible Alert!");
 
         // Make visible by changing visible state
-        await setData(app, 'showDismissibleAlert', true);
-        expect($el.textContent).toContain('Dismissible Alert!');
+        await setData(app, "showDismissibleAlert", true);
+        expect(vm.$el.textContent).toContain("Dismissible Alert!");
     });
 
-    it('dismiss button', async () => {
-        const {app: {$refs, $el}} = window;
-        const alert = $refs.success_alert;
+    it("should dismiss the alert when close button clicked and update v-model", async () => {
+        const { app: { $refs } } = window;
+        const vm = $refs.dismiss_test;
+        // Initial state is open
+        expect(app.dismiss_test_show).toBe(true);
 
-        expect(alert).toHaveClass('alert-dismissible');
-
-        const closeBtn = alert.$el.querySelector('.close');
+        const closeBtn = vm.$el.querySelector("button.close");
         expect(closeBtn).not.toBeNull();
+
         closeBtn.click();
         await nextTick();
-        expect($el.textContent).not.toContain('Success Alert');
+
+        expect(vm.$el.textContent).not.toContain("Success Alert");
+        expect(app.dismiss_test_show).toBe(false);
     });
 });

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -1,27 +1,15 @@
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
-import Vue from 'vue/dist/vue.common';
-import BootstrapVue from '../lib';
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import Vue from "vue/dist/vue.common";
+import BootstrapVue from "../lib";
 
-const readFile = (path) => String(readFileSync(resolve(__dirname, '../examples', path)));
-const throwIfNotVueInstance = vm => {
-    if (!vm instanceof Vue) {
-        // debugging breadcrumbs in case a non-Vue instance gets erroneously passed
-        // makes the error easier to fix than example: "Cannot read _prevClass of undefined"
-        throw new TypeError(`The matcher function expects Vue instance. Given ${typeof vm}`)
-    }
-}
-const throwIfNotArray = array => {
-    if (!Array.isArray(array)) {
-        throw new TypeError(`The matcher requires an array. Given ${typeof array}`)
-    }
-}
+const readFile = path => String(readFileSync(resolve(__dirname, "../examples", path)));
 
 export function loadFixture(name) {
     const template = readFile(`${name}/demo.html`);
     const js = readFile(`${name}/demo.js`);
 
-    return async() => {
+    return async () => {
         // Mount template
         document.body.innerHTML = template;
 
@@ -38,14 +26,14 @@ export function loadFixture(name) {
 }
 
 export async function testVM() {
-    it(`vm mounts`, async() => {
+    it(`vm mounts`, async () => {
         return expect(window.app.$el).toBeDefined();
     });
 }
 
 export function nextTick() {
     return new Promise((resolve, reject) => {
-        Vue.nextTick(resolve)
+        Vue.nextTick(resolve);
     });
 }
 
@@ -60,42 +48,105 @@ export function sleep(ms) {
     return new Promise(r => setTimeout(r, ms));
 }
 
+const isVueInstance = vm => vm instanceof Vue;
+const isHTMLElement = el => el instanceof HTMLElement;
+
+const throwIfNotVueInstance = vm => {
+    if (!isVueInstance(vm)) {
+        // debugging breadcrumbs in case a non-Vue instance gets erroneously passed
+        // makes the error easier to fix than example: "Cannot read _prevClass of undefined"
+        console.error(vm);
+        throw new TypeError(`The matcher function expects Vue instance. Given ${typeof vm}`);
+    }
+};
+
+const throwIfNotHTMLElement = el => {
+    if (!isHTMLElement(el)) {
+        console.error(el);
+        throw new TypeError(`The matcher function expects an HTML Element. Given ${typeof el}`);
+    }
+};
+
+const throwIfNotArray = array => {
+    if (!Array.isArray(array)) {
+        throw new TypeError(`The matcher requires an array. Given ${typeof array}`);
+    }
+};
+
+const vmHasClass = (vm, className) => {
+    throwIfNotVueInstance(vm);
+    return vm.$el._prevClass.indexOf(className) !== -1;
+};
+
+/**
+ * @param {HTMLElement} el
+ * @param {string} className
+ * @return {boolean}
+ */
+const elHasClass = (el, className) => {
+    throwIfNotHTMLElement(el);
+    return el.classList.contains(className);
+};
+
+/**
+ * @param {Vue|HTMLElement} node
+ * @param {string} className
+ * @return {boolean}
+ */
+const hasClass = (node, className) => (isVueInstance(node) ? vmHasClass(node, className) : elHasClass(node, className));
+
+const getVmTag = vm => vm.$options._componentTag;
+const getHTMLTag = el => String(el.tagName).toLowerCase();
+const getTagName = node => (isVueInstance(node) ? getVmTag(node) : getHTMLTag(node));
+
 // Extend Jest marchers
 expect.extend({
-    toHaveClass(vm, className) {
-        throwIfNotVueInstance(vm)
-
+    toHaveClass(node, className) {
         return {
-            message: `expected <${vm.$options._componentTag}> to have class '${className}'`,
-            pass: vm.$el._prevClass.indexOf(className) !== -1,
+            message: `expected <${getTagName(node)}> to have class '${className}'`,
+            pass: hasClass(node, className)
         };
     },
-    toHaveAllClasses(vm, classList) {
-        throwIfNotVueInstance(vm)
-        throwIfNotArray(classList)
+    toHaveAllClasses(node, classList) {
+        throwIfNotArray(classList);
 
         let pass = true;
-        let missingClassNames = []
+        let missingClassNames = [];
 
         classList.forEach(className => {
-            if (!vm.$el._prevClass.includes(className)) {
-                pass = false
-                missingClassNames.push(className)
+            if (!hasClass(node, className)) {
+                pass = false;
+                missingClassNames.push(className);
             }
-        })
+        });
+
+        const plural = missingClassNames.length > 1;
+        const classStr = classList.join(", ");
+        const missingClassStr = missingClassNames.join(", ");
+        const tagName = getTagName(node);
 
         return {
             // more debugging breadcrumbs
-            message: `Expected <${vm.$options._componentTag}> to have all classes in [ ${classList.join(', ')} ], but was missing [ ${missingClassNames.join(', ')} ] class${missingClassNames.length > 1 ? 'es' : ''}.`,
+            message: `Expected <${tagName}> to have all classes in [${classStr}], but was missing [${missingClassStr}] class${plural
+                ? "es"
+                : ""}.`,
             pass
-        }
-    },
-    toBeComponent(vm, componentTag) {
-        throwIfNotVueInstance(vm)
-
-        return {
-            message: `expected to be <${componentTag}>`,
-            pass: vm.$options._componentTag === componentTag
         };
     },
+    toBeComponent(vm, componentTag) {
+        throwIfNotVueInstance(vm);
+
+        return {
+            message: `Expected to be <${componentTag}>. Received: ${getVmTag(vm)}`,
+            pass: getVmTag(vm) === componentTag
+        };
+    },
+    toBeElement(el, tagName) {
+        throwIfNotHTMLElement(el);
+
+        return {
+            message: `Expected to be <${String(tagName).toLowerCase()}>. Received: ${el.tagName.toLowerCase()}`,
+            pass: el.tagName === String(tagName).toUpperCase()
+        };
+    }
 });

--- a/examples/alert/demo.html
+++ b/examples/alert/demo.html
@@ -1,37 +1,50 @@
 <div id="app">
+    <b-alert v-for="variant in variants"
+             :key="`variant-test-${variant}`"
+             :ref="`variant_${variant}`"
+             :variant="variant"
+             show>
+        {{ variant }}
+    </b-alert>
+    <b-alert ref="dismissible_alert"
+             dismissible
+             show>dismissible</b-alert>
     <b-alert show
-             ref="default_alert"
-    >
+             ref="default_alert">
         Default Alert
     </b-alert>
 
-    <b-alert ref="success_alert"
+    <b-alert ref="dismiss_test"
              variant="success"
              dismissible
-             show
-    >
+             v-model="dismiss_test_show">
         Success Alert
     </b-alert>
 
-    <b-alert variant="danger"
+    <b-alert ref="show_test"
+             variant="danger"
              dismissible
              :show="showDismissibleAlert"
-             @dismissed="showDismissibleAlert=false"
-    >
+             @dismissed="showDismissibleAlert=false">
         Dismissible Alert!
     </b-alert>
 
-    <b-alert :show="dismissCountDown"
+    <b-alert ref="dismissible_countdown_alert"
+             :show="dismissCountDown"
              dismissible
              variant="warning"
-             @dismiss-count-down="countDownChanged"
-    >
+             @dismiss-count-down="countDownChanged">
         This alert will dismiss after {{dismissCountDown}} seconds...
     </b-alert>
 
-    <b-btn @click="showAlert" variant="info" class="m-1">Show alert with count-down timer</b-btn>
+    <b-btn @click="showAlert"
+           variant="info"
+           class="m-1">Show alert with count-down timer</b-btn>
 
-    <b-btn @click="showDismissibleAlert=true" variant="info" class="m-1" ref="dismissible_alert_btn">
+    <b-btn @click="showDismissibleAlert=true"
+           variant="info"
+           class="m-1"
+           ref="dismissible_alert_btn">
         Show dismissible alert ({{showDismissibleAlert?'visible':'hidden'}})
     </b-btn>
 </div>

--- a/examples/alert/demo.js
+++ b/examples/alert/demo.js
@@ -1,8 +1,10 @@
 window.app = new Vue({
-    el: '#app',
+    el: "#app",
     data: {
         dismissCountDown: null,
-        showDismissibleAlert: false
+        showDismissibleAlert: false,
+        variants: ["success", "info", "warning", "danger"],
+        dismiss_test_show: true
     },
     methods: {
         countDownChanged(dismissCountDown) {

--- a/lib/components/alert.vue
+++ b/lib/components/alert.vue
@@ -84,7 +84,7 @@ export default {
         countdown() {
             const countdown = ~~this.show - 1;
 
-            if (countdown === 0) {
+            if (countdown < 1) {
                 return this.dismiss();
             }
 

--- a/lib/components/alert.vue
+++ b/lib/components/alert.vue
@@ -3,15 +3,13 @@
          :class="classObject"
          role="alert"
          aria-live="polite"
-         aria-atomic="true"
-    >
+         aria-atomic="true">
         <button type="button"
                 class="close"
                 data-dismiss="alert"
                 aria-label="dismissLabel"
                 v-if="dismissible"
-                @click.stop.prevent="dismiss"
-        >
+                @click.stop.prevent="dismiss">
             <span aria-hidden="true">&times;</span>
         </button>
         <slot></slot>
@@ -19,95 +17,96 @@
 </template>
 
 <script>
-    import {warn} from '../utils';
+import { warn } from '../utils';
 
-    export default {
-        data() {
-            return {
-                countDownTimerId: null,
-                dismissed: false
-            };
-        },
-        created() {
-            if (this.state) {
-                warn('<b-alert> "state" property is deprecated, please use "variant" property instead.');
-            }
-        },
-        computed: {
-            classObject() {
-                return ['alert', this.alertVariant, this.dismissible ? 'alert-dismissible' : ''];
-            },
-            alertVariant() {
-                const variant = this.state || this.variant || 'info';
-                return `alert-${variant}`;
-            },
-            localShow() {
-                return !this.dismissed && (this.countDownTimerId || this.show);
-            }
-        },
-        props: {
-            variant: {
-                type: String,
-                default: 'info'
-            },
-            state: {
-                type: String,
-                default: null
-            },
-            dismissible: {
-                type: Boolean,
-                default: false
-            },
-            dismissLabel: {
-                type: String,
-                default: 'Close'
-            },
-            show: {
-                type: [Boolean, Number],
-                default: false
-            }
-        },
-        watch: {
-            show() {
-                this.showChanged();
-            }
-        },
-        mounted() {
-            this.showChanged();
-        },
-        methods: {
-            dismiss() {
-                this.dismissed = true;
-                this.$emit('dismissed');
-                this.clearCounter();
-            },
-            clearCounter() {
-                if (this.countDownTimerId) {
-                    clearInterval(this.countDownTimerId);
-                }
-            },
-            showChanged() {
-                // Reset dismiss status
-                this.dismissed = false;
-
-                // No timer for boolean values
-                if (this.show === true || this.show === false || this.show === null || this.show === 0) {
-                    return;
-                }
-
-                let dismissCountDown = this.show;
-                this.$emit('dismiss-count-down', dismissCountDown);
-
-                // Start counter
-                this.clearCounter();
-                this.countDownTimerId = setInterval(() => {
-                    if (dismissCountDown < 2) {
-                        return this.dismiss();
-                    }
-                    dismissCountDown--;
-                    this.$emit('dismiss-count-down', dismissCountDown);
-                }, 1000);
-            }
+export default {
+    data() {
+        return {
+            countDownTimerId: null,
+            dismissed: false,
+            dismissCountDown: 0
+        };
+    },
+    created() {
+        if (this.state) {
+            warn('<b-alert> "state" property is deprecated, please use "variant" property instead.');
         }
-    };
+    },
+    computed: {
+        classObject() {
+            return ['alert', this.alertVariant, this.dismissible ? 'alert-dismissible' : ''];
+        },
+        alertVariant() {
+            const variant = this.state || this.variant || 'info';
+            return `alert-${variant}`;
+        },
+        localShow() {
+            return !this.dismissed && (this.countDownTimerId || this.show);
+        }
+    },
+    props: {
+        variant: {
+            type: String,
+            default: 'info'
+        },
+        state: {
+            type: String,
+            default: null
+        },
+        dismissible: {
+            type: Boolean,
+            default: false
+        },
+        dismissLabel: {
+            type: String,
+            default: 'Close'
+        },
+        show: {
+            type: [Boolean, Number],
+            default: false
+        }
+    },
+    watch: {
+        show() {
+            this.showChanged();
+        }
+    },
+    mounted() {
+        this.showChanged();
+    },
+    methods: {
+        dismiss() {
+            this.dismissed = true;
+            this.$emit('dismissed');
+            this.clearCounter();
+        },
+        clearCounter() {
+            if (this.countDownTimerId) {
+                clearInterval(this.countDownTimerId);
+            }
+        },
+        showChanged() {
+            // Reset dismiss status
+            this.dismissed = false;
+
+            // No timer for boolean values
+            if (this.show === true || this.show === false || this.show === null || this.show === 0) {
+                return;
+            }
+
+            let dismissCountDown = this.show;
+            this.$emit('dismiss-count-down', dismissCountDown);
+
+            // Start counter
+            this.clearCounter();
+            this.countDownTimerId = setInterval(() => {
+                if (dismissCountDown < 2) {
+                    return this.dismiss();
+                }
+                dismissCountDown--;
+                this.$emit('dismiss-count-down', dismissCountDown);
+            }, 1000);
+        }
+    }
+};
 </script>

--- a/lib/components/alert.vue
+++ b/lib/components/alert.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="show"
+    <div v-if="localShow"
          class="alert"
          :class="classObject"
          role="alert"
@@ -24,7 +24,8 @@ export default {
     data() {
         return {
             countDownTimerId: null,
-            dismissCountDown: 0
+            dismissCountDown: 0,
+            localShow: this.show
         };
     },
     created() {
@@ -68,7 +69,10 @@ export default {
         }
     },
     watch: {
-        show() {
+        show(newValue) {
+            // Prop validation can't guarantee integers,
+            // so use fast bitwise integer casting `~~`
+            this.localShow = typeof newValue === "number" ? ~~newValue : newValue
             this.showChanged();
         }
     },
@@ -78,18 +82,19 @@ export default {
     methods: {
         dismiss() {
             this.clearCounter();
-            this.$emit("change", false);
+            this.localShow = false;
+            this.$emit("change", this.localShow);
             this.$emit('dismissed');
         },
         countdown() {
-            const countdown = ~~this.show - 1;
+            this.localShow--;
 
-            if (countdown < 1) {
+            if (this.localShow < 1) {
                 return this.dismiss();
             }
 
-            this.$emit("dismiss-count-down", countdown);
-            this.$emit("change", countdown);
+            this.$emit("dismiss-count-down", this.localShow);
+            this.$emit("change", this.localShow);
         },
         clearCounter() {
             if (this.countDownTimerId) {
@@ -97,17 +102,19 @@ export default {
             }
         },
         showChanged() {
-            // No timer for boolean or falsey values
+            // Return early for boolean, or numbers that can't be counted down.
+            // Let prop validation take care of non Boolean/Number types.
             // eslint-disable-next-line eqeqeq
-            if (typeof this.show === "boolean" || this.show == null || this.show <= 0) {
+            if (typeof this.localShow === "boolean" || (typeof this.localShow === "number" && this.localShow < 1)) {
                 return;
             }
 
             // Show is a countdown number
             // but let's ensure it's an integer.
-            this.$emit('dismiss-count-down', ~~this.show);
-            // Start counter
+            this.$emit('dismiss-count-down', this.localShow);
+            // Remove any previous interval registered.
             this.clearCounter();
+            // Start counter
             this.countDownTimerId = setInterval(this.countdown, 1000);
         }
     }


### PR DESCRIPTION
Fix for issue #718 

My initial work on the idea of using v-model. I haven't run my bug test on this yet because things are really busy for me. 
**Edit:** This does clear up my bug.

**Note:** ~~This may need to be tweaked as doing `<b-alert show dismissible>` doesn't allow the alert to be dismissed. The addition of `v-model` becomes necessary. It might be necessary to have an initial show either as a prop or as a data value local to alert. But if you think about it, it's fundamentally flawed to declare both `show` and `dismissible` at the same time while also making alerts reusable.~~

Feel free to contribute on this branch.