### PR TITLE
fix: jquery dependency version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "bootstrap": "^4.0.0-beta",
-    "jquery": "jquery@>=3.0.0",
+    "jquery": "^3.0.0",
     "popper.js": "^1.11.0",
     "tether": "latest",
     "vue": "^2.4.2",


### PR DESCRIPTION
I am getting this output, while installing:

```
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "jquery@>=3.0.0": Tags may not have any characters that encodeURIComponent encodes.
```