### PR TITLE
fix(docs): Adjust header tags CSS specificity (issue #753)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,33 +6,33 @@
 
 >This library, **BootstrapVue**, helps you quickly integrate Bootstrap 4 components with Vue.js 2.
 
-# Setup
+## Setup
 To get started use [Quick Start](/docs/setup) guide.
  
 
-# Migrating a project already using Bootstrap
+## Migrating a project already using Bootstrap
 If you've already been using Bootstrap 4, there are a couple adjustments you may need to make to your project:
  
 - remove the bootstrap.js file from your page scripts or build pipeline
 - if Bootstrap is the only thing relying on jQuery, you can safely remove it — BootstrapVue **does not** depend on jQuery
 - don't forget to include the `bootstrap-vue.css` file!
 
-# Browsers Support
+## Browsers Support
 
 **CSS**
 
 BootstrapVue is to be used with Bootstrap 4 CSS.
 Please see [Browsers and devices](https://v4-alpha.getbootstrap.com/getting-started/browsers-devices)
-for more information about currently supported browsers by Bootstrap 4. 
+for more information about browsers currently supported by Bootstrap 4. 
 
 **JS**
 
 BootstrapVue is written in Vue! So this is up to your project and bundler that which browsers are supported.
-If you want support older IE, Android and IOS devices, you may want using [Babel Polyfill](https://babeljs.io/docs/usage/polyfill)
+If you want support older IE, Android and IOS devices, you may want to use
+[Babel Polyfill](https://babeljs.io/docs/usage/polyfill)
 
 **IE 11**
 
-You'll need babel-polyfill for BootstrapVue to work properly, since IE11 doesn't support Object.assign. 
-In order to support this browser: 
+You'll need babel-polyfill for BootstrapVue to work properly. In order to support this browser: 
 - npm install babel-polyfill --save
 - Import it in your app main entry point with _import 'babel-polyfill'_

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,11 +28,11 @@ for more information about browsers currently supported by Bootstrap 4.
 **JS**
 
 BootstrapVue is written in Vue! So this is up to your project and bundler that which browsers are supported.
-If you want support older IE, Android and IOS devices, you may want to use
+If you want to support older IE, Android and IOS devices, you may want to use
 [Babel Polyfill](https://babeljs.io/docs/usage/polyfill)
 
 **IE 11**
 
 You'll need babel-polyfill for BootstrapVue to work properly. In order to support this browser: 
 - npm install babel-polyfill --save
-- Import it in your app main entry point with _import 'babel-polyfill'_
+- Import it in your app main entry point with `import 'babel-polyfill'`

--- a/docs/nuxt/assets/css/styles.css
+++ b/docs/nuxt/assets/css/styles.css
@@ -57,7 +57,7 @@ blockquote {
     font-weight: 300;
 }
 
-.bd-content h1, .bd-content h2, .bd-content h3, .bd-content h4, .bd-content h5 {
+.bd-content>h1, .bd-content>h2, .bd-content>h3, .bd-content>h4, .bd-content>h5 {
     padding-top: 25px;
     padding-bottom: 15px;
 }

--- a/docs/nuxt/components/componentdoc.vue
+++ b/docs/nuxt/components/componentdoc.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="bd-content">
 
         <h2><code>{{tag}}</code></h2>
         <a :href="githubURL" target="_blank" class="text-muted">(view source)</a>

--- a/docs/nuxt/layouts/docs.vue
+++ b/docs/nuxt/layouts/docs.vue
@@ -4,7 +4,7 @@
     
         <div class="container mt-5">
             <div class="row">
-                <div class="col-12 col-md-9 bd-content">
+                <div class="col-12 col-md-9">
                     <div class="float-right">
                         <a href="https://github.com/bootstrap-vue/bootstrap-vue/releases" target="_blank">
                             <img src="https://img.shields.io/github/release/bootstrap-vue/bootstrap-vue.svg?style=flat-square" alt="GitHub release">

--- a/docs/nuxt/pages/docs/components/_component.vue
+++ b/docs/nuxt/pages/docs/components/_component.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="container">
     
-        <div v-html="readme" v-play></div>
+        <div class="bd-content" v-html="readme" v-play></div>
     
         <componentdoc :component="meta.component" :events="meta.events" :slots="meta.slots"></componentdoc>
     

--- a/docs/nuxt/pages/docs/contributing.vue
+++ b/docs/nuxt/pages/docs/contributing.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="container" v-html="readme"></div>
+    <div class="container bd-content" v-html="readme"></div>
 </template>
 
 <script>

--- a/docs/nuxt/pages/docs/directives/_directive.vue
+++ b/docs/nuxt/pages/docs/directives/_directive.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="container">
-        <div v-html="readme" v-play></div>
+        <div class="bd-content" v-html="readme" v-play></div>
     </div>
 </template>
 

--- a/docs/nuxt/pages/docs/index.vue
+++ b/docs/nuxt/pages/docs/index.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="container" v-html="readme"></div>
+    <div class="container bd-content" v-html="readme"></div>
 </template>
 
 <script>

--- a/docs/nuxt/pages/docs/setup.vue
+++ b/docs/nuxt/pages/docs/setup.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="container" v-html="readme"></div>
+    <div class="container bd-content" v-html="readme"></div>
 </template>
 
 <script>


### PR DESCRIPTION
Minor adjustment to CSS to target only top level `<H#>` tags within `README.md` so that docs custom CSS does not affect live examples.

Addresses issue #753 