### PR TITLE
fix(dropdowns): Focus dropdown item on hover

### DIFF
--- a/lib/components/dropdown-header.vue
+++ b/lib/components/dropdown-header.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="tag" tabindex="-1" class="dropdown-header">
+    <component :is="tag" class="dropdown-header">
         <slot></slot>
     </component>
 </template>

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :id="id || null" :class="['dropdown', 'btn-group', {dropup, show: visible}]">
+    <div :id="id || null" :class="dropdownClasses">
 
         <b-button :class="{'dropdown-toggle': !split}"
                   ref="button"
@@ -28,10 +28,11 @@
             <span class="sr-only">{{toggleText}}</span>
         </b-button>
 
-        <div :class="['dropdown-menu',{'dropdown-menu-right': right}]"
+        <div :class="menuClasses"
              ref="menu"
              role="menu"
              :aria-labelledby="id ? (id + (split ? '__BV_toggle_' : '__BV_button_')) : null"
+             @mouseover="onMouseOver"
              @keyup.esc="onEsc"
              @keydown.tab="onTab"
              @keydown.up="focusNext($event,true)"
@@ -42,15 +43,6 @@
 
     </div>
 </template>
-
-<style scoped>
-    .dropdown-item:focus,
-    .dropdown-item:hover,
-    .dropdown-header:focus {
-        background-color: #eaeaea;
-        outline: none;
-    }
-</style>
 
 <script>
     import { dropdownMixin } from '../mixins';
@@ -76,6 +68,36 @@
                 type: String,
                 default: null
             }
+        },
+        computed: {
+            dropdownClasses() {
+                return [
+                    'b-dropdown',
+                    'dropdown',
+                    'btn-group',
+                    this.dropup ? 'dropup' : '',
+                    this.visible ? 'show' : ''
+                ];
+            },
+            menuClasses() {
+                return [
+                    'dropdown-menu',
+                    this.right ? 'dropdown-menu-right' : '',
+                    this.visible ? 'show' : ''
+                ];
+            }
         }
     };
 </script>
+
+<style>
+.b-dropdown.dropdown-item:focus:not(.active),
+.b-dropdown.dropdown-item:hover:not(.active) {
+    /* @See https://github.com/twbs/bootstrap/issues/23329 */
+    box-shadow: inset 0px 0px 400px 110px rgba(0, 0, 0, .09);
+}
+
+.b-dropdown.dropdown-item:active {
+    box-shadow: initial;
+}
+</style>

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <li :id="id || null" :class="['nav-item','dropdown', {dropup, show: visible}]">
+    <li :id="id || null" :class="dropdownClasses">
 
         <a :class="['nav-link', dropdownToggle, {disabled}]"
            href="#"
@@ -15,10 +15,11 @@
             <slot name="button-content"><slot name="text"><span v-html="text"></span></slot></slot>
         </a>
 
-        <div :class="['dropdown-menu',{'dropdown-menu-right': right}]"
+        <div :class="menuClasses"
              role="menu"
              ref="menu"
              :aria-labelledby="id ? (id + '__BV_button_') : null"
+             @mouseover="onMouseOver"
              @keyup.esc="onEsc"
              @keydown.tab="onTab"
              @keydown.up="focusNext($event,true)"
@@ -30,15 +31,6 @@
     </li>
 </template>
 
-<style scoped>
-    .dropdown-item:focus,
-    .dropdown-item:hover,
-    .dropdown-header:focus {
-        background-color: #eaeaea;
-        outline: none;
-    }
-</style>
-
 <script>
     import { dropdownMixin } from '../mixins';
 
@@ -47,6 +39,22 @@
         computed: {
             dropdownToggle() {
                 return this.noCaret ? '' : 'dropdown-toggle';
+            },
+            dropdownClasses() {
+                return [
+                    'nav-item',
+                    'b-nav-dropdown',
+                    'dropdown',
+                    this.dropup ? 'dropup' : '',
+                    this.visible ? 'show' : ''
+                ];
+            },
+            menuClasses() {
+                return [
+                    'dropdown-menu',
+                    this.right ? 'dropdown-menu-right': '',
+                    this.visible ? 'show' : ''
+                ];
             }
         },
         props: {
@@ -57,3 +65,14 @@
         }
     };
 </script>
+
+<style>
+.b-nav-dropdown.dropdown-item:focus:not(.active),
+.b-nav-dropdown.dropdown-item:hover:not(.active) {
+    /* @See https://github.com/twbs/bootstrap/issues/23329 */
+    box-shadow: inset 0px 0px 400px 110px rgba(0, 0, 0, .09);
+}
+.b-nav-dropdown.dropdown-item:active {
+    box-shadow: initial;
+}
+</style>

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -14,8 +14,6 @@ function filterVisible(els) {
 
 // Dropdown item CSS selectors
 const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled])';
-const HEADER_SELECTOR = '.dropdown-header';
-const ALL_SELECTOR = [ITEM_SELECTOR, HEADER_SELECTOR].join(',');
 
 export default {
     mixins: [listenOnRootMixin],
@@ -65,7 +63,6 @@ export default {
             if (state === old) {
                 return; // Avoid duplicated emits
             }
-
             if (state) {
                 this.emitOnRoot('shown::dropdown', this);
                 this.$emit('shown');
@@ -75,12 +72,16 @@ export default {
                  only needed because of broken event delegation on iOS
                  https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
                  */
-                if (typeof document !== 'undefined' && 'ontouchstart' in document.documentElement) {
+                if ('ontouchstart' in document.documentElement) {
                     const children = arrayFrom(document.body.children);
                     children.forEach(el => {
                         el.addEventListener('mouseover', this.noop);
                     });
                 }
+
+                // Focus on the first item on show
+                this.$nextTick(() => { this.focusFirstItem() });
+
             } else {
                 this.emitOnRoot('hidden::dropdown', this);
                 this.$emit('hidden');
@@ -88,13 +89,21 @@ export default {
                  If this is a touch-enabled device we remove the extra
                  empty mouseover listeners we added for iOS support
                  */
-                if (typeof document !== 'undefined' && 'ontouchstart' in document.documentElement) {
+                if ('ontouchstart' in document.documentElement) {
                     const children = arrayFrom(document.body.children);
                     children.forEach(el => {
                         el.removeEventListener('mouseover', this.noop);
                     });
                 }
             }
+        }
+    },
+    computed: {
+        toggler() {
+            if (this.split && this.$refs.toggle) {
+                return this.$refs.toggle.$el || this.$refs.toggle;
+            } 
+            return this.$refs.button.$el || this.$refs.button;
         }
     },
     methods: {
@@ -123,15 +132,6 @@ export default {
                 return;
             }
             this.visible = !this.visible;
-            if (this.visible) {
-                this.$nextTick(function () {
-                    // Focus first visible non-disabled item
-                    const item = this.getFirstItem();
-                    if (item) {
-                        this.focusItem(0, [item]);
-                    }
-                });
-            }
         },
         onTab() {
             if (this.visible) {
@@ -143,18 +143,18 @@ export default {
                 this.visible = false;
                 e.preventDefault();
                 e.stopPropagation();
-                this.$nextTick(function () {
-                    // Return focus to original trigger button
-                    let el;
-                    if (this.split && this.$refs.toggle) {
-                        el = this.$refs.toggle.$el || this.$refs.toggle;
-                    } else {
-                        el = this.$refs.button.$el || this.$refs.button;
-                    }
-                    if (el && el.focus) {
-                        el.focus();
-                    }
-                });
+                // Return focus to original trigger button
+                this.$nextTick(() => { this.focusToggler() });
+            }
+        },
+        onMouseOver(evt) {
+            // Focus the item on hover
+            const item = evt.target;
+            if (item.classList.contains('dropdown-item')
+                    && !item.disabled
+                    && !item.classList.contains('disabled')
+                    && item.focus) {
+                item.focus();
             }
         },
         focusNext(e, up) {
@@ -181,24 +181,31 @@ export default {
             });
         },
         focusItem(idx, items) {
-            items.forEach((el, i) => {
-                if (i === idx) {
-                    el.focus();
-                }
-            });
+            let el = items.find((el, i) => i === idx)
+            if (el && el.getAttribute('tabindex') !== "-1") {
+                el.focus()
+            }
         },
         getItems() {
-            // Get all items and headers
-            return filterVisible(arrayFrom(this.$refs.menu.querySelectorAll(ALL_SELECTOR)));
+            // Get all items
+            return filterVisible(arrayFrom(this.$refs.menu.querySelectorAll(ITEM_SELECTOR)));
         },
         getFirstItem() {
-            // Get the first non-header non-disabled item
-            let item = filterVisible(arrayFrom(this.$refs.menu.querySelectorAll(ITEM_SELECTOR)))[0];
-            if (!item) {
-                // If no items then try a header
-                item = filterVisible(arrayFrom(this.$refs.menu.querySelectorAll(HEADER_SELECTOR)))[0];
-            }
+            // Get the first non-disabled item
+            let item = this.getItems()[0];
             return item || null;
+        },
+        focusFirstItem() {
+            const item = this.getFirstItem();
+            if (item) {
+                this.focusItem(0, [item]);
+            }
+        },
+        focusToggler() {
+            let toggler = this.toggler
+            if (toggler && toggler.focus) {
+                toggler.focus();
+            }
         }
     }
 };


### PR DESCRIPTION
Prevent two items from visually having the focus/hover states.

Also removed focusing of dropdown-header elements, as per discussion in https://github.com/twbs/bootstrap/issues/23336 (users should add an `aria-describedby` attribute on dropdown-items that point to their header element, if the dropdown-item needs context from the header)

Also name-spaced custom CSS (adding class `.b-dropdown` and `b-navdropdown` on the root elements)