### PR TITLE
feat(progress): Support for multiple progress bars

### DIFF
--- a/docs/components/progress/README.md
+++ b/docs/components/progress/README.md
@@ -8,7 +8,7 @@ bars, featuring support for horzontally stacked bars, animated backgrounds, and 
 <div>
     <b-progress :value="counter" :max="max" show-progress animated></b-progress>
     <b-btn class="mt-4" @click="clicked">Click me</b-btn>
-</div>    
+</div>
 </template>
 
 <script>
@@ -31,7 +31,7 @@ export default {
 ```
 ## Value
 Set the maximum value with the `max` prop (default is `100`), and the current value via the
-`value` prop (default `0`). 
+`value` prop (default `0`).
 
 When creating multiple bars in a sinple process, place hte value prop on the individual
 `<b-progress-bar>` sub components (see the **Multiple Bars** section below for more details)
@@ -54,7 +54,7 @@ digits after the decimal) via the `precision` prop (default is `0`digits after t
     <b-progress :value="value" :max="max" :precision="2" show-value class="mb-3"></b-progress>
     <h5>Progress label with precision</h5>
     <b-progress :value="value" :max="max" :precision="2" show-progress class="mb-3"></b-progress>
-  </div>    
+  </div>
 </template>
 
 <script>
@@ -82,7 +82,7 @@ a `<b-progress-bar>` sub-component:
           Progress: {{ value.toFixed(3) }}
       </b-progress-bar>
     </b-progress>
-  </div>    
+  </div>
 </template>
 
 <script>
@@ -111,7 +111,7 @@ one of the standard Bootstrap width classes.
     <b-progress :value="value" class="w-75 mb-2"></b-progress>
     <b-progress :value="value" class="w-50 mb-2"></b-progress>
     <b-progress :value="value" class="w-25"></b-progress>
-  </div>    
+  </div>
 </template>
 
 <script>
@@ -138,7 +138,7 @@ height is `1rem`.
     <b-progress height="2rem" :value="value" show-progress class="mb-2"></b-progress>
     <b-progress height="20px" :value="value" show-progress class="mb-2"></b-progress>
     <b-progress height="2px" :value="value"></b-progress>
-  </div>    
+  </div>
 </template>
 
 <script>
@@ -212,7 +212,7 @@ background variant.
     <b-progress :value="50" variant="info" striped class="mb-2"></b-progress>
     <b-progress :value="75" variant="warning" striped class="mb-2"></b-progress>
     <b-progress :value="100" variant="danger" striped class="mb-2"></b-progress>
-  </div>    
+  </div>
 </template>
 
 <!-- progress-striped.vue -->
@@ -232,7 +232,7 @@ The striped gradient can also be animated by setting the `animated`prop.
       {{ animate ? 'Stop' : 'Start'}} Animation
     </b-button>
   </div>
-</template> 
+</template>
 
 <script>
 export default {
@@ -253,26 +253,26 @@ a horizontally stacked set of progress bars.
 <template>
   <div>
     <b-progress:max="max" class="mb-3">
-      <b-progress-bar :variant="primary" :value="values[0]"></b-progress-bar>
-      <b-progress-bar :variant="success" :value="values[1]"></b-progress-bar>
-      <b-progress-bar :variant="info" :value="values[2]"></b-progress-bar>
+      <b-progress-bar variant="primary" :value="values[0]"></b-progress-bar>
+      <b-progress-bar variant="success" :value="values[1]"></b-progress-bar>
+      <b-progress-bar variant="info" :value="values[2]"></b-progress-bar>
     </b-progress>
     <b-progress show-progress :max="max" class="mb-3"></b-progress-bar>
-      <b-progress-bar :variant="primary" :value="values[0]"></b-progress-bar>
-      <b-progress-bar :variant="success" :value="values[1]"></b-progress-bar>
-      <b-progress-bar :variant="info" :value="values[2]"></b-progress-bar>
+      <b-progress-bar variant="primary" :value="values[0]"></b-progress-bar>
+      <b-progress-bar variant="success" :value="values[1]"></b-progress-bar>
+      <b-progress-bar variant="info" :value="values[2]"></b-progress-bar>
     </b-progress>
     <b-progress show-value striped :max="max" class="mb-3"></b-progress-bar>
-      <b-progress-bar :variant="primary" :value="values[0]"></b-progress-bar>
-      <b-progress-bar :variant="success" :value="values[1]"></b-progress-bar>
-      <b-progress-bar :variant="info" :value="values[2]"></b-progress-bar>
+      <b-progress-bar variant="primary" :value="values[0]"></b-progress-bar>
+      <b-progress-bar variant="success" :value="values[1]"></b-progress-bar>
+      <b-progress-bar variant="info" :value="values[2]"></b-progress-bar>
     </b-progress>
     <b-progress :max="max" class="mb-3">
-      <b-progress-bar :variant="primary" :value="values[0]" show-progress></b-progress-bar>
-      <b-progress-bar :variant="success" :value="values[1]" animated show-progress></b-progress-bar>
-      <b-progress-bar :variant="info" :value="values[2]" striped show-progress></b-progress-bar>
+      <b-progress-bar variant="primary" :value="values[0]" show-progress></b-progress-bar>
+      <b-progress-bar variant="success" :value="values[1]" animated show-progress></b-progress-bar>
+      <b-progress-bar variant="info" :value="values[2]" striped show-progress></b-progress-bar>
     </b-progress>
-  </div>    
+  </div>
 </template>
 
 <script>

--- a/docs/components/progress/README.md
+++ b/docs/components/progress/README.md
@@ -164,7 +164,10 @@ The default variant is `primary`.
     <div v-for="bar in bars" class="row mb-1">
       <div class="col-sm-2">{{ bar.variant }}:</div>
       <div class="col-sm-10 pt-1">
-        <b-progress :value="bar.value" :variant="bar.variant"></b-progress>
+        <b-progress :value="bar.value"
+                    :variant="bar.variant"
+                    :key="bar.variant"
+        ></b-progress>
       </div>
     </div>
   </div>

--- a/docs/components/progress/README.md
+++ b/docs/components/progress/README.md
@@ -1,7 +1,7 @@
 # Progress
 
-> Use our custom progress component for displaying simple or complex progress bars.
-We don’t use the HTML5 `<progress>` element, ensuring you can animate them, and place text labels over them.
+> Use our custom progress component for displaying simple or complex progress
+bars, featuring support for horzontally stacked bars, animated backgrounds, and text labels.
 
 ```html
 <template>
@@ -33,15 +33,13 @@ export default {
 Set the maximum value with the `max` prop (default is `100`), and the current value via the
 `value` prop (default `0`). 
 
-## Labels
-Add labels to your progress bars by either enabling `show-progress` (as a percentage) or
-`show-value`for the current absolute value. For `show-progress`, you may also set the
-percentage precision (number of digits after the decimal) via the `precision` prop (default
-is `0`digits after the decimal).
+When creating multiple bars in a sinple process, place hte value prop on the individual
+`<b-progress-bar>` sub components (see the **Multiple Bars** section below for more details)
 
-### Custom label
-Need more control over the label? Provide your own label by using the default slot with
-a `<b-progress-bar>` sub-component:
+## Labels
+Add labels to your progress bars by either enabling `show-progress` (percentage of max) or
+`show-value`for the current absolute value. You may also set the precision (number of
+digits after the decimal) via the `precision` prop (default is `0`digits after the decimal).
 
 ```html
 <template>
@@ -52,8 +50,32 @@ a `<b-progress-bar>` sub-component:
     <b-progress :value="value" :max="max" show-value class="mb-3"></b-progress>
     <h5>Progress label</h5>
     <b-progress :value="value" :max="max" show-progress class="mb-3"></b-progress>
+    <h5>Value label with precision</h5>
+    <b-progress :value="value" :max="max" :precision="2" show-value class="mb-3"></b-progress>
     <h5>Progress label with precision</h5>
-    <b-progress :value="value" :max="max" :precision="2" show-progress class="mb-3></b-progress>
+    <b-progress :value="value" :max="max" :precision="2" show-progress class="mb-3"></b-progress>
+  </div>    
+</template>
+
+<script>
+export default {
+  data: {
+    max: 50,
+    value: 33.333333333
+  }
+}
+</script>
+
+<!-- progress-labels.vue -->
+```
+
+### Custom label
+Need more control over the label? Provide your own label by using the default slot within
+a `<b-progress-bar>` sub-component:
+
+```html
+<template>
+  <div>
     <h5>Custom Label</h5>
     <b-progress :max="max">
       <b-progress-bar :value="value">
@@ -72,12 +94,12 @@ export default {
 }
 </script>
 
-<!-- progress-labels.vue -->
+<!-- progress-custom-labels.vue -->
 ```
 
 ## Width and Height
 `<b-progress>` will always expand to the maximum with of it's parent container. To
-change the width, place the progress bar in a standard Bootstrap column or apply
+change the width, place `<b-progress>` in a standard Bootstrap column or apply
 one of the standard Bootstrap width classes.
 
 ```html
@@ -104,7 +126,7 @@ export default {
 ```
 
 The height of the progress bar can be controled with the `height` prop. The height
-value should be a standard CSS dimension (`px`, `rem`, `em`, etc). the default
+value should be a standard CSS dimension (`px`, `rem`, `em`, etc). The default
 height is `1rem`.
 
 ```html
@@ -137,15 +159,39 @@ The default variant is `primary`.
 ```html
 <template>
   <div>
-    <b-progress :value="25" variant="success" class="mb-2"></b-progress>
-    <b-progress :value="50" variant="info" class="mb-2"></b-progress>
-    <b-progress :value="75" variant="warning" class="mb-2"></b-progress>
-    <b-progress :value="100" variant="danger" class="mb-2"></b-progress>
-    <b-progress :value="66.6" variant="primary" class="mb-2"></b-progress>
-    <b-progress :value="45" variant="secondary" class="mb-2"></b-progress>
-    <b-progress :value="33.3" variant="dark" class="mb-2"></b-progress>
-  </div>    
+    <div v-for="bar in bars" class="row mb-1">
+      <div class="col-sm-2">{{ bar.variant }}:</div>
+      <div class="col-sm-10 pt-1">
+        <b-progress :value="bar.value" :variant="bar.variant"></b-progress>
+      </div>
+    </div>
+  </div>
 </template>
+
+<script>
+export default {
+  data: {
+    bars: [
+      {variant:'success', value:75},
+      {variant:'info', value:75},
+      {variant:'warning', value:75},
+      {variant:'danger', value:75},
+      {variant:'primary', value:75},
+      {variant:'secondary', value:75},
+      {variant:'dark', value:75}
+    ],
+    timer: null
+  },
+  mounted() {
+    this.timer = setInterval(() => {
+      this.bars.forEach(bar => bar.value = 25 + (Math.random() * 75));
+    }, 2000);
+  },
+  destroyed() {
+    clearInterval(this.timer);
+  }
+}
+</script>
 
 <!-- progress-backgrounds.vue -->
 ```
@@ -201,24 +247,24 @@ Include multiple `<b-progress-bar>` sub-components in a `<b-progress>` component
 <template>
   <div>
     <b-progress:max="max" class="mb-3">
-      <b-progress-bar :variant="primary" :value="values[0]">
-      <b-progress-bar :variant="success" :value="values[1]">
-      <b-progress-bar :variant="info" :value="values[2]">
+      <b-progress-bar :variant="primary" :value="values[0]"></b-progress-bar>
+      <b-progress-bar :variant="success" :value="values[1]"></b-progress-bar>
+      <b-progress-bar :variant="info" :value="values[2]"></b-progress-bar>
     </b-progress>
-    <b-progress show-progress :max="max" class="mb-3">
-      <b-progress-bar :variant="primary" :value="values[0]">
-      <b-progress-bar :variant="success" :value="values[1]">
-      <b-progress-bar :variant="info" :value="values[2]">
+    <b-progress show-progress :max="max" class="mb-3"></b-progress-bar>
+      <b-progress-bar :variant="primary" :value="values[0]"></b-progress-bar>
+      <b-progress-bar :variant="success" :value="values[1]"></b-progress-bar>
+      <b-progress-bar :variant="info" :value="values[2]"></b-progress-bar>
     </b-progress>
-    <b-progress show-value :max="max" class="mb-3">
-      <b-progress-bar :variant="primary" :value="values[0]">
-      <b-progress-bar :variant="success" :value="values[1]">
-      <b-progress-bar :variant="info" :value="values[2]">
+    <b-progress show-value striped :max="max" class="mb-3"></b-progress-bar>
+      <b-progress-bar :variant="primary" :value="values[0]"></b-progress-bar>
+      <b-progress-bar :variant="success" :value="values[1]"></b-progress-bar>
+      <b-progress-bar :variant="info" :value="values[2]"></b-progress-bar>
     </b-progress>
     <b-progress:max="max" class="mb-3">
-      <b-progress-bar :variant="primary" :value="values[0]">
-      <b-progress-bar :variant="success" animated :value="values[1]">
-      <b-progress-bar :variant="info" striped :value="values[2]">
+      <b-progress-bar :variant="primary" :value="values[0]" show-progress></b-progress-bar>
+      <b-progress-bar :variant="success" :value="values[1]" animated show-progress></b-progress-bar>
+      <b-progress-bar :variant="info" :value="values[2]" striped show-progress></b-progress-bar>
     </b-progress>
   </div>    
 </template>
@@ -235,3 +281,9 @@ export default {
 <!-- progress-multiple.vue -->
 ```
 
+`<b-prgress-bar>` will inherit most of the props from the `<b-progress>` parent component,
+but you can override any of hte props by setting htem on hte `<b-progress-bar>`
+
+Notes:
+- `max` and `height` are always set on the `<b-progress>` component.
+- `<b-progress-bar>` will not inherit `value` from `<b-progress>`.

--- a/docs/components/progress/README.md
+++ b/docs/components/progress/README.md
@@ -6,7 +6,7 @@ We don’t use the HTML5 `<progress>` element, ensuring you can animate them, an
 ```html
 <template>
 <div>
-    <b-progress :value="counter" show-progress animated></b-progress>
+    <b-progress :value="counter" :max="max" show-progress animated></b-progress>
     <b-btn class="mt-4" @click="clicked">Click me</b-btn>
 </div>    
 </template>
@@ -15,10 +15,11 @@ We don’t use the HTML5 `<progress>` element, ensuring you can animate them, an
 export default {
   data: {
     counter: 45,
+    max: 100
   },
   methods: {
     clicked() {
-      this.counter = Math.random() * 100;
+      this.counter = Math.random() * this.max;
       console.log("Change progress to " +
         Math.round(this.counter * 100) / 100);
     }
@@ -38,7 +39,9 @@ Add labels to your progress bars by either enabling `show-progress` (as a percen
 percentage precision (number of digits after the decimal) via the `precision` prop (default
 is `0`digits after the decimal).
 
-Need more control over the label? Provide your own label by using the default slot.
+### Custom label
+Need more control over the label? Provide your own label by using the default slot with
+a `<b-progress-bar>` sub-component:
 
 ```html
 <template>
@@ -52,8 +55,10 @@ Need more control over the label? Provide your own label by using the default sl
     <h5>Progress label with precision</h5>
     <b-progress :value="value" :max="max" :precision="2" show-progress class="mb-3></b-progress>
     <h5>Custom Label</h5>
-    <b-progress :value="value" :max="max">
-      Progress: {{ value.toFixed(3) }}
+    <b-progress :max="max">
+      <b-progress-bar :value="value">
+          Progress: {{ value.toFixed(3) }}
+      </b-progress-bar>
     </b-progress>
   </div>    
 </template>
@@ -100,7 +105,7 @@ export default {
 
 The height of the progress bar can be controled with the `height` prop. The height
 value should be a standard CSS dimension (`px`, `rem`, `em`, etc). the default
-is `1rem`.
+height is `1rem`.
 
 ```html
 <template>
@@ -188,3 +193,45 @@ export default {
 
 <!-- progress-animated.vue -->
 ```
+
+## Multiple bars
+Include multiple `<b-progress-bar>` sub-components in a `<b-progress>` component if you like.
+
+```html
+<template>
+  <div>
+    <b-progress:max="max" class="mb-3">
+      <b-progress-bar :variant="primary" :value="values[0]">
+      <b-progress-bar :variant="success" :value="values[1]">
+      <b-progress-bar :variant="info" :value="values[2]">
+    </b-progress>
+    <b-progress show-progress :max="max" class="mb-3">
+      <b-progress-bar :variant="primary" :value="values[0]">
+      <b-progress-bar :variant="success" :value="values[1]">
+      <b-progress-bar :variant="info" :value="values[2]">
+    </b-progress>
+    <b-progress show-value :max="max" class="mb-3">
+      <b-progress-bar :variant="primary" :value="values[0]">
+      <b-progress-bar :variant="success" :value="values[1]">
+      <b-progress-bar :variant="info" :value="values[2]">
+    </b-progress>
+    <b-progress:max="max" class="mb-3">
+      <b-progress-bar :variant="primary" :value="values[0]">
+      <b-progress-bar :variant="success" animated :value="values[1]">
+      <b-progress-bar :variant="info" striped :value="values[2]">
+    </b-progress>
+  </div>    
+</template>
+
+<script>
+export default {
+  data: {
+    max: 100,
+    values: [ 15, 30, 20 ]
+  }
+}
+</script>
+
+<!-- progress-multiple.vue -->
+```
+

--- a/docs/components/progress/README.md
+++ b/docs/components/progress/README.md
@@ -156,6 +156,8 @@ export default {
 Use background variants to change the appearance of individual progress bars.
 The default variant is `primary`.
 
+### Solid backgrounds
+
 ```html
 <template>
   <div>
@@ -241,7 +243,8 @@ export default {
 ```
 
 ## Multiple bars
-Include multiple `<b-progress-bar>` sub-components in a `<b-progress>` component if you like.
+Include multiple `<b-progress-bar>` sub-components in a `<b-progress>` component to build
+a horizontally stacked set of progress bars.
 
 ```html
 <template>
@@ -261,7 +264,7 @@ Include multiple `<b-progress-bar>` sub-components in a `<b-progress>` component
       <b-progress-bar :variant="success" :value="values[1]"></b-progress-bar>
       <b-progress-bar :variant="info" :value="values[2]"></b-progress-bar>
     </b-progress>
-    <b-progress:max="max" class="mb-3">
+    <b-progress :max="max" class="mb-3">
       <b-progress-bar :variant="primary" :value="values[0]" show-progress></b-progress-bar>
       <b-progress-bar :variant="success" :value="values[1]" animated show-progress></b-progress-bar>
       <b-progress-bar :variant="info" :value="values[2]" striped show-progress></b-progress-bar>
@@ -282,8 +285,8 @@ export default {
 ```
 
 `<b-prgress-bar>` will inherit most of the props from the `<b-progress>` parent component,
-but you can override any of hte props by setting htem on hte `<b-progress-bar>`
+but you can override any of the props by setting them on the `<b-progress-bar>`
 
 Notes:
-- `max` and `height` are always set on the `<b-progress>` component.
+- `height`, if speified, should always set on the `<b-progress>` component.
 - `<b-progress-bar>` will not inherit `value` from `<b-progress>`.

--- a/docs/components/progress/README.md
+++ b/docs/components/progress/README.md
@@ -208,12 +208,23 @@ background variant.
 ```html
 <template>
   <div>
-    <b-progress :value="25" variant="success" striped class="mb-2"></b-progress>
-    <b-progress :value="50" variant="info" striped class="mb-2"></b-progress>
-    <b-progress :value="75" variant="warning" striped class="mb-2"></b-progress>
-    <b-progress :value="100" variant="danger" striped class="mb-2"></b-progress>
+    <b-progress :value="25" variant="success" :striped="striped" class="mb-2"></b-progress>
+    <b-progress :value="50" variant="info" :striped="striped" class="mb-2"></b-progress>
+    <b-progress :value="75" variant="warning" :striped="striped" class="mb-2"></b-progress>
+    <b-progress :value="100" variant="danger" :striped="striped" class="mb-2"></b-progress>
+    <b-button variant="secondary" @click="striped = !striped">
+      {{ striped ? 'Remove' : 'Add'}} Striped
+    </b-button>
   </div>
 </template>
+
+<script>
+export default {
+  data: {
+    striped: true
+  }
+}
+</script>
 
 <!-- progress-striped.vue -->
 ```
@@ -252,7 +263,7 @@ a horizontally stacked set of progress bars.
 ```html
 <template>
   <div>
-    <b-progress:max="max" class="mb-3">
+    <b-progress :max="max" class="mb-3">
       <b-progress-bar variant="primary" :value="values[0]"></b-progress-bar>
       <b-progress-bar variant="success" :value="values[1]"></b-progress-bar>
       <b-progress-bar variant="info" :value="values[2]"></b-progress-bar>

--- a/docs/components/progress/README.md
+++ b/docs/components/progress/README.md
@@ -69,17 +69,24 @@ export default {
 <!-- progress-labels.vue -->
 ```
 
-### Custom label
+### Custom progress label
 Need more control over the label? Provide your own label by using the default slot within
-a `<b-progress-bar>` sub-component:
+a `<b-progress-bar>` sub-component, or by using the `label` prop on `<b-progress-bar>`
+(HTML supported):
 
 ```html
 <template>
   <div>
-    <h5>Custom Label</h5>
+    <h5>Custom Label via Default Slot</h5>
     <b-progress :max="max">
       <b-progress-bar :value="value">
-          Progress: {{ value.toFixed(3) }}
+        Progress: <strong>{{ value.toFixed(3) }} / {{ max }}</strong>
+      </b-progress-bar>
+    </b-progress>
+    
+    <h5 class="mt-3">Custom Label via Prop</h5>
+    <b-progress :max="max">
+      <b-progress-bar :value="value" :label="'&lt;'+value.toFixed(0)+'&gt;'">
       </b-progress-bar>
     </b-progress>
   </div>
@@ -96,6 +103,16 @@ export default {
 
 <!-- progress-custom-labels.vue -->
 ```
+
+Precedence order for label methods:
+- default slot of `<b-progress-bar>`
+- `label` prop of `<b-progress-bar>`
+- `show-progress` prop of `<b-progress-bar>`
+- `show-value` prop of `<b-progress-bar>`
+- `show-progress` prop of `<b-progress>`
+- `show-value` prop of `<b-progress>`
+- no label
+
 
 ## Width and Height
 `<b-progress>` will always expand to the maximum with of it's parent container. To
@@ -156,7 +173,7 @@ export default {
 Use background variants to change the appearance of individual progress bars.
 The default variant is `primary`.
 
-### Solid backgrounds
+### Solid background variants
 
 ```html
 <template>
@@ -238,7 +255,7 @@ The striped gradient can also be animated by setting the `animated`prop.
     <b-progress :value="25" variant="success" striped :animated="animate" class="mb-2"></b-progress>
     <b-progress :value="50" variant="info" striped :animated="animate" class="mb-2"></b-progress>
     <b-progress :value="75" variant="warning" striped :animated="animate" class="mb-2"></b-progress>
-    <b-progress :value="100" variant="danger" striped :animated="animate" class="mb-3"></b-progress>
+    <b-progress :value="100" variant="danger" :animated="animate" class="mb-3"></b-progress>
     <b-button variant="secondary" @click="animate = !animate">
       {{ animate ? 'Stop' : 'Start'}} Animation
     </b-button>
@@ -255,6 +272,11 @@ export default {
 
 <!-- progress-animated.vue -->
 ```
+
+Notes:
+ - if `animated` is true, `striped` will automatically be enabled.
+ - Animated progress bars don’t work in Opera 12 — as they don’t support CSS3 animations.
+
 
 ## Multiple bars
 Include multiple `<b-progress-bar>` sub-components in a `<b-progress>` component to build

--- a/docs/components/progress/meta.json
+++ b/docs/components/progress/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Progress",
-  "component": "bProgress"
+  "component": "bProgress",
+  "components": [ "bProgressBar" ]
 }

--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -2,7 +2,7 @@
     <input :id="safeId()"
            :class="inputClass"
            :name="name"
-           v-model="localValue"
+           :value="localValue"
            :type="localType"
            :disabled="disabled"
            :required="required"

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -53,6 +53,7 @@ import bNavForm from "./nav-form";
 import bPagination from "./pagination.vue";
 import bPaginationNav from "./pagination-nav.vue";
 import bPopover from "./popover.vue";
+import bProgressBar from "./progress-bar.vue";
 import bProgress from "./progress.vue";
 import bTable from "./table.vue";
 import bTabs from "./tabs.vue";
@@ -117,6 +118,7 @@ export {
     bPagination,
     bPaginationNav,
     bPopover,
+    bProgressBar,
     bProgress,
     bTable,
     bTooltip,

--- a/lib/components/progress-bar.vue
+++ b/lib/components/progress-bar.vue
@@ -1,0 +1,99 @@
+<template>
+    <div role="progressbar"
+         :class="progressBarClasses"
+         :style="progressBarStyles"
+         :aria-valuenow="value"
+         :aria-valuemin="0"
+         :aria-valuemax="max"
+    >
+        <slot>
+            <template v-if="showProgress">{{ progress.toFixed(this.computedPrecision) }}%</template>
+            <template v-else-if="showValue">{{ value.toFixed(this.computedPrecision) }}</template>
+        </slot>
+    </div>
+</template>
+
+<script>
+    export default {
+        computed: {
+            progressBarClasses() {
+                return [
+                    'progress-bar',
+                    this.computedVariant ? `bg-${this.computedVariant}` : '',
+                    (this.computedStriped || this.computedAnimated) ? 'progress-bar-striped' : '',
+                    this.computedAnimated ? 'progress-bar-animated' : ''
+                ];
+            },
+            progressBarStyles() {
+                return {
+                    width: this.progress + '%',
+                    // We enherit height and line height from parent wrapper
+                    height: 'inherit',
+                    lineHeight: 'inherit'
+                };
+            },
+            progress() {
+                const p = Math.pow(10, this.computedPrecison);
+                return Math.round((100 * p * this.value) / this.max) / p;
+            },
+            max() {
+                // We get the maximum value from the parent b-progress
+                return this.$parent.max || 100;
+            },
+            computedVariant() {
+                // Prefer our variant over parent setting
+                return this.variant ? this.variant : this.$parent.variant;
+            },
+            computedPrecison() {
+                // Prefer our precision over parent setting
+                return this.precision === null ? (this.$parent.precision || 0) : this.precision;
+            },
+            computedStriped() {
+                // Prefer our striped over parent setting
+                return typeof this.striped === 'boolean' ? this.striped : this.$parent.striped;
+            },
+            computedAnimated() {
+                // Prefer our animated over parent setting
+                return typeof this.animated === 'boolean' ? this.animated : this.$parent.animated;
+            },
+            computedShowProgress() {
+                // Prefer our showProgress over parent setting
+                return typeof this.showProgress === 'boolean' ? this.showProgress : this.$parent.showProgress;
+            },
+            computedShowValue() {
+                // Prefer our showValue over parent setting
+                return typeof this.showValue === 'boolean' ? this.showVale : this.$parent.showValue;
+            }
+        },
+        props: {
+            value: {
+                type: Number,
+                default: 0
+            },
+            precision: {
+                type: Number,
+                default: null
+            },
+            variant: {
+                type: String,
+                default: null
+            },
+            striped: {
+                type: Boolean,
+                default: null
+            },
+            animated: {
+                type: Boolean,
+                default: null
+            },
+            showProgress: {
+                type: Boolean,
+                default: null
+            },
+            showValue: {
+                type: Boolean,
+                default: null
+            }
+        }
+    };
+</script>

--- a/lib/components/progress-bar.vue
+++ b/lib/components/progress-bar.vue
@@ -4,7 +4,7 @@
          :style="progressBarStyles"
          :aria-valuenow="value"
          :aria-valuemin="0"
-         :aria-valuemax="max"
+         :aria-valuemax="computedMax"
     >
         <slot>
             <template v-if="showProgress">{{ progress.toFixed(this.computedPrecision) }}%</template>
@@ -27,22 +27,25 @@
             progressBarStyles() {
                 return {
                     width: this.progress + '%',
-                    // We enherit height and line height from parent wrapper
-                    height: this.$parent.height || '1rem',
-                    lineHeight: this.$parent.height || '1rem'
+                    height: this.computedHeight,
+                    lineHeight: this.computedHeight
                 };
             },
             progress() {
                 const p = Math.pow(10, this.computedPrecison);
-                return Math.round((100 * p * this.value) / this.max) / p;
+                return Math.round((100 * p * this.value) / this.computedMax) / p;
             },
-            max() {
-                // We get the maximum value from the parent b-progress
-                return this.$parent.max || 100;
+            computedMax() {
+                // Prefer our max over parent setting
+                return this.max || this.$parent.max || 100;
+            },
+            computedHeight() {
+                // Prefer parent height over our height
+                return this.$parent.height || this.height || '1rem';
             },
             computedVariant() {
                 // Prefer our variant over parent setting
-                return this.variant ? this.variant : this.$parent.variant;
+                return this.variant || this.$parent.variant;
             },
             computedPrecison() {
                 // Prefer our precision over parent setting
@@ -70,6 +73,10 @@
                 type: Number,
                 default: 0
             },
+            max: {
+                type: Number,
+                default: null
+            },
             precision: {
                 type: Number,
                 default: null
@@ -92,6 +99,10 @@
             },
             showValue: {
                 type: Boolean,
+                default: null
+            },
+            height: {
+                type: String,
                 default: null
             }
         }

--- a/lib/components/progress-bar.vue
+++ b/lib/components/progress-bar.vue
@@ -7,7 +7,7 @@
          :aria-valuemax="computedMax"
     >
         <slot>
-            <span v-if"label" v-html="label"></span>
+            <span v-if="label" v-html="label"></span>
             <template v-else-if="showProgress">{{ progress.toFixed(this.computedPrecision) }}%</template>
             <template v-else-if="showValue">{{ value.toFixed(this.computedPrecision) }}</template>
         </slot>

--- a/lib/components/progress-bar.vue
+++ b/lib/components/progress-bar.vue
@@ -32,7 +32,7 @@
                 };
             },
             progress() {
-                const p = Math.pow(10, this.computedPrecison);
+                const p = Math.pow(10, this.computedPrecision);
                 return Math.round((100 * p * this.value) / this.computedMax) / p;
             },
             computedMax() {
@@ -47,7 +47,7 @@
                 // Prefer our variant over parent setting
                 return this.variant || this.$parent.variant;
             },
-            computedPrecison() {
+            computedPrecision() {
                 // Prefer our precision over parent setting
                 return this.precision === null ? (this.$parent.precision || 0) : this.precision;
             },
@@ -65,7 +65,7 @@
             },
             computedShowValue() {
                 // Prefer our showValue over parent setting
-                return typeof this.showValue === 'boolean' ? this.showVale : this.$parent.showValue;
+                return typeof this.showValue === 'boolean' ? this.showValue : this.$parent.showValue;
             }
         },
         props: {

--- a/lib/components/progress-bar.vue
+++ b/lib/components/progress-bar.vue
@@ -7,7 +7,8 @@
          :aria-valuemax="computedMax"
     >
         <slot>
-            <template v-if="showProgress">{{ progress.toFixed(this.computedPrecision) }}%</template>
+            <span v-if"label" v-html="label"></span>
+            <template v-else-if="showProgress">{{ progress.toFixed(this.computedPrecision) }}%</template>
             <template v-else-if="showValue">{{ value.toFixed(this.computedPrecision) }}</template>
         </slot>
     </div>
@@ -92,6 +93,10 @@
             animated: {
                 type: Boolean,
                 default: null
+            },
+            label: {
+                type: String,
+                value: null
             },
             showProgress: {
                 type: Boolean,

--- a/lib/components/progress-bar.vue
+++ b/lib/components/progress-bar.vue
@@ -28,8 +28,8 @@
                 return {
                     width: this.progress + '%',
                     // We enherit height and line height from parent wrapper
-                    height: 'inherit',
-                    lineHeight: 'inherit'
+                    height: this.$parent.height || '1rem',
+                    lineHeight: this.$parent.height || '1rem'
                 };
             },
             progress() {

--- a/lib/components/progress.vue
+++ b/lib/components/progress.vue
@@ -1,52 +1,29 @@
 <template>
-    <div class="progress">
-        <transition>
-            <div role="progressbar"
-                 :class="progressClasses"
-                 :style="progressStyles"
-                 :aria-valuenow="value"
-                 :aria-valuemin="0"
-                 :aria-valuemax="max"
-            >
-                <slot>
-                    <template v-if="showProgress">{{progress}}%</template>
-                    <template v-else-if="showValue">{{value}}</template>
-                </slot>
-            </div>
-        </transition>
+    <div class="progress" :style="progressStyles">
+        <slot>
+            <b-progress-bar :value="value"></b-progress-bar>
+        </slot>
     </div>
 </template>
 
-<style>
-    .progress-bar {
-        transition: all .5s;
-    }
-</style>
-
 <script>
+    import bProgressBar from './progress-bar.vue';
+
     export default {
+        components: { bProgressBar },
         computed: {
-            progressClasses() {
-                return [
-                    'progress-bar',
-                    this.variant ? `bg-${this.variant}` : '',
-                    (this.striped || this.animated) ? 'progress-bar-striped' : '',
-                    this.animated ? 'progress-bar-animated' : ''
-                ];
-            },
             progressStyles() {
                 return {
-                    width: this.progress + '%',
-                    height: this.height || null,
-                    lineHeight: this.height || null
+                    height: this.height || '1rem',
+                    lineHeight: this.height || '1rem'
                 };
-            },
-            progress() {
-                const p = Math.pow(10, this.precision);
-                return Math.round((100 * p * this.value) / this.max) / p;
             }
         },
         props: {
+            variant: {
+                type: String,
+                default: null
+            },
             striped: {
                 type: Boolean,
                 default: false
@@ -55,21 +32,13 @@
                 type: Boolean,
                 default: false
             },
+            height: {
+                type: String,
+                default: '1rem'
+            },
             precision: {
                 type: Number,
                 default: 0
-            },
-            value: {
-                type: Number,
-                default: 0
-            },
-            max: {
-                type: Number,
-                default: 100
-            },
-            variant: {
-                type: String,
-                default: null
             },
             showProgress: {
                 type: Boolean,
@@ -79,9 +48,13 @@
                 type: Boolean,
                 default: false
             },
-            height: {
-                type: String,
-                default: '1rem'
+            max: {
+                type: Number,
+                default: 100
+            },
+            value: {
+                type: Number,
+                default: 0
             }
         }
     };

--- a/lib/components/progress.vue
+++ b/lib/components/progress.vue
@@ -1,7 +1,16 @@
 <template>
-    <div class="progress" :style="progressStyles">
+    <div class="progress">
         <slot>
-            <b-progress-bar :value="value"></b-progress-bar>
+            <b-progress-bar :value="value"
+                            :max="max"
+                            :precision="precision"
+                            :variant="variant"
+                            :animated="animated"
+                            :striped="striped"
+                            :show-progress="showProgress"
+                            :show-value="showValue"
+                            :height="height"
+            ></b-progress-bar>
         </slot>
     </div>
 </template>
@@ -11,15 +20,8 @@
 
     export default {
         components: { bProgressBar },
-        computed: {
-            progressStyles() {
-                return {
-                    height: this.height || '1rem',
-                    lineHeight: this.height || '1rem'
-                };
-            }
-        },
         props: {
+            // These props can be inherited via the child b-progress-bar(s)
             variant: {
                 type: String,
                 default: null
@@ -52,6 +54,7 @@
                 type: Number,
                 default: 100
             },
+            // This prop is not inherited by child b-progress-bar(s)
             value: {
                 type: Number,
                 default: 0

--- a/tests/fixtures/progress/demo.html
+++ b/tests/fixtures/progress/demo.html
@@ -10,9 +10,9 @@
         <b-progress-bar :value="progress" show-progress></b-progress-bar>
     </b-progress>
 
-    <b-progress :max="150" class="mb-4">
-        <b-progress-bar :value="progress" variant="primary" show-progress></b-progress-bar>
-        <b-progress-bar :value="10" variant="success" show-progress></b-progress-bar>
+    <b-progress :max="150" height="2rem" class="mb-4">
+        <b-progress-bar :value="progress" variant="primary" animated striped show-value></b-progress-bar>
+        <b-progress-bar :value="10" variant="success" show-value></b-progress-bar>
     </b-progress>
 
     <b-btn class="mt-4" @click="clicked">Click me</b-btn>

--- a/tests/fixtures/progress/demo.html
+++ b/tests/fixtures/progress/demo.html
@@ -1,6 +1,19 @@
 <div id="app">
 
-    <b-progress :value="progress" show-progress animated></b-progress>
+    <b-progress :value="progress" show-progress animated class="mb-4"></b-progress>
+
+    <b-progress class="mb-4">
+        <b-progress-bar :value="progress" show-progress animated variant="danger"></b-progress-bar>
+    </b-progress>
+
+    <b-progress variant="primary" animated striped class="mb-4">
+        <b-progress-bar :value="progress" show-progress></b-progress-bar>
+    </b-progress>
+
+    <b-progress :max="150" class="mb-4">
+        <b-progress-bar :value="progress" variant="primary" show-progress></b-progress-bar>
+        <b-progress-bar :value="10" variant="success" show-progress></b-progress-bar>
+    </b-progress>
 
     <b-btn class="mt-4" @click="clicked">Click me</b-btn>
 


### PR DESCRIPTION
Adds support for multiple progress bars by introducing a new `b-progress-bar` sub component.

sub component b-progress-bar will inherit many of the props from the parent b-progress component, but my be overridden at the sub component level.

PR includes updated docs and examples