### PR TITLE
feat(table): Scoped slots for fixed top/bottom rows

### DIFF
--- a/docs/components/table/meta.json
+++ b/docs/components/table/meta.json
@@ -102,15 +102,15 @@
   "slots": [
     {
       "name": "<field>",
-      "description": "Scoped slot for custom data rendering of field data"
+      "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
     },
     {
       "name": "HEAD_<field>",
-      "description": "Scoped slot for custom rendering of field header"
+      "description": "Scoped slot for custom rendering of field header. See docs for scoped data"
     },
     {
       "name": "FOOT_<field>",
-      "description": "Scoped slot for custom rendering of field footer"
+      "description": "Scoped slot for custom rendering of field footer. See docs for scoped data"
     },
     {
       "name": "empty",
@@ -119,6 +119,14 @@
     {
       "name": "emptyfiltered",
       "description": "Content to display when no items are present in the filtered `items` array"
+    },
+    {
+      "name": "top-row",
+      "description": "Fixed top row slot for user supplied TD cells. Soped data: columns - number of TDs to provide, fields - fileds object"
+    },
+    {
+      "name": "bottom-row",
+      "description": "Fixed bottom row slot for user supplied TD cells. Soped data: columns - number of TDs to provide, fields - fileds object"
     }
   ]
 }

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -67,6 +67,14 @@
             variant: {
                 type: String,
                 default: null
+            },
+            offset: {
+                type: Number,
+                default: 0
+            },
+            noFlip: {
+                type: Boolean,
+                default: false
             }
         },
         computed: {

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -67,14 +67,6 @@
             variant: {
                 type: String,
                 default: null
-            },
-            offset: {
-                type: Number,
-                default: 0
-            },
-            noFlip: {
-                type: Boolean,
-                default: false
             }
         },
         computed: {

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -46,7 +46,7 @@
         </tr>
         </tfoot>
         <tbody>
-        <tr v-if"$scopedSlots['top-row']">
+        <tr v-if="$scopedSlots['top-row']">
             <slot name="top-row" :columns="keys(fields).length" :fields="fields"></slot>
         </tr>
         <tr v-for="(item,index) in _items"
@@ -79,7 +79,7 @@
                 </div>
             </td>
         </tr>
-        <tr v-if"$scopedSlots['bottom-row']">
+        <tr v-if="$scopedSlots['bottom-row']">
             <slot name="bottom-row" :columns="keys(fields).length" :fields="fields"></slot>
         </tr>
         </tbody>

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -46,6 +46,9 @@
         </tr>
         </tfoot>
         <tbody>
+        <tr v-if"$scopedSlots['top-row']">
+            <slot name="top-row" :columns="keys(fields).length" :fields="fields"></slot>
+        </tr>
         <tr v-for="(item,index) in _items"
             :key="index"
             :class="rowClass(item)"
@@ -75,6 +78,9 @@
                     </slot>
                 </div>
             </td>
+        </tr>
+        <tr v-if"$scopedSlots['bottom-row']">
+            <slot name="bottom-row" :columns="keys(fields).length" :fields="fields"></slot>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Allows user to provide `TD` cells across the top and/or bottom of the table.  The user must supply the correct number of `TD` cells (or `TD`s spanned to the correct number of columns)

Scoped slots are 'top-row' and 'bottom-row'.  Both slots (rendered inside a `TR`)receive two properties on the scoped data variable: `columns` (number of `TD` cells the user needs to render) and `fields` (a reference to the fields object)

Addresses issue #682