### PR TITLE
Fix "narbar" typo in Navbar docs

### DIFF
--- a/docs/components/form-input/README.md
+++ b/docs/components/form-input/README.md
@@ -16,7 +16,7 @@
     <small class="text-muted">We will convert your name to lowercase instantly</small>
     <p>Value: {{ text1 }}</p>
 
-    <h5>Text input with lazy formatter (on bluer)</h5>
+    <h5>Text input with lazy formatter (on blur)</h5>
     <b-form-input v-model="text2"
                   type="text"
                   placeholder="Enter your name"

--- a/docs/components/navbar/README.md
+++ b/docs/components/navbar/README.md
@@ -73,7 +73,7 @@ Navbars come with built-in support for a handful of sub-components. Choose from 
 - `<b-nav-item>` for link (and router-link) action items
 - `<b-nav-item-dropdown>` for navbar dropdown menus
 - `<b-nav-text>` for adding vertically centered strings of text.
-- `<b-narbar-form>` for any form controls and actions.
+- `<b-navbar-form>` for any form controls and actions.
 - `<b-navbar-toggler>` for use with the `<b-collapse>` component.
 - `<b-collapse is-nav>` for grouping and hiding navbar contents by a parent breakpoint.
 
@@ -86,7 +86,7 @@ tag type by setting the `tag` prop to the element you would like rendered:
 <div>
   <!-- As a link -->
   <b-navbar variant="faded" type="light">
-    <b-narbar-brand href="#">BootstrapVue</b-narbar-brand>
+    <b-navbar-brand href="#">BootstrapVue</b-navbar-brand>
   </b-navbar>
 </div>
 
@@ -97,7 +97,7 @@ tag type by setting the `tag` prop to the element you would like rendered:
 <div>
   <!-- As a heading -->
   <b-navbar variant="faded" type="light">
-    <b-narbar-brand tag="h1" class="mb-0">BootstrapVue</b-narbar-brand>
+    <b-navbar-brand tag="h1" class="mb-0">BootstrapVue</b-navbar-brand>
   </b-navbar>
 </div>
 
@@ -111,9 +111,9 @@ to properly size.  Here are some examples to demonstrate:
 <div>
   <!-- Just an image -->
   <b-navbar variant="faded" type="light">
-    <b-narbar-brand href="#">
+    <b-navbar-brand href="#">
       <img src="https://placekitten.com/g/30/30" alt="BV">
-    </b-narbar-brand>
+    </b-navbar-brand>
   </b-navbar>
 </div>
 
@@ -124,10 +124,10 @@ to properly size.  Here are some examples to demonstrate:
 <div>
   <!-- Image and text -->
   <b-navbar variant="faded" type="light">
-    <b-narbar-brand href="#">
+    <b-navbar-brand href="#">
       <img src="https://placekitten.com/g/30/30" class="d-inline-block align-top" alt="BV">
       BootstrapVue
-    </b-narbar-brand>
+    </b-navbar-brand>
   </b-navbar>
 </div>
 
@@ -253,4 +253,3 @@ the breakpoint you would like content to automatically collapse. Possible values
 
 See the first example on this page for reference, and also refer to [`<b-collapse>`](./collapse) for
 details on the collapse component.
-

--- a/docs/components/table/meta.json
+++ b/docs/components/table/meta.json
@@ -17,6 +17,20 @@
       ]
     },
     {
+      "event": "row-dblclicked",
+      "description": "Emitted when a row is double clicked.",
+      "args": [
+        {
+          "arg": "item",
+          "description": "Item data of the row being double clicked."
+        },
+        {
+          "arg": "index",
+          "description": "Index of the row being double clicked."
+        }
+      ]
+    },
+    {
       "event": "row-hovered",
       "description": "Emitted when a row is hovered.",
       "args": [

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -89,7 +89,8 @@
             },
             btnGroupClasses() {
                 return [
-                    this.size ? `button-group-${this.size}` : null,
+                    'btn-group',
+                    this.size ? `btn-group-${this.size}` : null,
                     this.stacked ? 'btn-group-vertical' : ''
                  ];
             },

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -50,6 +50,7 @@
             :key="index"
             :class="rowClass(item)"
             @click="rowClicked($event,item,index)"
+            @dblclick="rowDblClicked($event,item,index)"
             @hover="rowHovered($event,item,index)"
         >
             <template v-for="(field,key) in fields">
@@ -465,6 +466,15 @@
                     return;
                 }
                 this.$emit('row-clicked', item, index);
+            },
+            rowDblClicked(e, item, index) {
+                if (this.busy) {
+                    // If table is busy (via provider) then don't propagate
+                    e.preventDefault();
+                    e.stopPropagation();
+                    return;
+                }
+                this.$emit('row-dblclicked', item, index);
             },
             rowHovered(e, item, index) {
                 if (this.busy) {


### PR DESCRIPTION
"navbar" was misspelled "narbar" in a number of places in the Navbar documentation. This fixes those typos.