### PR TITLE
fix(package.json): Set bootstrap dependency to 4.0.0.alpha.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "bootstrap": "^4.0.0-alpha.6",
+    "bootstrap": "4.0.0-alpha.6",
     "tether": "latest",
     "vue": "^2.4.2"
   },


### PR DESCRIPTION
Change dependency from `^4.0.0.alpha.6` to `4.0.0.alpha.6`

As there are no further alpha releases