### PR TITLE
feat(forms): Auto ID generation client side if no id prop provided

### DIFF
--- a/lib/components/form-checkbox.vue
+++ b/lib/components/form-checkbox.vue
@@ -3,7 +3,7 @@
            :aria-pressed="button ? (isChecked ? 'true' : 'false') : null"
     >
         <input type="checkbox"
-               :id="id || null"
+               :id="safeId"
                :class="checkClasses"
                :name="name"
                :value="value"
@@ -27,11 +27,11 @@
 </template>
 
 <script>
-import { formMixin, formCustomMixin, formCheckBoxMixin } from '../mixins';
+import { idMixin, formMixin, formCustomMixin, formCheckBoxMixin } from '../mixins';
 import { arrayIncludes, isArray } from '../utils/array';
 
 export default {
-    mixins: [formMixin, formCustomMixin, formCheckBoxMixin],
+    mixins: [idMixin, formMixin, formCustomMixin, formCheckBoxMixin],
     model: {
         prop: 'checked',
         event: 'change'

--- a/lib/components/form-checkbox.vue
+++ b/lib/components/form-checkbox.vue
@@ -3,7 +3,7 @@
            :aria-pressed="button ? (isChecked ? 'true' : 'false') : null"
     >
         <input type="checkbox"
-               :id="safeId"
+               :id="safeId()"
                :class="checkClasses"
                :name="name"
                :value="value"

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Normally this should be a <label> but IE borks out on it. Awaiting fix from MSFT -->
     <div :class="[custom?'custom-file':null, state?`is-${state}`:null]"
-         :id="safeId ? `${safeId}__BV_file_outer_` : null"
+         :id="safeIdPlus('_BV_file_outer_')"
          @dragover.stop.prevent="dragover"
     >
 
@@ -26,13 +26,13 @@
                :accept="accept || null"
                :multiple="multiple"
                :webkitdirectory="directory"
-               :aria-describedby="(custom && safeId) ? `${safeId}__BV_file_control_` : null"
+               :aria-describedby="custom ? safeIdPlus('_BV_file_control_') : null"
                @change="onFileChange"
         >
 
         <!-- Overlay Labels -->
         <span :class="['custom-file-control',dragging?'dragging':null]"
-              :id="safeId ? `${safeid}__BV_file_control_` : null"
+              :id="safeIdPlus('_BV_file_control_')"
               :data-choose="computedChooseLabel"
               :data-selected="selectedLabel"
               v-if="custom"

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Normally this should be a <label> but IE borks out on it. Awaiting fix from MSFT -->
     <div :class="[custom?'custom-file':null, state?`is-${state}`:null]"
-         :id="id ? (id + '__BV_file_outer_') : null"
+         :id="safeId ? `${safeId}__BV_file_outer_` : null"
          @dragover.stop.prevent="dragover"
     >
 
@@ -19,20 +19,20 @@
                ref="input"
                :class="[custom?'custom-file-input':'form-control-file', state?`is-${state}`:null]"
                :name="name"
-               :id="id || null"
+               :id="safeId"
                :disabled="disabled"
                :required="required"
                :aria-required="required ? 'true' : null"
                :accept="accept || null"
                :multiple="multiple"
                :webkitdirectory="directory"
-               :aria-describedby="(custom && id) ? (id + '__BV_file_control_') : null"
+               :aria-describedby="(custom && safeId) ? `${safeId}__BV_file_control_` : null"
                @change="onFileChange"
         >
 
         <!-- Overlay Labels -->
         <span :class="['custom-file-control',dragging?'dragging':null]"
-              :id="id ? (id + '__BV_file_control_') : null"
+              :id="safeId ? `${safeid}__BV_file_control_` : null"
               :data-choose="computedChooseLabel"
               :data-selected="selectedLabel"
               v-if="custom"
@@ -86,11 +86,11 @@
 </style>
 
 <script>
-    import { formCustomMixin, formMixin } from '../mixins';
+    import { idMixin, formCustomMixin, formMixin } from '../mixins';
     import { from as arrayFrom } from '../utils/array';
 
     export default {
-        mixins: [formMixin, formCustomMixin],
+        mixins: [idMixin, formMixin, formCustomMixin],
         data() {
             return {
                 selectedFile: null,

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Normally this should be a <label> but IE borks out on it. Awaiting fix from MSFT -->
     <div :class="[custom?'custom-file':null, state?`is-${state}`:null]"
-         :id="safeIdPlus('_BV_file_outer_')"
+         :id="safeId('_BV_file_outer_')"
          @dragover.stop.prevent="dragover"
     >
 
@@ -19,20 +19,20 @@
                ref="input"
                :class="[custom?'custom-file-input':'form-control-file', state?`is-${state}`:null]"
                :name="name"
-               :id="safeId"
+               :id="safeId()"
                :disabled="disabled"
                :required="required"
                :aria-required="required ? 'true' : null"
                :accept="accept || null"
                :multiple="multiple"
                :webkitdirectory="directory"
-               :aria-describedby="custom ? safeIdPlus('_BV_file_control_') : null"
+               :aria-describedby="custom ? safeId('_BV_file_control_') : null"
                @change="onFileChange"
         >
 
         <!-- Overlay Labels -->
         <span :class="['custom-file-control',dragging?'dragging':null]"
-              :id="safeIdPlus('_BV_file_control_')"
+              :id="safeId('_BV_file_control_')"
               :data-choose="computedChooseLabel"
               :data-selected="selectedLabel"
               v-if="custom"

--- a/lib/components/form-group.vue
+++ b/lib/components/form-group.vue
@@ -159,17 +159,17 @@
                 ]
             },
             labelId() {
-                return (this.safeId && this.label) ? `${this.safeId}__BV_label_` : null;
+                return this.label ? this.safeIdPlus('_BV_label_') : null;
             },
             descriptionId() {
-                if (this.safeId && (this.description || this.$slots['description'])) {
-                    return `${this.safeId}__BV_description_`;
+                if (this.description || this.$slots['description']) {
+                    return this.safeIdPlus('_BV_description_');
                 }
                 return null;
             },
             feedbackId() {
-                if (this.safeId && (this.feedback || this.$slots['feedback'])) {
-                    return `${this.safeId}__BV_feedback_`;
+                if (this.feedback || this.$slots['feedback']) {
+                    return this.safeIdPlus('_BV_feedback_');
                 }
                 return null;
             },

--- a/lib/components/form-group.vue
+++ b/lib/components/form-group.vue
@@ -1,6 +1,6 @@
 <template>
     <b-form-row :class="groupClasses"
-                :id="id || null"
+                :id="safeId"
                 role="group"
                 :aria-describedby="describedByIds"
     >
@@ -45,6 +45,7 @@
     import bFormRow from './form-row';
     import bFormText from './form-text';
     import bFormFeedback from './form-feedback';
+    import ( idMixin } from '../mixins';
 
     // Selector to find first input with an ID. This Order is important!
     const INPUT_SELECTOR = [
@@ -59,6 +60,7 @@
     ].join(',');
 
     export default {
+        mixins: [idMixin],
         components: {
             bFormRow,
             bFormText,
@@ -157,17 +159,17 @@
                 ]
             },
             labelId() {
-                return (this.id && this.label) ? `${this.id}__BV_label_` : null;
+                return (this.safeId && this.label) ? `${this.safeId}__BV_label_` : null;
             },
             descriptionId() {
-                if (this.id && (this.description || this.$slots['description'])) {
-                    return `${this.id}__BV_description_`;
+                if (this.safeId && (this.description || this.$slots['description'])) {
+                    return `${this.safeId}__BV_description_`;
                 }
                 return null;
             },
             feedbackId() {
-                if (this.id && (this.feedback || this.$slots['feedback'])) {
-                    return `${this.id}__BV_feedback_`;
+                if (this.safeId && (this.feedback || this.$slots['feedback'])) {
+                    return `${this.safeId}__BV_feedback_`;
                 }
                 return null;
             },
@@ -199,10 +201,10 @@
             }
         },
         mounted() {
-            this.updateTargetId();
+            this.$nextTick(() => this.updateTargetId());
         },
         updated() {
-            this.updateTargetId();
+            this.$nextTick(() => this.updateTargetId());
         }
     };
 </script>

--- a/lib/components/form-group.vue
+++ b/lib/components/form-group.vue
@@ -45,7 +45,7 @@
     import bFormRow from './form-row';
     import bFormText from './form-text';
     import bFormFeedback from './form-feedback';
-    import ( idMixin } from '../mixins';
+    import { idMixin } from '../mixins';
 
     // Selector to find first input with an ID. This Order is important!
     const INPUT_SELECTOR = [

--- a/lib/components/form-group.vue
+++ b/lib/components/form-group.vue
@@ -1,6 +1,6 @@
 <template>
     <b-form-row :class="groupClasses"
-                :id="safeId"
+                :id="safeId()"
                 role="group"
                 :aria-describedby="describedByIds"
     >
@@ -159,17 +159,17 @@
                 ]
             },
             labelId() {
-                return this.label ? this.safeIdPlus('_BV_label_') : null;
+                return this.label ? this.safeId('_BV_label_') : null;
             },
             descriptionId() {
                 if (this.description || this.$slots['description']) {
-                    return this.safeIdPlus('_BV_description_');
+                    return this.safeId('_BV_description_');
                 }
                 return null;
             },
             feedbackId() {
                 if (this.feedback || this.$slots['feedback']) {
-                    return this.safeIdPlus('_BV_feedback_');
+                    return this.safeId('_BV_feedback_');
                 }
                 return null;
             },

--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -1,5 +1,5 @@
 <template>
-    <input :id="id || null"
+    <input :id="safeId"
            :class="inputClass"
            :name="name"
            v-model="localValue"
@@ -16,9 +16,9 @@
 </template>
 
 <script>
-    import { formMixin } from '../mixins';
+    import { idMixin, formMixin } from '../mixins';
     export default {
-        mixins: [formMixin],
+        mixins: [idMixin, formMixin],
         data() {
             return {
                 localValue: this.value

--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -1,5 +1,5 @@
 <template>
-    <input :id="safeId"
+    <input :id="safeId()"
            :class="inputClass"
            :name="name"
            v-model="localValue"

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :id="id || null"
+    <div :id="safeId"
          :class="buttons ? btnGroupClasses : radioGroupClasses"
          role="radiogroup"
          tabindex="-1"
@@ -12,7 +12,7 @@
                :key="'radio_'+idx"
                :aria-pressed="buttons ? (option.value === localValue ? 'true' : 'false') : null"
         >
-            <input :id="id ? (id + '__BV_radio_' + idx) : null"
+            <input :id="safeId ? `${safeId}__BV_radio_${idx}` : null"
                    :class="radioClasses"
                    ref="inputs"
                    type="radio"
@@ -33,10 +33,10 @@
 </template>
 
 <script>
-    import { formOptionsMixin, formMixin, formCustomMixin, formCheckBoxMixin } from '../mixins';
+    import { idMixin, formOptionsMixin, formMixin, formCustomMixin, formCheckBoxMixin } from '../mixins';
 
     export default {
-        mixins: [formMixin, formCustomMixin, formCheckBoxMixin, formOptionsMixin],
+        mixins: [idMixin, formMixin, formCustomMixin, formCheckBoxMixin, formOptionsMixin],
         data() {
             return {
                 localValue: this.value,

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :id="safeId"
+    <div :id="safeId()"
          :class="buttons ? btnGroupClasses : radioGroupClasses"
          role="radiogroup"
          tabindex="-1"
@@ -12,7 +12,7 @@
                :key="'radio_'+idx"
                :aria-pressed="buttons ? (option.value === localValue ? 'true' : 'false') : null"
         >
-            <input :id="safeIdPlus(`_BV_radio_${idx}`)"
+            <input :id="safeId(`_BV_radio_${idx}`)"
                    :class="radioClasses"
                    ref="inputs"
                    type="radio"

--- a/lib/components/form-radio.vue
+++ b/lib/components/form-radio.vue
@@ -12,7 +12,7 @@
                :key="'radio_'+idx"
                :aria-pressed="buttons ? (option.value === localValue ? 'true' : 'false') : null"
         >
-            <input :id="safeId ? `${safeId}__BV_radio_${idx}` : null"
+            <input :id="safeIdPlus(`_BV_radio_${idx}`)"
                    :class="radioClasses"
                    ref="inputs"
                    type="radio"

--- a/lib/components/form-select.vue
+++ b/lib/components/form-select.vue
@@ -1,7 +1,7 @@
 <template>
     <select :class="inputClass"
             :name="name"
-            :id="safeId"
+            :id="safeId()"
             v-model="localValue"
             :multiple="multiple || null"
             :size="(multiple || selectSize > 1) ? selectSize : null"

--- a/lib/components/form-select.vue
+++ b/lib/components/form-select.vue
@@ -1,7 +1,7 @@
 <template>
     <select :class="inputClass"
             :name="name"
-            :id="id || null"
+            :id="safeId"
             v-model="localValue"
             :multiple="multiple || null"
             :size="(multiple || selectSize > 1) ? selectSize : null"
@@ -22,11 +22,11 @@
 </template>
 
 <script>
-    import { formMixin, formOptionsMixin, formCustomMixin } from '../mixins';
+    import { idMixin, formMixin, formOptionsMixin, formCustomMixin } from '../mixins';
     import { warn } from '../utils';
 
     export default {
-        mixins: [formMixin, formCustomMixin, formOptionsMixin],
+        mixins: [idMixin, formMixin, formCustomMixin, formOptionsMixin],
         data() {
             return {
                 localValue: this.multiple ? (this.value || []) : this.value

--- a/lib/components/form-textarea.vue
+++ b/lib/components/form-textarea.vue
@@ -1,7 +1,7 @@
 <template>
     <textarea v-model="localValue"
               :class="inputClass"
-              :id="id || null"
+              :id="safeId"
               :name="name"
               :disabled="disabled"
               :placeholder="placeholder"
@@ -16,9 +16,9 @@
 </template>
 
 <script>
-    import { formMixin } from '../mixins';
+    import { idMixin, formMixin } from '../mixins';
     export default {
-        mixins: [formMixin],
+        mixins: [idMixin, formMixin],
         data() {
             return {
                 localValue: this.value

--- a/lib/components/form-textarea.vue
+++ b/lib/components/form-textarea.vue
@@ -1,7 +1,7 @@
 <template>
     <textarea v-model="localValue"
               :class="inputClass"
-              :id="safeId"
+              :id="safeId()"
               :name="name"
               :disabled="disabled"
               :placeholder="placeholder"

--- a/lib/mixins/id.js
+++ b/lib/mixins/id.js
@@ -24,5 +24,10 @@ export default {
         safeId() {
             return this.id || this.localId_ || null;
         }
+    },
+    methods: {
+        safeIdPlus(str) {
+             return this.safeId ? `${this.safeId}_${str)` : null;
+        }
     }
 };

--- a/lib/mixins/id.js
+++ b/lib/mixins/id.js
@@ -27,7 +27,7 @@ export default {
     },
     methods: {
         safeIdPlus(str) {
-            str = String(str || '').replace(/\s+/g,'_');
+            str = String(str || '').replace(/\s+/g, '_');
             return (this.safeId && Boolean(str)) ? `${this.safeId}_${str)` : null;
         }
     }

--- a/lib/mixins/id.js
+++ b/lib/mixins/id.js
@@ -21,12 +21,12 @@ export default {
         }
     },
     methods: {
-        safeId(suffix) {
+        safeId(suffix = '') {
             const id = this.id || this.localId_ || null;
             if (!id) {
                 return null;
             }
-            suffix = String(suffix || '').replace(/\s+/g, '_');
+            suffix = String(suffix).replace(/\s+/g, '_');
             return Boolean(suffix) ? `${id}_${suffix}` : id;
         }
     }

--- a/lib/mixins/id.js
+++ b/lib/mixins/id.js
@@ -27,7 +27,8 @@ export default {
     },
     methods: {
         safeIdPlus(str) {
-             return this.safeId ? `${this.safeId}_${str)` : null;
+            str = String(str || '').replace(/\s+/g,'_');
+            return (this.safeId && Boolean(str)) ? `${this.safeId}_${str)` : null;
         }
     }
 };

--- a/lib/mixins/id.js
+++ b/lib/mixins/id.js
@@ -28,7 +28,7 @@ export default {
     methods: {
         safeIdPlus(str) {
             str = String(str || '').replace(/\s+/g, '_');
-            return (this.safeId && Boolean(str)) ? `${this.safeId}_${str)` : null;
+            return (this.safeId && Boolean(str)) ? `${this.safeId}_${str}` : null;
         }
     }
 };

--- a/lib/mixins/id.js
+++ b/lib/mixins/id.js
@@ -17,18 +17,17 @@ export default {
     },
     mounted() {
         if (!this.$isServer && !this.id && this._uid) {
-            this.localId_ = `__BV__${this._uid}_`;
-        }
-    },
-    computed: {
-        safeId() {
-            return this.id || this.localId_ || null;
+            this.localId_ = `__BVID__${this._uid}_`;
         }
     },
     methods: {
-        safeIdPlus(str) {
-            str = String(str || '').replace(/\s+/g, '_');
-            return (this.safeId && Boolean(str)) ? `${this.safeId}_${str}` : null;
+        safeId(suffix) {
+            const id = this.id || this.localId_ || null;
+            if (!id) {
+                return null;
+            }
+            suffix = String(suffix || '').replace(/\s+/g, '_');
+            return Boolean(suffix) ? `${id}_${suffix}` : id;
         }
     }
 };


### PR DESCRIPTION
This is a client side only ID generator, which supplies an ID attribute on form control when no ID prop is provided.

ID generation only runs on client side, during the mounted() hook (after SSR rehydration, if applicable).

The presence if IDs, even if not in the initial SSR rendered HTML will greatly improve accessibility.

Other components that can take advantage of IDs (i.e. dropdowns, carousel, etc) can use the new `id.js` mixin