### PR TITLE
feat(Event): standard evt obj emulates native Event

### DIFF
--- a/lib/utils/BvEvent.js
+++ b/lib/utils/BvEvent.js
@@ -23,7 +23,9 @@ export class BvEvent {
         let defaultPrevented = false;
         // Recreate preventDefault method. One way setter.
         this.preventDefault = function preventDefault() {
-            defaultPrevented = true;
+            if (this.cancelable) {
+                defaultPrevented = true;
+            }
         };
         // Create 'defaultPrevented' publicly accessible prop
         // that can only be altered by the preventDefault method.

--- a/lib/utils/BvEvent.js
+++ b/lib/utils/BvEvent.js
@@ -8,11 +8,10 @@ export class BvEvent {
                 `Failed to construct '${this.constructor.name}'. 1 argument required, ${arguments.length} given.`
             );
         }
-        // Assign defaults first,
-        // the eventInit,
-        // and last the type and timestamp so they can't be overwritten.
+        // Assign defaults first, the eventInit,
+        // and the type last so it can't be overwritten.
         assign(this, BvEvent.defaults(), eventInit, { type });
-        // Freeze some props as readonly.
+        // Freeze some props as readonly, but leave them enumerable.
         defineProperties(this, {
             type: readonlyDescriptor(),
             cancelable: readonlyDescriptor(),
@@ -22,13 +21,12 @@ export class BvEvent {
         });
         // Create a private variable using closure scoping.
         let defaultPrevented = false;
-        // Recreate event method
+        // Recreate preventDefault method. One way setter.
         this.preventDefault = function preventDefault() {
             defaultPrevented = true;
         };
-        // Alias preventDefault
-        this.cancel = this.preventDefault;
-        // Create a publicly accessible prop that can only be altered by preventDefault
+        // Create 'defaultPrevented' publicly accessible prop
+        // that can only be altered by the preventDefault method.
         defineProperty(this, "defaultPrevented", {
             enumerable: true,
             get() {

--- a/lib/utils/BvEvent.js
+++ b/lib/utils/BvEvent.js
@@ -19,6 +19,7 @@ export class BvEvent {
             timeStamp: readonlyDescriptor(),
             // Alias for misspelling
             timestamp: {
+                enumerable: true,
                 get() {
                     return this.timeStamp;
                 }
@@ -38,6 +39,7 @@ export class BvEvent {
         this.cancel = this.preventDefault;
         // Create a publicly accessible prop that can only be altered by preventDefault
         defineProperty(this, "defaultPrevented", {
+            enumerable: true,
             get() {
                 return defaultPrevented;
             }

--- a/lib/utils/BvEvent.js
+++ b/lib/utils/BvEvent.js
@@ -1,0 +1,57 @@
+import { assign, defineProperty, defineProperties, readonlyDescriptor } from "../utils/object";
+
+export class BvEvent {
+    constructor(type, eventInit = {}) {
+        // Start by emulating native Event constructor.
+        if (!type) {
+            throw new TypeError(
+                `Failed to construct '${this.constructor.name}'. 1 argument required, ${arguments.length} given.`
+            );
+        }
+        // Assign defaults first,
+        // the eventInit,
+        // and last the type and timestamp so they can't be overwritten.
+        assign(this, BvEvent.defaults(), eventInit, { type, timeStamp: new Date().getTime() });
+        // Freeze some props as readonly.
+        defineProperties(this, {
+            type: readonlyDescriptor(),
+            // Conform to native Event's name
+            timeStamp: readonlyDescriptor(),
+            // Alias for misspelling
+            timestamp: {
+                get() {
+                    return this.timeStamp;
+                }
+            },
+            cancelable: readonlyDescriptor(),
+            nativeEvent: readonlyDescriptor(),
+            target: readonlyDescriptor(),
+            vueTarget: readonlyDescriptor()
+        });
+        // Create a private variable using closure scoping.
+        let defaultPrevented = false;
+        // Recreate event method
+        this.preventDefault = function preventDefault() {
+            defaultPrevented = true;
+        };
+        // Alias preventDefault
+        this.cancel = this.preventDefault;
+        // Create a publicly accessible prop that can only be altered by preventDefault
+        defineProperty(this, "defaultPrevented", {
+            get() {
+                return defaultPrevented;
+            }
+        });
+    }
+
+    static defaults() {
+        return {
+            type: "",
+            timeStamp: 0,
+            cancelable: true,
+            nativeEvent: null,
+            target: null,
+            vueTarget: null
+        };
+    }
+}

--- a/lib/utils/BvEvent.js
+++ b/lib/utils/BvEvent.js
@@ -11,7 +11,7 @@ export class BvEvent {
         // Assign defaults first,
         // the eventInit,
         // and last the type and timestamp so they can't be overwritten.
-        assign(this, BvEvent.defaults(), eventInit, { type, timeStamp: new Date().getTime() });
+        assign(this, BvEvent.defaults(), eventInit, { type });
         // Freeze some props as readonly.
         defineProperties(this, {
             type: readonlyDescriptor(),

--- a/lib/utils/BvEvent.js
+++ b/lib/utils/BvEvent.js
@@ -15,15 +15,6 @@ export class BvEvent {
         // Freeze some props as readonly.
         defineProperties(this, {
             type: readonlyDescriptor(),
-            // Conform to native Event's name
-            timeStamp: readonlyDescriptor(),
-            // Alias for misspelling
-            timestamp: {
-                enumerable: true,
-                get() {
-                    return this.timeStamp;
-                }
-            },
             cancelable: readonlyDescriptor(),
             nativeEvent: readonlyDescriptor(),
             target: readonlyDescriptor(),
@@ -49,7 +40,6 @@ export class BvEvent {
     static defaults() {
         return {
             type: "",
-            timeStamp: 0,
             cancelable: true,
             nativeEvent: null,
             target: null,

--- a/lib/utils/object.js
+++ b/lib/utils/object.js
@@ -10,44 +10,44 @@
 if (typeof Object.assign != "function") {
     Object.assign = function(target, varArgs) {
         // .length of function is 2
-        "use strict"
+
         if (target == null) {
             // TypeError if undefined or null
-            throw new TypeError("Cannot convert undefined or null to object")
+            throw new TypeError("Cannot convert undefined or null to object");
         }
 
-        let to = Object(target)
+        let to = Object(target);
 
         for (let index = 1; index < arguments.length; index++) {
-            const nextSource = arguments[index]
+            const nextSource = arguments[index];
 
             if (nextSource != null) {
                 // Skip over if undefined or null
                 for (const nextKey in nextSource) {
                     // Avoid bugs when hasOwnProperty is shadowed
                     if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-                        to[nextKey] = nextSource[nextKey]
+                        to[nextKey] = nextSource[nextKey];
                     }
                 }
             }
         }
-        return to
-    }
+        return to;
+    };
 }
 
-export const assign = Object.assign
-export const getOwnPropertyNames = Object.getOwnPropertyNames
-export const keys = Object.keys
-export const defineProperties = Object.defineProperties
-export const defineProperty = Object.defineProperty
-export const freeze = Object.freeze
-export const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor
-export const getOwnPropertySymbols = Object.getOwnPropertySymbols
-export const getPrototypeOf = Object.getPrototypeOf
-export const create = Object.create
-export const isFrozen = Object.isFrozen
-export const is = Object.is
+export const assign = Object.assign;
+export const getOwnPropertyNames = Object.getOwnPropertyNames;
+export const keys = Object.keys;
+export const defineProperties = Object.defineProperties;
+export const defineProperty = Object.defineProperty;
+export const freeze = Object.freeze;
+export const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+export const getOwnPropertySymbols = Object.getOwnPropertySymbols;
+export const getPrototypeOf = Object.getPrototypeOf;
+export const create = Object.create;
+export const isFrozen = Object.isFrozen;
+export const is = Object.is;
 
 export function readonlyDescriptor() {
-    return { configurable: false, writable: false }
+    return { enumerable: true, configurable: false, writable: false };
 }

--- a/lib/utils/object.js
+++ b/lib/utils/object.js
@@ -47,3 +47,7 @@ export const getPrototypeOf = Object.getPrototypeOf
 export const create = Object.create
 export const isFrozen = Object.isFrozen
 export const is = Object.is
+
+export function readonlyDescriptor() {
+    return { configurable: false, writable: false }
+}


### PR DESCRIPTION
Stripped down version of browser `Event` object for use in component events that offer some kind of `preventDefault` behavior implemented by BootstrapVue.

- Adds a `BvEvent` class.

## Example usage

```js
// Inside modal.vue
{
  methods: {
    handleOkayClick(e) {
      this.$emit("ok", new BvEvent("ok", {
        nativeEvent: e,
        target: e.target,
        vueTarget: this,
      }))
    }
  }
}

// Listener
function handleOkay(e) {
  if (someCondition) {
    // Stops modal from closing
    e.preventDefault()
  }
}
```