### PR TITLE
feat(form-text): New functional component

### DIFF
--- a/docs/components/form/meta.json
+++ b/docs/components/form/meta.json
@@ -1,7 +1,7 @@
 {
   "title": "Form",
   "component": "bForm",
-  "components": ["bFormRow"],
+  "components": ["bFormRow", "bFormText"],
   "events": [
     {
       "event": "submit",

--- a/lib/components/form-text.js
+++ b/lib/components/form-text.js
@@ -1,0 +1,40 @@
+import { mergeData } from "../utils";
+
+export const props = {
+    id: {
+        type: String,
+        default: null
+    },
+    tag: {
+        type: String,
+        default: "small"
+    },
+    textVariant: {
+        type: String,
+        default: "muted"
+    },
+    inline: {
+        type: Boolean,
+        default: false
+    }
+};
+
+export default {
+    functional: true,
+    props,
+    render(h, { props, data, children }) {
+        return h(
+            props.tag,
+            mergeData(data, {
+                class: {
+                  'form-text': !Boolean(props.inline),
+                  [`text-${props.textVariant}`]: Boolean(props.textVariant)
+                },
+                attrs: {
+                  id: props.id
+                }
+            }),
+            children
+        );
+    }
+};

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -24,6 +24,7 @@ import bDropdownDivider from "./dropdown-divider.vue";
 import bDropdownHeader from "./dropdown-header.vue";
 import bForm from "./form.vue";
 import bFormRow from "./form-row";
+import bFormText from "./form-text";
 import bFormFieldset from "./form-fieldset.vue";
 import bFormCheckbox from "./form-checkbox.vue";
 import bFormRadio from "./form-radio.vue";
@@ -82,6 +83,7 @@ export {
     bDropdownHeader,
     bForm,
     bFormRow,
+    bFormText,
     bFormCheckbox,
     bFormFieldset,
     bFormFieldset as bFormGroup,

--- a/tests/components/form-text.spec.js
+++ b/tests/components/form-text.spec.js
@@ -9,6 +9,11 @@ describe("form-text", async () => {
         expect($refs.default).toBeElement("small");
     });
 
+    it("default should have id", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.default.getAttribute("id")).toBe("default");
+    });
+
     it("default should have base class", async () => {
         const { app: { $refs } } = window;
         expect($refs.default).toHaveClass("form-text");

--- a/tests/components/form-text.spec.js
+++ b/tests/components/form-text.spec.js
@@ -1,0 +1,72 @@
+import { loadFixture, testVM } from "../helpers";
+
+describe("button-group", async () => {
+    beforeEach(loadFixture("form-text"));
+    testVM();
+
+    it("default should be tag small", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.default).toBeElement("small");
+    });
+
+    it("default should have base class", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.default).toHaveClass("form-text");
+    });
+
+    it("default should have muted variant", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.default).toHaveClass("text-muted");
+    });
+
+    it("default should have content", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.default.textContent).toContain("default");
+    });
+
+    it("custom should be tag p", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.custom).toBeElement("p");
+    });
+
+    it("custom should have base class", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.custom).toHaveClass("form-text");
+    });
+
+    it("custom should have content", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.custom.textContent).toContain("custom");
+    });
+
+    it("variant should have base class", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.variant).toHaveClass("form-text");
+    });
+
+    it("variant should have danger variant", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.variant).toHaveClass("text-danger");
+    });
+
+    it("variant should have danger variant", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.variant.textContent).toContain("variant");
+    });
+
+    it("inline should not have base class", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.inline).not.toHaveClass("form-text");
+    });
+
+    it("inline should have variant muted", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.inline).toHaveClass("text-muted");
+    });
+
+    it("inline should have content", async () => {
+        const { app: { $refs } } = window;
+        expect($refs.inline.textContent).toContain("inline");
+    });
+
+});

--- a/tests/components/form-text.spec.js
+++ b/tests/components/form-text.spec.js
@@ -1,6 +1,6 @@
 import { loadFixture, testVM } from "../helpers";
 
-describe("button-group", async () => {
+describe("form-text", async () => {
     beforeEach(loadFixture("form-text"));
     testVM();
 

--- a/tests/fixtures/form-text/demo.html
+++ b/tests/fixtures/form-text/demo.html
@@ -9,5 +9,5 @@
     <b-form-text text-variant="danger" ref="variant">variant</b-form-text>
     <br>
     <!-- inline -->
-    <b-form-text inline="inline">inline</b-form-text>
+    <b-form-text inline="inline" ref="inline">inline</b-form-text>
 </div>

--- a/tests/fixtures/form-text/demo.html
+++ b/tests/fixtures/form-text/demo.html
@@ -1,12 +1,12 @@
 <div id="app">
     <!-- default -->
-    <b-form-text ref="default">default</b-form-text>
+    <b-form-text ref="default" id="default">default</b-form-text>
     <br>
     <!-- custom tag -->
     <b-form-text tag="p" ref="custom">custom</b-form-text>
     <br>
     <!-- text variant -->
-    <b-form-text text-cariant="danger" ref="variant">variant</b-form-text>
+    <b-form-text text-variant="danger" ref="variant">variant</b-form-text>
     <br>
     <!-- inline -->
     <b-form-text inline="inline">inline</b-form-text>

--- a/tests/fixtures/form-text/demo.html
+++ b/tests/fixtures/form-text/demo.html
@@ -9,5 +9,5 @@
     <b-form-text text-variant="danger" ref="variant">variant</b-form-text>
     <br>
     <!-- inline -->
-    <b-form-text inline="inline" ref="inline">inline</b-form-text>
+    <b-form-text inline ref="inline">inline</b-form-text>
 </div>

--- a/tests/fixtures/form-text/demo.html
+++ b/tests/fixtures/form-text/demo.html
@@ -1,0 +1,13 @@
+<div id="app">
+    <!-- default -->
+    <b-form-text ref="default">default</b-form-text>
+    <br>
+    <!-- custom tag -->
+    <b-form-text tag="p" ref="custom">custom</b-form-text>
+    <br>
+    <!-- text variant -->
+    <b-form-text text-cariant="danger" ref="variant">variant</b-form-text>
+    <br>
+    <!-- inline -->
+    <b-form-text inline="inline">inline</b-form-text>
+</div>

--- a/tests/fixtures/form-text/demo.js
+++ b/tests/fixtures/form-text/demo.js
@@ -1,0 +1,3 @@
+window.app = new Vue({
+    el: '#app'
+});


### PR DESCRIPTION
New `b-form-text` (AKA form-help) functional component

Defaults to tag `<small`> and `text-muted` variant

Can be placed in inline mode (`inline` prop) which removed the `.form-text` class