### PR TITLE
feat(table): Add row-dblclicked event

### DIFF
--- a/docs/components/table/meta.json
+++ b/docs/components/table/meta.json
@@ -17,6 +17,20 @@
       ]
     },
     {
+      "event": "row-dblclicked",
+      "description": "Emitted when a row is double clicked.",
+      "args": [
+        {
+          "arg": "item",
+          "description": "Item data of the row being double clicked."
+        },
+        {
+          "arg": "index",
+          "description": "Index of the row being double clicked."
+        }
+      ]
+    },
+    {
       "event": "row-hovered",
       "description": "Emitted when a row is hovered.",
       "args": [

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -50,6 +50,7 @@
             :key="index"
             :class="rowClass(item)"
             @click="rowClicked($event,item,index)"
+            @dblclick="rowDblClicked($event,item,index)"
             @hover="rowHovered($event,item,index)"
         >
             <template v-for="(field,key) in fields">
@@ -465,6 +466,15 @@
                     return;
                 }
                 this.$emit('row-clicked', item, index);
+            },
+            rowDblClicked(e, item, index) {
+                if (this.busy) {
+                    // If table is busy (via provider) then don't propagate
+                    e.preventDefault();
+                    e.stopPropagation();
+                    return;
+                }
+                this.$emit('row-dblclicked', item, index);
             },
             rowHovered(e, item, index) {
                 if (this.busy) {


### PR DESCRIPTION
Emit a `row-dblclicked` event when a row is double clicked.

Event has same argument signature as `row-clicked`