### PR TITLE
[WIP] feat(modal): Modal enhancements

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -246,6 +246,10 @@
                 type: Boolean,
                 default: false
             },
+            noBackdrop: {
+                type: Boolean,
+                default: false
+            },
             okOnly: {
                 type: Boolean,
                 default: false

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -11,7 +11,7 @@
                     @before-leave="onBeforeLeave"
                     @after-leave="onAfterLeave"
         >
-            <div :class="['modal',{fade: !noFade, show: isShowing]"
+            <div :class="['modal',{fade: !noFade, show: isShowing}]"
                  :id="id || null"
                  role="dialog"
                  ref="modal"

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -18,7 +18,7 @@
                  key="modal"
                  :style="modalStyle"
                  v-show="is_visible"
-                 :aria-hidden="is_visible ? 'fasle' : 'true'
+                 :aria-hidden="is_visible ? 'fasle' : 'true'"
                  @click="onClickOut()"
                  @keyup.esc="onEsc()"
             >


### PR DESCRIPTION
Tweaks to modal animation handling (for better fade support)

Add similar functionality as BS4 modal (scrollbar adjustments, body padding, etc)

TODO:
 - Use new synthetic cancel event from `utils/event.js`
 - `no-backdrop` support (and use of clickout mixin)
 - Update documentation
 - Testing

Basing on code from https://github.com/twbs/bootstrap/blob/v4-dev/js/src/modal.js with adjustments for transition component
