### PR TITLE
feat(form-checkbox): Support button style checkbox

### DIFF
--- a/docs/components/form-checkbox/README.md
+++ b/docs/components/form-checkbox/README.md
@@ -151,24 +151,26 @@ when they are in the checked state.
 <div>
   <h5>button style checkboxes</h5>
   <b-button-group data-toggle="buttons">
-    <b-form-checkbox button name="flavour" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox button name="flavour" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox button name="flavour" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox button name="flavour" value="grape">Grape</b-form-checkbox>
+    <b-form-checkbox button name="a" value="orange">Orange</b-form-checkbox>
+    <b-form-checkbox button name="a" value="apple">Apple</b-form-checkbox>
+    <b-form-checkbox button name="a" value="pineapple">Pineapple</b-form-checkbox>
+    <b-form-checkbox button name="ar" value="grape">Grape</b-form-checkbox>
   </b-button-group>
+
   <h5>button style checkboxes with variant <code>primary</code> and large buttons</h5>
   <b-button-group size="lg" data-toggle="buttons">
-    <b-form-checkbox button button-variant"primary" name="flavour" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox button button-variant"primary" name="flavour" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox button button-variant"primary" name="flavour" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox button button-variant"primary" name="flavour" value="grape">Grape</b-form-checkbox>
+    <b-form-checkbox button button-variant"primary" name="b" value="orange">Orange</b-form-checkbox>
+    <b-form-checkbox button button-variant"primary" name="b" value="apple">Apple</b-form-checkbox>
+    <b-form-checkbox button button-variant"primary" name="b" value="pineapple">Pineapple</b-form-checkbox>
+    <b-form-checkbox button button-variant"primary" name="b" value="grape">Grape</b-form-checkbox>
   </b-button-group>
+
   <h5>Stacked (vertical) button style checkboxes</h5>
   <b-button-group vertical data-toggle="buttons">
-    <b-form-checkbox button class="mb-0" name="flavour" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox button class="mb-0" name="flavour" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox button class="mb-0" name="flavour" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox button name="flavour" value="grape">Grape</b-form-checkbox>
+    <b-form-checkbox button class="mb-0" name="c" value="orange">Orange</b-form-checkbox>
+    <b-form-checkbox button class="mb-0" name="c" value="apple">Apple</b-form-checkbox>
+    <b-form-checkbox button class="mb-0" name="c" value="pineapple">Pineapple</b-form-checkbox>
+    <b-form-checkbox button name="flavour" value="c">Grape</b-form-checkbox>
   </b-button-group>
 </div>
 

--- a/docs/components/form-checkbox/README.md
+++ b/docs/components/form-checkbox/README.md
@@ -88,22 +88,33 @@ with class `.custom-controls-stacked` to ensure each form control is on a separa
 
 **Example 3: Inline & Stacked checkboxes:**
 ```html
-<div>
-  <h5>Inline Checkboxes (default)</h5>
-  <div role="group">
-    <b-form-checkbox name="flavour" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox name="flavour" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox name="flavour" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox name="flavour" value="grape">Grape</b-form-checkbox>
+<template>
+  <div>
+    <h5>Inline Checkboxes (default)</h5>
+    <div role="group">
+      <b-form-checkbox name="flavour" v-model="a" value="orange">Orange</b-form-checkbox>
+      <b-form-checkbox name="flavour" v-model="a" value="apple">Apple</b-form-checkbox>
+      <b-form-checkbox name="flavour" v-model="a" value="pineapple">Pineapple</b-form-checkbox>
+      <b-form-checkbox name="flavour" v-model="a" value="grape">Grape</b-form-checkbox>
+    </div>
+    <h5>Stacked Checkboxes</h5>
+    <div role="group" class="custom-controls-stacked">
+      <b-form-checkbox name="flavour" v-model="b" value="orange">Orange</b-form-checkbox>
+      <b-form-checkbox name="flavour" v-model="b" value="apple">Apple</b-form-checkbox>
+      <b-form-checkbox name="flavour" v-model="b" value="pineapple">Pineapple</b-form-checkbox>
+      <b-form-checkbox name="flavour" v-model="b" value="grape">Grape</b-form-checkbox>
+    </div>
   </div>
-  <h5>Stacked Checkboxes</h5>
-  <div role="group" class="custom-controls-stacked">
-    <b-form-checkbox name="flavour" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox name="flavour" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox name="flavour" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox name="flavour" value="grape">Grape</b-form-checkbox>
-  </div>
-</div>
+</template>
+
+<script>
+export default {
+    data: {
+        a: [],
+        b: []
+    }
+}
+</script>
 
 <!-- form-checkbox-3.vue -->
 ```
@@ -148,31 +159,43 @@ when they are in the checked state.
 
 **Example 4: Button style checkboxes:**
 ```html
-<div>
-  <h5>button style checkboxes</h5>
-  <b-button-group data-toggle="buttons">
-    <b-form-checkbox button name="a" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox button name="a" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox button name="a" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox button name="a" value="grape">Grape</b-form-checkbox>
-  </b-button-group>
+<template>
+  <div>
+    <h5>button style checkboxes</h5>
+    <b-button-group data-toggle="buttons">
+      <b-form-checkbox button name="a" v-model="a" value="orange">Orange</b-form-checkbox>
+      <b-form-checkbox button name="a" v-model="a" value="apple">Apple</b-form-checkbox>
+      <b-form-checkbox button name="a" v-model="a" value="pineapple">Pineapple</b-form-checkbox>
+      <b-form-checkbox button name="a" v-model="a" value="grape">Grape</b-form-checkbox>
+    </b-button-group>
 
-  <h5>button style checkboxes with variant <code>primary</code> and large buttons</h5>
-  <b-button-group size="lg" data-toggle="buttons">
-    <b-form-checkbox button button-variant="primary" name="b" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox button button-variant="primary" name="b" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox button button-variant="primary" name="b" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox button button-variant="primary" name="b" value="grape">Grape</b-form-checkbox>
-  </b-button-group>
+    <h5>button style checkboxes with variant <code>primary</code> and large buttons</h5>
+    <b-button-group size="lg" data-toggle="buttons">
+      <b-form-checkbox button button-variant="primary" v-model="b" name="b" value="orange">Orange</b-form-checkbox>
+      <b-form-checkbox button button-variant="primary" v-model="b" name="b" value="apple">Apple</b-form-checkbox>
+      <b-form-checkbox button button-variant="primary" v-model="b" name="b" value="pineapple">Pineapple</b-form-checkbox>
+      <b-form-checkbox button button-variant="primary" v-model="b" name="b" value="grape">Grape</b-form-checkbox>
+    </b-button-group>
 
-  <h5>Stacked (vertical) button style checkboxes</h5>
-  <b-button-group vertical data-toggle="buttons">
-    <b-form-checkbox button class="mb-0" name="c" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox button class="mb-0" name="c" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox button class="mb-0" name="c" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox button name="flavour" value="c">Grape</b-form-checkbox>
-  </b-button-group>
-</div>
+    <h5>Stacked (vertical) button style checkboxes</h5>
+    <b-button-group vertical data-toggle="buttons">
+      <b-form-checkbox button class="mb-0" name="c" v-model="c" value="orange">Orange</b-form-checkbox>
+      <b-form-checkbox button class="mb-0" name="c" v-model="c" value="apple">Apple</b-form-checkbox>
+      <b-form-checkbox button class="mb-0" name="c" v-model="c" value="pineapple">Pineapple</b-form-checkbox>
+      <b-form-checkbox button name="flavour" v-model="c" value="grape">Grape</b-form-checkbox>
+    </b-button-group>
+  </div>
+</template>
+
+<script>
+export default {
+    data: {
+        a: [],
+        b: [],
+        c: []
+    }
+}
+</script>
 
 <!-- form-checkbox-4.vue -->
 ```

--- a/docs/components/form-checkbox/README.md
+++ b/docs/components/form-checkbox/README.md
@@ -154,15 +154,15 @@ when they are in the checked state.
     <b-form-checkbox button name="a" value="orange">Orange</b-form-checkbox>
     <b-form-checkbox button name="a" value="apple">Apple</b-form-checkbox>
     <b-form-checkbox button name="a" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox button name="ar" value="grape">Grape</b-form-checkbox>
+    <b-form-checkbox button name="a" value="grape">Grape</b-form-checkbox>
   </b-button-group>
 
   <h5>button style checkboxes with variant <code>primary</code> and large buttons</h5>
   <b-button-group size="lg" data-toggle="buttons">
-    <b-form-checkbox button button-variant"primary" name="b" value="orange">Orange</b-form-checkbox>
-    <b-form-checkbox button button-variant"primary" name="b" value="apple">Apple</b-form-checkbox>
-    <b-form-checkbox button button-variant"primary" name="b" value="pineapple">Pineapple</b-form-checkbox>
-    <b-form-checkbox button button-variant"primary" name="b" value="grape">Grape</b-form-checkbox>
+    <b-form-checkbox button button-variant="primary" name="b" value="orange">Orange</b-form-checkbox>
+    <b-form-checkbox button button-variant="primary" name="b" value="apple">Apple</b-form-checkbox>
+    <b-form-checkbox button button-variant="primary" name="b" value="pineapple">Pineapple</b-form-checkbox>
+    <b-form-checkbox button button-variant="primary" name="b" value="grape">Grape</b-form-checkbox>
   </b-button-group>
 
   <h5>Stacked (vertical) button style checkboxes</h5>

--- a/docs/components/form-checkbox/README.md
+++ b/docs/components/form-checkbox/README.md
@@ -180,7 +180,7 @@ a `<b-form-fieldset>` component (which has the `state` prop set to the state you
 would like), or wrapped in another element - such as a `<div>` - which has one
 of the standard Bootstrap V4 `.has-*` state class applied.
 
-**Note:** Contextual states are not supprted when `button` is set.
+**Note:** Contextual states are not supported when `button` is set.
 
 
 ### Indeterminate (tri-state) support
@@ -200,7 +200,7 @@ prop (defaults to `false`). Clicking the checkbox will clear its indeterminate s
 The `indeterminate` prop can be synced to the checkboxe's state by v-binding the
 `indeterminate` prop with the `.sync` modifier.
 
-**Note:** indeterminate is not supprted when `button` is set.
+**Note:** indeterminate is not supported when `button` is set.
 
 **Example 5: Single Indeterminate checkbox:**
 ```html

--- a/docs/components/form-checkbox/README.md
+++ b/docs/components/form-checkbox/README.md
@@ -116,9 +116,10 @@ properties.
 `v-model` binds to the `checked` property.  When you have multiple checkboxes that bind to a
 single data state variable, you **must** provide an array reference `[]` to your `v-model`!
 
-Note that when `v-model` is bound to multiple checkboxes, the `unchecked-value` is **not used**.
-Only the value(s) of the checked chcekboxes will be returned in the `v-model` bound array. You
-should provide unique values for each checkbox's `value` prop.
+Note that when `v-model` is bound to multiple checkboxes (i.e an array ref), the
+`unchecked-value` is **not used**. Only the value(s) of the checked chcekboxes will
+be returned in the `v-model` bound array. You should provide unique values for each
+checkbox's `value` prop.
 
 
 #### Multiple checkboxes and accessibility

--- a/docs/components/form-checkbox/README.md
+++ b/docs/components/form-checkbox/README.md
@@ -134,11 +134,53 @@ recommended that they be placed in a `<b-form-fieldset>` component to associate 
 with the entire group of checkboxes.
 
 
+### Button style checkboxes
+Render a checkbox with the look of a button by setting the prop `button`. Change the button variant by
+setting the `button-variant` prop to one of the standard Bootstrap button variants (see
+[`<b-button>`](./button) for supported variants). The default `button-variant` is `secondary`.
+
+Youy **must** wrap your button style checkbox(es) in a `<b-button-group>` component
+and add the attribute `data-toggle="buttons"` to get the proper Bootstrap CSS styling.
+
+Button style checkboxes will have the class `.active` automatically applied to the label
+when they are in the checked state.
+
+**Example 4: Button style checkboxes:**
+```html
+<div>
+  <h5>button style checkboxes</h5>
+  <b-button-group data-toggle="buttons">
+    <b-form-checkbox button name="flavour" value="orange">Orange</b-form-checkbox>
+    <b-form-checkbox button name="flavour" value="apple">Apple</b-form-checkbox>
+    <b-form-checkbox button name="flavour" value="pineapple">Pineapple</b-form-checkbox>
+    <b-form-checkbox button name="flavour" value="grape">Grape</b-form-checkbox>
+  </b-button-group>
+  <h5>button style checkboxes with variant <code>primary</code> and large buttons</h5>
+  <b-button-group size="lg" data-toggle="buttons">
+    <b-form-checkbox button button-variant"primary" name="flavour" value="orange">Orange</b-form-checkbox>
+    <b-form-checkbox button button-variant"primary" name="flavour" value="apple">Apple</b-form-checkbox>
+    <b-form-checkbox button button-variant"primary" name="flavour" value="pineapple">Pineapple</b-form-checkbox>
+    <b-form-checkbox button button-variant"primary" name="flavour" value="grape">Grape</b-form-checkbox>
+  </b-button-group>
+  <h5>Stacked (vertical) button style checkboxes</h5>
+  <b-button-group vertical data-toggle="buttons">
+    <b-form-checkbox button class="mb-0" name="flavour" value="orange">Orange</b-form-checkbox>
+    <b-form-checkbox button class="mb-0" name="flavour" value="apple">Apple</b-form-checkbox>
+    <b-form-checkbox button class="mb-0" name="flavour" value="pineapple">Pineapple</b-form-checkbox>
+    <b-form-checkbox button name="flavour" value="grape">Grape</b-form-checkbox>
+  </b-button-group>
+</div>
+
+<!-- form-checkbox-4.vue -->
+```
+
 ### Contextual states
 To apply contextual state colors to `<b-form-checkbox>`, it must be wrapped in
 a `<b-form-fieldset>` component (which has the `state` prop set to the state you
 would like), or wrapped in another element - such as a `<div>` - which has one
 of the standard Bootstrap V4 `.has-*` state class applied.
+
+**Note:** Contextual states are not supprted when `button` is set.
 
 
 ### Indeterminate (tri-state) support
@@ -158,7 +200,9 @@ prop (defaults to `false`). Clicking the checkbox will clear its indeterminate s
 The `indeterminate` prop can be synced to the checkboxe's state by v-binding the
 `indeterminate` prop with the `.sync` modifier.
 
-**Example 4: Single Indeterminate checkbox:**
+**Note:** indeterminate is not supprted when `button` is set.
+
+**Example 5: Single Indeterminate checkbox:**
 ```html
 <template>
   <div>
@@ -188,10 +232,10 @@ export default {
 }
 </script>
 
-<!-- form-checkbox-4.vue -->
+<!-- form-checkbox-5.vue -->
 ```
 
-**Example 5: Indeterminate checkbox use-case:**
+**Example 6: Indeterminate checkbox use-case:**
 ```html
 <template>
   <b-card>
@@ -249,7 +293,7 @@ export default {
 }
 </script>
 
-<!-- form-checkbox-5.vue -->
+<!-- form-checkbox-6.vue -->
 ```
 
 #### Indeterminate state and accessibility
@@ -262,7 +306,10 @@ meaning in your application.
 ### Non custom check inputs
 You can have `b-form-checkbox` render a browser native chechbox input by setting the `plain` prop.
 
+**Note:** The `plain` prop has no effect with `button` is set.
 
 ### See also
 - [`<b-form-fieldset>`](./form-fieldset)
+- [`<b-button-group>`](./button-group)
+- [`<b-button>`](./button)
 

--- a/lib/components/form-checkbox.vue
+++ b/lib/components/form-checkbox.vue
@@ -1,5 +1,7 @@
 <template>
-    <label :class="[inputClass,checkboxClass]">
+    <label :class="button ? btnLabelClasses : labelClasses"
+           :aria-pressed="button ? (isChecked ? 'true' : 'false') : null"
+    >
         <input type="checkbox"
                :id="id || null"
                :name="name"
@@ -9,13 +11,16 @@
                ref="check"
                autocomplete="off"
                :aria-required="required ? 'true' : null"
-               :class="[custom?'custom-control-input':null]"
+               :class="(custom && !button ) ? 'custom-control-input' : null"
                :checked="isChecked"
+               @focusin.native="handleFocus"
+               @focusout.native="handleFocus"
                @change="handleChange">
-        <span class="custom-control-indicator"
+        <span v-if="custom && !button"
+              class="custom-control-indicator"
               aria-hidden="true"
-              v-if="custom"></span>
-        <span :class="custom ? 'custom-control-description' : null">
+        ></span>
+        <span :class="(custom && !button) ? 'custom-control-description' : null">
             <slot></slot>
         </span>
     </label>
@@ -48,13 +53,31 @@ export default {
         size: {
             type: String,
             default: null
+        },
+        button: {
+            type: Boolean,
+            default: false,
+        },
+        buttonVariant: {
+            type: String,
+            default: 'secondary',
         }
     },
     computed: {
-        inputClass() {
+        labelClasses() {
             return [
-                this.size ? `form-control-${this.size}` : null,
-                this.custom ? 'custom-checkbox' : null
+                this.size ? `form-control-${this.size}` : '',
+                this.custom ? 'custom-checkbox' : '',
+                this.checkboxClass
+            ];
+        },
+        btnLabelClasses() {
+            return [
+                'btn',
+                `btn-${this.buttonVariant}`,
+                this.size ? `btn-${this.size}` : '',
+                this.isChecked ? 'active' : '',
+                this.disabled ? 'disabled' : ''
             ];
         },
         isChecked() {
@@ -87,6 +110,16 @@ export default {
             this.$refs.check.indeterminate = state;
             // Emit update event to prop
             this.$emit('update:indeterminate', this.$refs.check.indeterminate);
+        },
+        handleFocus(evt) {
+            // Add or remove 'focus' class on label in button mode
+            if (this.button && evt.target === this.$refs.check) {
+                if (evt.type === 'focusin') {
+                    this.$el.classList.add('focus');
+                } else if (evt.type === 'focusout') {
+                    this.$el.classList.remove('focus');
+                }
+            }
         }
     },
     mounted() {


### PR DESCRIPTION
Support rending checkbox in button style, by setting the prop `button`.
http://v4-alpha.getbootstrap.com/components/buttons/#checkbox-and-radio-buttons

Button variant style can be set via the prop `button-variant`. Defaults to `secondary`.

`button` prop has precedence over `plain` prop