### PR TITLE
fix(popover.js): destroy check for trigger & classes (issue #735)

### DIFF
--- a/lib/mixins/popover.js
+++ b/lib/mixins/popover.js
@@ -200,7 +200,9 @@ export default {
                 this.$data._tether.destroy();
                 this.$data._tether = null;
                 const regx = new RegExp('(^|[^-]\\b)(' + TETHER_CLASS_PREFIX + '\\S*)', 'g');
-                this.$data._trigger.className = this.$data._trigger.className.replace(regx, '');
+                if (this.$data._trigger && this.$data._trigger.className) {
+                    this.$data._trigger.className = this.$data._trigger.className.replace(regx, '');
+                }
             }
         },
         /**


### PR DESCRIPTION
Addresses issue #735 

Prevents console warning:
`[Vue warn]: Error in beforeDestroy hook: "TypeError: this.$data._trigger.className.replace is not a function" found in ---> <BPopover>`