### PR TITLE
feat(button): refactor toggle button focus handler

### DIFF
--- a/lib/components/button.vue
+++ b/lib/components/button.vue
@@ -7,6 +7,8 @@
             :type="btnType"
             :disabled="disabled"
             :tabindex="(disabled && componentType !== 'button') ? '-1' : null"
+            @focusin.native="handleFocus"
+            @focusout.native="handleFocus"
             @click="onClick">
         <slot></slot>
     </button>
@@ -16,24 +18,6 @@
 import bLink from './link.vue';
 import { omitLinkProps, props as originalLinkProps, computed } from '../mixins/link';
 import { assign } from '../utils/object';
-
-// focus handler for data-toggle="button"
-function handleToggleFocus(evt) {
-    const el = evt.target;
-    if (el && el.classList.contains('btn') && el.getAttribute('data-toggle') === 'button') {
-        if (evt.type === 'focusin') {
-            el.classList.add('focus');
-        } else if (evt.type === 'focusout') {
-            el.classList.remove('focus');
-        }
-    }
-}
-
-// Add our data-toggle="button" focus handler
-if (typeof document !== 'undefined') {
-    document.addEventListener('focusin', handleToggleFocus, false);
-    document.addEventListener('focusout', handleToggleFocus, false);
-}
 
 // Grab a fresh object of link props (omitLinkProps does this)
 // less the 'href' and 'to' props
@@ -132,6 +116,15 @@ export default {
                 if (this.isToggle) {
                     // Emit .sync notification about pressed prop state changing
                     this.$emit('update:pressed', !this.pressed);
+                }
+            }
+        },
+        handleFocus(evt) {
+            if (this.isToggle) {
+                if (evt.type === 'focusin') {
+                    evt.target.classList.add('focus');
+                } else if (evt.type === 'focusout') {
+                    evt.target.classList.remove('focus');
                 }
             }
         }


### PR DESCRIPTION
Minor change to focus handler for toggle style buttons.

Uses `@focus(in|out).native` handler now.