### PR TITLE
fix(alert): add colon for binding `aria-label`

### DIFF
--- a/lib/components/alert.vue
+++ b/lib/components/alert.vue
@@ -8,7 +8,7 @@
         <button type="button"
                 class="close"
                 data-dismiss="alert"
-                aria-label="dismissLabel"
+                :aria-label="dismissLabel"
                 v-if="dismissible"
                 @click.stop.prevent="dismiss"
         >


### PR DESCRIPTION
I think this place maybe forget colon to bind attribute `aria-label` . So I make this PR.