### PR TITLE
fix(dropdown): Emit shown and hidden events (issue #757)

### DIFF
--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -68,6 +68,7 @@ export default {
 
             if (state) {
                 this.emitOnRoot('shown::dropdown', this);
+                this.$emit('shown');
                 /*
                  If this is a touch-enabled device we add extra
                  empty mouseover listeners to the body's immediate children;
@@ -82,6 +83,7 @@ export default {
                 }
             } else {
                 this.emitOnRoot('hidden::dropdown', this);
+                this.$emit('hidden');
                 /*
                  If this is a touch-enabled device we remove the extra
                  empty mouseover listeners we added for iOS support


### PR DESCRIPTION
Dropdowns were not emitting `hidden` or `shown` events on the component as documented.

Addresses issue #757 
