### PR TITLE
feat(form-radio): Support button style radios

### DIFF
--- a/docs/components/form-radio/README.md
+++ b/docs/components/form-radio/README.md
@@ -32,34 +32,93 @@ semantic and accessible markup, so it is a solid replacement for the default rad
 export default {
   data: {
     selected: 'first',
-    options: [{
-      text: 'Toggle this custom radio',
-      value: 'first'
-    }, {
-      text: 'Or toggle this other custom radio',
-      value: 'second'
-    }, {
-      text: 'This one is Disabled',
-      value: 'third',
-      disabled: true
-    }]
+    options: [
+      { text: 'Toggle this custom radio', value: 'first' },
+      { text: 'Or toggle this other custom radio', value: 'second' },
+      { text: 'This one is Disabled', value: 'third', disabled: true }
+    ]
   }
 }
 </script>
 
-<!-- form-radio.vue -->
+<!-- form-radio-1.vue -->
 ```
 
 ### Options
 
-Please see options in [`<b-form-select>`](./form-select) docs for details on passing options
-to `<b-form-radio>`
+Please see options in [`<b-form-select>`](./form-select) docs for details on passing
+options (value array) to `<b-form-radio>`
 
+### Size
+Constrol the size of the radio text by setting the prop `size` to either `sm` for small or
+`lg` for large.
 
 ### Inline or stacked
 By default `<b-form-radio>` generates inline radio inputs. Set the prop `stacked` to make
 the radios appear one over the other.
 
+
+### Buttons style
+Render radios with the look of buttons by setting the prop `buttons`. Set the button variant by
+setting the `button-variant` prop to one ofhte standard Bootstrap button variants (see
+[`<b-button>`](./button) for supported variants). The default `button-variant` is `secondary`.
+
+The `buttons` prop has precedence over `plain`, and `button-variant` has no effect if
+`buttons` is not set.
+
+```html
+<template>
+  <div>
+    <h5>Button style radios</h5>
+    <b-form-radio id="btnradios1"
+                  buttons
+                  v-model="selected"
+                  :options="options"
+    ></b-form-radio>
+    <br>
+    
+    <h5>Button style radios with <code>primary</code> variant and size <code>lg</code></h5>
+    <b-form-radio id="btnradios2"
+                  buttons
+                  button-variant="primary"
+                  size="lg"
+                  v-model="selected"
+                  :options="options"
+    ></b-form-radio>
+    <br>
+    
+    <h5>Stacked button style radios</h5>
+    <b-form-radio id="btnradios3"
+                  buttons
+                  stacked
+                  v-model="selected"
+                  :options="options"
+    ></b-form-radio>
+
+    <hr>
+
+    <div>
+      Selected: <strong>{{ selected }}</strong>
+    </div>
+  </div> 
+</template>
+
+<script>
+export default {
+  data: {
+    selected: 'radio1',
+    options: [
+      { text: 'Radio 1', value: 'radio1' },
+      { text: 'Radio 3', value: 'radio2' },
+      { text: 'Radio 3 (disabled)', value: 'radio3', disabled: true }
+      { text: 'Radio 4', value: 'radio4' }
+    ]
+  }
+}
+</script>
+
+<!-- form-radio-2.vue -->
+```
 
 ### Contextual States
 Bootstrap includes validation styles for danger, warning, and success states on most form controls.
@@ -75,6 +134,8 @@ and want to encourage a user through the rest of the fields.
 To apply one of the contextual states on `b-form-radio`, set the `state` prop
 to `danger`, `warning`, or `success`.  You may also wrap `<b-form-radio>` in a
 `<b-form-fieldset>` and set the contextual `state` prop on `<b-form-fieldset>` instead.
+
+**Note:** contextual state is not supported for radios rednered in `buttons` mode.
 
 #### Conveying contextual validation state to assistive technologies and colorblind users:
 Using these contextual states to denote the state of a form control only provides
@@ -98,3 +159,6 @@ Supported `invalid` values are:
 
 ### Non custom radio inputs
 You can have `b-form-radio` render a browser native radio input by setting the `plain` prop.
+
+**Note:** `plain` will have no effect if `buttons` is set.
+

--- a/docs/components/form-radio/README.md
+++ b/docs/components/form-radio/README.md
@@ -50,7 +50,7 @@ Please see options in [`<b-form-select>`](./form-select) docs for details on pas
 options (value array) to `<b-form-radio>`
 
 ### Size
-Constrol the size of the radio text by setting the prop `size` to either `sm` for small or
+Control the size of the radio text by setting the prop `size` to either `sm` for small or
 `lg` for large.
 
 ### Inline or stacked
@@ -138,7 +138,7 @@ To apply one of the contextual states on `b-form-radio`, set the `state` prop
 to `danger`, `warning`, or `success`.  You may also wrap `<b-form-radio>` in a
 `<b-form-fieldset>` and set the contextual `state` prop on `<b-form-fieldset>` instead.
 
-**Note:** contextual state is not supported for radios rednered in `buttons` mode.
+**Note:** contextual state is not supported for radios rendered in `buttons` mode.
 
 #### Conveying contextual validation state to assistive technologies and colorblind users:
 Using these contextual states to denote the state of a form control only provides

--- a/docs/components/form-radio/README.md
+++ b/docs/components/form-radio/README.md
@@ -66,6 +66,9 @@ setting the `button-variant` prop to one of the standard Bootstrap button varian
 The `buttons` prop has precedence over `plain`, and `button-variant` has no effect if
 `buttons` is not set.
 
+Button style radios will have the class `active` automatically applied to their label
+when they are in the checked state.
+
 ```html
 <template>
   <div>

--- a/docs/components/form-radio/README.md
+++ b/docs/components/form-radio/README.md
@@ -66,7 +66,7 @@ setting the `button-variant` prop to one of the standard Bootstrap button varian
 The `buttons` prop has precedence over `plain`, and `button-variant` has no effect if
 `buttons` is not set.
 
-Button style radios will have the class `active` automatically applied to their label
+Button style radios will have the class `.active` automatically applied to their label
 when they are in the checked state.
 
 ```html

--- a/docs/components/form-radio/README.md
+++ b/docs/components/form-radio/README.md
@@ -97,7 +97,6 @@ when they are in the checked state.
                   v-model="selected"
                   :options="options"
     ></b-form-radio>
-
     <hr>
 
     <div>
@@ -113,7 +112,7 @@ export default {
     options: [
       { text: 'Radio 1', value: 'radio1' },
       { text: 'Radio 3', value: 'radio2' },
-      { text: 'Radio 3 (disabled)', value: 'radio3', disabled: true }
+      { text: 'Radio 3 (disabled)', value: 'radio3', disabled: true },
       { text: 'Radio 4', value: 'radio4' }
     ]
   }

--- a/docs/components/form-radio/README.md
+++ b/docs/components/form-radio/README.md
@@ -58,9 +58,9 @@ By default `<b-form-radio>` generates inline radio inputs. Set the prop `stacked
 the radios appear one over the other.
 
 
-### Buttons style
+### Button style radios
 Render radios with the look of buttons by setting the prop `buttons`. Set the button variant by
-setting the `button-variant` prop to one ofhte standard Bootstrap button variants (see
+setting the `button-variant` prop to one of the standard Bootstrap button variants (see
 [`<b-button>`](./button) for supported variants). The default `button-variant` is `secondary`.
 
 The `buttons` prop has precedence over `plain`, and `button-variant` has no effect if

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -105,7 +105,7 @@
                     'btn',
                     `btn-${this.buttonVariant}`,
                     (option.disabled || this.disabled) ? 'disabled' : '',
-                    option.value === this.localValue ? 'active' ; null,
+                    option.value === this.localValue ? 'active' : null,
                     // Fix staking issue (remove space between buttons)
                     (this.stacked && idx === this.formOptions.length - 1) ? '', 'mb-0'
                 ];

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -2,6 +2,7 @@
     <div :id="id || null"
          :class="buttons ? btnGroupClasses : radioGroupClasses"
          role="radiogroup"
+         :data-toggle="buttons ? 'buttons' : null"
          :aria-required="required ? 'true' : null"
          :aria-invalid="invalid ? 'true' : null"
          @focusin.native="handleFocus"

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -107,7 +107,7 @@
                     (option.disabled || this.disabled) ? 'disabled' : '',
                     option.value === this.localValue ? 'active' : null,
                     // Fix staking issue (remove space between buttons)
-                    (this.stacked && idx === this.formOptions.length - 1) ? '', 'mb-0'
+                    (this.stacked && idx === this.formOptions.length - 1) ? '' : 'mb-0'
                 ];
             },
             handleFocus(evt) {

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -112,11 +112,16 @@
             },
             handleFocus(evt) {
                 // When in buttons mode, we need to add 'focus' class to label when radio focused
-                if (this.buttons && evt.target.tagName === 'INPUT') {
+                const el = evt.target;
+                if (this.buttons && el && el.tagName === 'INPUT' && el.parentElement) {
+                    const label = el.parentElement;
+                    if (!label || label.tagName !== 'LABEL') {
+                        return;
+                    }
                     if (evt.type ==='focusin') {
-                        evt.target.classList.add('focus');
+                        label.classList.add('focus');
                     } else if (evt.type ==='focusout') {
-                        evt.target.classList.remove('focus');
+                        label.classList.remove('focus');
                     }
                 }
             }

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -97,6 +97,9 @@
                     this.checkboxClass,
                     this.custom ? 'custom-radio' : null
                 ];
+            },
+            inline() {
+                return !this.stacked;
             }
         },
         methods: {

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -1,15 +1,19 @@
 <template>
     <div :id="id || null"
-         :class="inputClass"
+         :class="buttons ? btnGroupClasses : radioGroupClasses"
          role="radiogroup"
          :aria-required="required ? 'true' : null"
-         :aria-invalid="ariaInvalid"
+         :aria-invalid="invalid ? 'true' : null"
+         @focusin.native="handleFocus"
+         @focusout.native="handleFocus"
     >
-        <label :class="[checkboxClass, custom?'custom-radio':null]"
-               v-for="(option, idx) in formOptions"
+        <label v-for="(option, idx) in formOptions"
+               :class="buttons ? btnLabelClasses(option, idx) : labelClasses"
+               :key="idx"
+               :aria-pressed="buttons ? (option.value === this.localValue ? 'true' : 'false') : null"
         >
             <input :id="id ? (id + '__BV_radio_' + idx) : null"
-                   :class="custom?'custom-control-input':null"
+                   :class="(custom && !buttons) ? 'custom-control-input' : null"
                    ref="inputs"
                    type="radio"
                    autocomplete="off"
@@ -20,8 +24,8 @@
                    :disabled="option.disabled || disabled"
                    @change="$emit('change', returnObject ? option : option.value)"
             >
-            <span v-if="custom" class="custom-control-indicator" aria-hidden="true"></span>
-            <span :class="custom?'custom-control-description':null" v-html="option.text"></span>
+            <span v-if="custom && !buttons" class="custom-control-indicator" aria-hidden="true"></span>
+            <span :class="(custom && !buttons) ? 'custom-control-description' : null" v-html="option.text"></span>
         </label>
     </div>
 </template>
@@ -35,21 +39,6 @@
             return {
                 localValue: this.value
             };
-        },
-        computed: {
-            inputClass() {
-                return [
-                    this.size ? `form-control-${this.size}` : null,
-                    this.state ? `has-${this.state}` : '',
-                    this.stacked ? 'custom-controls-stacked' : ''
-                 ];
-            },
-            ariaInvalid() {
-                if (this.invalid === true || this.invalid === 'true') {
-                    return 'true';
-                }
-                return null;
-            }
         },
         props: {
             value: {},
@@ -74,11 +63,63 @@
                 type: Boolean,
                 default: false
             },
+            buttons: {
+                // Render as button style
+                type: Boolean,
+                default: false
+            },
+            buttonVariant: {
+                // Only applicable when rendered with button style
+                type: String,
+                defaultL 'secondary'
+            },
             returnObject: {
                 type: Boolean,
                 default: false
             }
+        },
+        computed: {
+            radioGroupClasses() {
+                return [
+                    this.size ? `form-control-${this.size}` : null,
+                    this.state ? `has-${this.state}` : '',
+                    this.stacked ? 'custom-controls-stacked' : ''
+               ];
+            },
+            btnGroupClasses() {
+                return [
+                    this.size ? `button-group-${this.size}` : null,
+                    this.stacked ? 'btn-group-vertical' : ''
+                 ];
+            },
+            labelClasses() {
+                return [
+                    this.checkboxClass,
+                    this.custom ? 'custom-radio' : null
+                ];
+            }
+        },
+        methods: {
+            btnLabelClasses(option, idx) {
+                return [
+                    'btn',
+                    `btn-${this.buttonVariant}`,
+                    (option.disabled || this.disabled) ? 'disabled' : '',
+                    option.value === this.localValue ? 'active' ; null,
+                    // Fix staking issue (remove space between buttons)
+                    (this.stacked && idx === this.formOptions.length - 1) ? '', 'mb-0'
+                ];
+            },
+            handleFocus(evt) {
+                // When in buttons mode, we need to add 'focus' class to label when radio focused
+                if (this.buttons && evt.target.tagName === 'INPUT') {
+                    if (evt.type ==='focusin') {
+                        evt.target.classList.add('focus');
+                    } else if (evt.type ==='focusout') {
+                        evt.target.classList.remove('focus');
+                    }
+                }
+            }
         }
     };
-
 </script>

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -71,7 +71,7 @@
             buttonVariant: {
                 // Only applicable when rendered with button style
                 type: String,
-                defaultL 'secondary'
+                default: 'secondary'
             },
             returnObject: {
                 type: Boolean,


### PR DESCRIPTION
Adds new Boolean prop `buttons` (defaults to `false`) that wil enable the radios to be rendered with the look of buttons.
http://v4-alpha.getbootstrap.com/components/buttons/#checkbox-and-radio-buttons

Currently the buttons can only be rendered with the same variant specified by the prop `button-variant`.  Different variants for each radio button ar currently not supported (not without altering the `form-options.js` mixin).

`stacked` button radios are supported,, but `state` is not supported for button radios