### PR TITLE
feat(form-input): Add autocomplete prop

### DIFF
--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -7,6 +7,7 @@
            :id="id || null"
            :disabled="disabled"
            :required="required"
+           :autocomplete="autocomplete"
            :aria-required="required ? 'true' : null"
            :aria-invalid="ariaInvalid"
            :readonly="readonly"
@@ -109,6 +110,10 @@
             readonly: {
                 type: Boolean,
                 default: false
+            },
+            autocomplete: {
+                type: String,
+                default: null
             },
             static: {
                 type: Boolean,

--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -7,7 +7,7 @@
            :id="id || null"
            :disabled="disabled"
            :required="required"
-           :autocomplete="autocomplete"
+           :autocomplete="autocomplete || null"
            :aria-required="required ? 'true' : null"
            :aria-invalid="ariaInvalid"
            :readonly="readonly"


### PR DESCRIPTION
It would be nice to be able to control browsers autocomplete features with an `autocomplete` prop on form inputs.