### PR TITLE
fix(dropdown.js): import clickout as a mixin

### DIFF
--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,4 +1,4 @@
-import clickOut from './clickout';
+import clickOutMixn from './clickout';
 import listenOnRootMixin from './listen-on-root'
 import { from as arrayFrom } from '../utils/array'
 
@@ -16,7 +16,7 @@ function filterVisible(els) {
 const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled])';
 
 export default {
-    mixins: [listenOnRootMixin],
+    mixins: [clickOutMixin, listenOnRootMixin],
     props: {
         id: {
             type: String
@@ -56,8 +56,6 @@ export default {
         // Hide when clicked on links
         this.listenOnRoot('clicked::link', listener);
     },
-    mounted: clickOut.mounted,
-    destroyed: clickOut.destroyed,
     watch: {
         visible(state, old) {
             if (state === old) {
@@ -107,7 +105,6 @@ export default {
         }
     },
     methods: {
-        ...clickOut.methods,
         noop() {
             // Do nothing event handler (used in visible watch)
         },

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,4 +1,4 @@
-import clickOutMixn from './clickout';
+import clickoutMixin from './clickout';
 import listenOnRootMixin from './listen-on-root'
 import { from as arrayFrom } from '../utils/array'
 
@@ -16,7 +16,7 @@ function filterVisible(els) {
 const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled])';
 
 export default {
-    mixins: [clickOutMixin, listenOnRootMixin],
+    mixins: [clickoutMixin, listenOnRootMixin],
     props: {
         id: {
             type: String


### PR DESCRIPTION

Removes need for object spread operator (issue #884)