### PR TITLE
fix(dropdowns): Migration to popper.js positioning

### DIFF
--- a/docs/components/dropdown/README.md
+++ b/docs/components/dropdown/README.md
@@ -3,13 +3,13 @@
 > Dropdowns are toggleable, contextual overlays for displaying lists of links and actions
 in a dropdown menu format.
 
-`<b-dropdown>` (or kown by its shorter alias of `<b-dd>`) components are toggleable,
+`<b-dropdown>` (or known by its shorter alias of `<b-dd>`) components are toggleable,
 contextual overlays for displaying lists of links and more. They’re toggled by
 clicking (or pressing space or enter when focused), not by hovering; this is an
 [intentional design decision](http://markdotto.com/2012/02/27/bootstrap-explained-dropdowns/).
 
-**Note:** _Dropdowns are built on a third party library, [Popper.js](https://popper.js.org/),
-which provides dynamic positioning and viewport detection. Dropwdown requires
+>**Note:** _Dropdowns are built on a third party library, [Popper.js](https://popper.js.org/),
+which provides dynamic positioning and viewport detection. Dropdown requires
 that the `popper.js` library to be loaded into your propject, or if using CDN
 version of Bootstrap-Vue load popper **before** Bootstrap-Vue!_
 
@@ -100,7 +100,7 @@ dropdown buttons.
 
 Set the `size` prop to either `sm` for small button(s), or `lg` for large button(s).
 
-**Note:** _chaging the size of the button(s) does not affect the size of the menu items!_
+>**Note:** _chaging the size of the button(s) does not affect the size of the menu items!_
 
 
 ## Button contextual variants
@@ -121,7 +121,7 @@ component or markup may break keyboard navigation.
 | `<b-dropdown-header>` | A header item, used to help identify a group of dropdown items. | `<b-dd-header>`
 | `<b-dropdown-divider>` | A divider / spacer which can be used to separate dropdown items. | `<b-dd-divider>`
 
-**Note:* _Nested sub-menus are **not** supported._
+>**Note:* _Nested sub-menus are **not** supported._
 
 
 ## Accessibility
@@ -132,10 +132,10 @@ The default ARIA role is set to `menu`, but you can change this default to anoth
 (such as `navigation`) via the `role` prop, depending on your user case.
 
 ### Accessibility with Headers
-When using `<b-dropdown-header>` components in the dropdown menu, it is reccomended to add an
-`id` attribute to the header, and then set the `aria-describedby` attribite (set to the `id`
+When using `<b-dropdown-header>` components in the dropdown menu, it is recommended to add an
+`id` attribute to the header, and then set the `aria-describedby` attribute (set to the `id`
 value of the associated header) on each following dropdown items under that header.
-This will provide users of assitive technologies (i.e. sight-impared users) additional
+This will provide users of assistive technologies (i.e. sight-impared users) additional
 context about the dropdown item:
 
 ```html

--- a/docs/components/dropdown/README.md
+++ b/docs/components/dropdown/README.md
@@ -3,8 +3,8 @@
 > Dropdowns are toggleable, contextual overlays for displaying lists of links and actions
 in a dropdown menu format.
 
-`<b-dropdown>` (or `<b-dd>` for les tying) components are toggleable, contextual overlays for
-displaying lists of links and more, and they’re fully interactive. They’re toggled by
+`<b-dropdown>` (or kown by its shorter alias of `<b-dd>`) components are toggleable,
+contextual overlays for displaying lists of links and more. They’re toggled by
 clicking (or pressing space or enter when focused), not by hovering; this is an
 [intentional design decision](http://markdotto.com/2012/02/27/bootstrap-explained-dropdowns/).
 

--- a/docs/components/dropdown/README.md
+++ b/docs/components/dropdown/README.md
@@ -100,7 +100,7 @@ dropdown buttons.
 
 Set the `size` prop to either `sm` for small button(s), or `lg` for large button(s).
 
->**Note:** _chaging the size of the button(s) does not affect the size of the menu items!_
+>**Note:** _changing the size of the button(s) does not affect the size of the menu items!_
 
 
 ## Button contextual variants
@@ -135,7 +135,7 @@ The default ARIA role is set to `menu`, but you can change this default to anoth
 When using `<b-dropdown-header>` components in the dropdown menu, it is recommended to add an
 `id` attribute to the header, and then set the `aria-describedby` attribute (set to the `id`
 value of the associated header) on each following dropdown items under that header.
-This will provide users of assistive technologies (i.e. sight-impared users) additional
+This will provide users of assistive technologies (i.e. sight-impaired users) additional
 context about the dropdown item:
 
 ```html
@@ -162,7 +162,7 @@ Dropdowns support keyboard navigation, emulating native `<select>` behaviour.
 | Keypress | Action
 | -------- | ------
 | <kbd>DOWN</kbd> | Will highlight the next lower non-disabled item in the menu.
-| <kbd>UP</kbd> | Will highlight the next higher non-disbled item in the menu.
+| <kbd>UP</kbd> | Will highlight the next higher non-disabled item in the menu.
 | <kbd>ENTER</kbd> or <kbd>SPACE</kbd> | Will click the highlighted menu item.
 | <kbd>ESC</kbd> | Will close the dropdown and return focus to the trigger button.
 | <kbd>TAB</kbd> | Will close the dropdown and jump to the next focusable control on the page.

--- a/docs/components/dropdown/README.md
+++ b/docs/components/dropdown/README.md
@@ -3,8 +3,15 @@
 > Dropdowns are toggleable, contextual overlays for displaying lists of links and actions
 in a dropdown menu format.
 
-**Beta Warning: Dropwdown is currently under re-development to align with Boostrap
-V4.beta CSS and code changes. Positioning and placement are not yet working**
+`<b-dropdown>` (or `<b-dd>` for les tying) components are toggleable, contextual overlays for
+displaying lists of links and more, and they’re fully interactive. They’re toggled by
+clicking (or pressing space or enter when focused), not by hovering; this is an
+[intentional design decision](http://markdotto.com/2012/02/27/bootstrap-explained-dropdowns/).
+
+**Note:** _Dropdowns are built on a third party library, [Popper.js](https://popper.js.org/),
+which provides dynamic positioning and viewport detection. Dropwdown requires
+that the `popper.js` library to be loaded into your propject, or if using CDN
+version of Bootstrap-Vue load popper **before** Bootstrap-Vue!_
 
 
 **Example:** Various usage
@@ -52,6 +59,7 @@ V4.beta CSS and code changes. Positioning and placement are not yet working**
   <b-dropdown id="ddown5" text="Dropdown using buttons as menu items" class="m-md-2">
     <b-dropdown-item-button>I'm a button</b-dropdown-item-button>
     <b-dropdown-item-button>I'm also a button</b-dropdown-item-button>
+    <b-dropdown-item-button disabled>I'm a button, but disabled!</b-dropdown-item-button>
     <b-dropdown-item-button>I don't look like a button, but I am!</b-dropdown-item-button>
   </b-dropdown>
 
@@ -60,13 +68,25 @@ V4.beta CSS and code changes. Positioning and placement are not yet working**
 <!-- dropdown.vue -->
 ```
 
-## Menu alignment
+## Positioning
+
+### Menu left and right alignment
 The dropdown menu can either be left aligned (default) or right aligned with respect
 to the button above it. To have the dropdown aligned on the right, set the `right` prop.
 
-
-## Dropup
+### Dropup
 Turn your dropdown menu into a drop-up menu by setting the `dropup` prop.
+
+### Auto "flipping"
+By default, dropdowns may flip to the top, or to the bottom, based on
+their current position in the viewport. To disable this auto-flip feature, set
+the `no-flip` prop.
+
+### Menu offset
+Like to move your menu away from the toggle buttons a bit? Then use the `offset`
+prop to specify the number of pixels to push away from the toggle button
+- pased as a number, or specify the distance in CSS units (i.e. `0.3rem`,
+`4px`, `1.2em`, etc) passed as a string.
 
 
 ## Split button support
@@ -80,11 +100,12 @@ dropdown buttons.
 
 Set the `size` prop to either `sm` for small button(s), or `lg` for large button(s).
 
-Note chaging the size of the button(s) does not affect the size of the menu items.
+**Note:** _chaging the size of the button(s) does not affect the size of the menu items!_
+
 
 ## Button contextual variants
 The dropdown buttons can have one of the standard Boostrap contextual variants applied
-by setting the prop `variant` to `success`, `info`, `danger`, `link` etc.
+by setting the prop `variant` to `success`, `primary`, `info`, `danger`, `link` etc.
 
 See [`<b-button>`](./button) for a list of supported contextual variants.
 
@@ -100,32 +121,35 @@ component or markup may break keyboard navigation.
 | `<b-dropdown-header>` | A header item, used to help identify a group of dropdown items. | `<b-dd-header>`
 | `<b-dropdown-divider>` | A divider / spacer which can be used to separate dropdown items. | `<b-dd-divider>`
 
-_Note: Nested sub-menus are **not** supported._
+**Note:* _Nested sub-menus are **not** supported._
 
 
 ## Accessibility
 Providing a unique `id` prop ensures ARIA compliance by automatically adding
 the appropriate `aria-*` attributes in the rendered markup.
 
+The default ARIA role is set to `menu`, but you can change this default to another role
+(such as `navigation`) via the `role` prop, depending on your user case.
+
 ### Accessibility with Headers
 When using `<b-dropdown-header>` components in the dropdown menu, it is reccomended to add an
 `id` attribute to the header, and then set the `aria-describedby` attribite (set to the `id`
-value of the associated header) on each following dropdown items associated with the header.
-This will provide users of assitive technologies (i.e. sight-impared users) context about
-the dropdown item:
+value of the associated header) on each following dropdown items under that header.
+This will provide users of assitive technologies (i.e. sight-impared users) additional
+context about the dropdown item:
 
 ```html
 <template>
   <div>
     <b-dropdown id="ddown_hdrs" text="Dropdown Button sm" variant="primary" class="m-md-2">
-      <b-dropdown-header id="header1">Heading 1</b-dropdown-header>
-      <b-dropdown-item aria-describedby="header1">Action</b-dropdown-item>
-      <b-dropdown-item aria-describedby="header1">Another action</b-dropdown-item>
-      <b-dropdown-header id="header2">Heading 2</b-dropdown-header>
-      <b-dropdown-item aria-describedby="header2">Some Action</b-dropdown-item>
-      <b-dropdown-item aria-describedby="header2">Some other action</b-dropdown-item>
+      <b-dropdown-header id="header1">Groups</b-dropdown-header>
+      <b-dropdown-item aria-describedby="header1">Add</b-dropdown-item>
+      <b-dropdown-item aria-describedby="header1">Delete</b-dropdown-item>
+      <b-dropdown-header id="header2">Users</b-dropdown-header>
+      <b-dropdown-item aria-describedby="header2">Add</b-dropdown-item>
+      <b-dropdown-item aria-describedby="header2">Delete</b-dropdown-item>
       <b-dropdown-divider></b-dropdown-divider>
-      <b-dropdown-item>Something else here...</b-dropdown-item>
+      <b-dropdown-item>Something <strong>not</strong> associated with user</b-dropdown-item>
       <b-dropdown-item disabled>Disabled action</b-dropdown-item>
     </b-dropdown>
   </div>

--- a/docs/components/dropdown/README.md
+++ b/docs/components/dropdown/README.md
@@ -121,7 +121,7 @@ component or markup may break keyboard navigation.
 | `<b-dropdown-header>` | A header item, used to help identify a group of dropdown items. | `<b-dd-header>`
 | `<b-dropdown-divider>` | A divider / spacer which can be used to separate dropdown items. | `<b-dd-divider>`
 
->**Note:* _Nested sub-menus are **not** supported._
+>**Note:** _Nested sub-menus are **not** supported._
 
 
 ## Accessibility

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -2,10 +2,10 @@
     <div :id="safeId()" :class="dropdownClasses">
 
         <b-button :id="safeId('_BV_button_')"
-                  :class="{'dropdown-toggle': !split}"
+                  v-if="split"
                   ref="button"
-                  :aria-haspopup="split ? null : 'true'"
-                  :aria-expanded="split ? null : (visible ? 'true' : 'false')"
+                  :aria-haspopup="split ? 'true' : null"
+                  :aria-expanded="split ? (visible ? 'true' : 'false') : null"
                   :variant="variant"
                   :size="size"
                   :disabled="disabled"
@@ -13,19 +13,19 @@
         >
             <slot name="button-content"><slot name="text">{{text}}</slot></slot>
         </b-button>
-
         <b-button :id="safeId('_BV_toggle_')"
-                  :class="['dropdown-toggle','dropdown-toggle-split']"
-                  v-if="split"
+                  :class="['dropdown-toggle',{dropdownToggleSplit: split}]"
+
                   ref="toggle"
-                  :aria-haspopup="split ? 'true' : null"
-                  :aria-expanded="split ? (visible ? 'true' : 'false') : null"
+                  :aria-haspopup="split ? null : 'true'"
+                  :aria-expanded="split ? null : (visible ? 'true' : 'false')"
                   :variant="variant"
                   :size="size"
                   :disabled="disabled"
                   @click.stop.prevent="toggle"
         >
-            <span class="sr-only">{{toggleText}}</span>
+            <span v-if="split" class="sr-only">{{toggleText}}</span>
+            <slot v-else name="button-content"><slot name="text">{{text}}</slot></slot>
         </b-button>
 
         <div :class="menuClasses"

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -30,7 +30,7 @@
 
         <div :class="menuClasses"
              ref="menu"
-             role="menu"
+             :role="role"
              :aria-labelledby="safeId(split ? '_BV_toggle_' : '_BV_button_')"
              @mouseover="onMouseOver"
              @keyup.esc="onEsc"
@@ -67,14 +67,18 @@
             variant: {
                 type: String,
                 default: null
+            },
+            role: {
+                type: String,
+                default: 'menu'
             }
         },
         computed: {
             dropdownClasses() {
                 return [
+                    'btn-group',
                     'b-dropdown',
                     'dropdown',
-                    'btn-group',
                     this.dropup ? 'dropup' : '',
                     this.visible ? 'show' : ''
                 ];

--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -14,7 +14,7 @@
             <slot name="button-content"><slot name="text">{{text}}</slot></slot>
         </b-button>
         <b-button :id="safeId('_BV_toggle_')"
-                  :class="['dropdown-toggle',{dropdownToggleSplit: split}]"
+                  :class="['dropdown-toggle',{'dropdown-toggle-split': split}]"
 
                   ref="toggle"
                   :aria-haspopup="split ? null : 'true'"

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -60,7 +60,7 @@
             menuClasses() {
                 return [
                     'dropdown-menu',
-                    this.right ? 'dropdown-menu-right': 'dropdown-menu-right',
+                    this.right ? 'dropdown-menu-right': 'dropdown-menu-left',
                     this.visible ? 'show' : ''
                 ];
             }

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -60,7 +60,7 @@
             menuClasses() {
                 return [
                     'dropdown-menu',
-                    this.right ? 'dropdown-menu-right' : 'dropdown-menu-left',
+                    this.right ? 'dropdown-menu-right': 'dropdown-menu-left',
                     this.visible ? 'show' : ''
                 ];
             }

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -1,22 +1,22 @@
 <template>
     <li :id="safeId()" :class="dropdownClasses">
 
-        <a :class="['nav-link', dropdownToggle, {disabled}]"
+        <a :class="toggleClasses"
            href="#"
            ref="button"
            :id="safeId('_BV_button_')"
            aria-haspopup="true"
            :aria-expanded="visible ? 'true' : 'false'"
            :disabled="disabled"
-           @click.stop.prevent="toggle($event)"
-           @keydown.enter.stop.prevent="toggle($event)"
-           @keydown.space.stop.prevent="toggle($event)"
+           @click.stop.prevent="toggle"
+           @keydown.enter.stop.prevent="toggle"
+           @keydown.space.stop.prevent="toggle"
         >
             <slot name="button-content"><slot name="text"><span v-html="text"></span></slot></slot>
         </a>
 
         <div :class="menuClasses"
-             role="menu"
+             :role="role"
              ref="menu"
              :aria-labelledby="safeId('_BV_button_')"
              @mouseover="onMouseOver"
@@ -37,8 +37,9 @@
     export default {
         mixins: [idMixin, dropdownMixin],
         computed: {
-            dropdownToggle() {
-                return this.noCaret ? '' : 'dropdown-toggle';
+            isNav() {
+                // Signal to dropdown mixin that we are in a navbar
+                return true;
             },
             dropdownClasses() {
                 return [
@@ -47,6 +48,13 @@
                     'dropdown',
                     this.dropup ? 'dropup' : '',
                     this.visible ? 'show' : ''
+                ];
+            },
+            toggleClasses() {
+                return [
+                    'nav-link',
+                    this.noCaret ? '' : 'dropdown-toggle',
+                    this.disabled ? disabled : ''
                 ];
             },
             menuClasses() {
@@ -61,6 +69,10 @@
             noCaret: {
                 type: Boolean,
                 default: false
+            },
+            role: {
+                type: String,
+                default: 'menu'
             }
         }
     };

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -60,7 +60,7 @@
             menuClasses() {
                 return [
                     'dropdown-menu',
-                    this.right ? 'dropdown-menu-right': '',
+                    this.right ? 'dropdown-menu-right': 'dropdown-menu-right',
                     this.visible ? 'show' : ''
                 ];
             }

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -60,7 +60,7 @@
             menuClasses() {
                 return [
                     'dropdown-menu',
-                    this.right ? 'dropdown-menu-right': 'dropdown-menu-left',
+                    this.right ? 'dropdown-menu-right' : 'dropdown-menu-left',
                     this.visible ? 'show' : ''
                 ];
             }

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -107,7 +107,7 @@ export default {
             return this.$refs.button.$el || this.$refs.button;
         }
     },
-    destroy() {
+    destroyed() {
         if (this._popper) {
             this_popper.destroy();
         }
@@ -124,8 +124,8 @@ export default {
             // Ensure other menus are closed
             this.emitOnRoot('shown::dropdown', this);
 
-            // for dropup with alignment we use the parent as popper container
-            let element = this.dropup ? this.$el : this.$refs.menu;
+            // for dropup with alignment we use the parent element as popper container
+            let element = ((this.dropup && this.right) || this.split) ? this.$el : (this.$refs.button || this.$refs.toggle);
             this._popper = new Popper(element, this.$refs.menu, this.getPopperConfig());
 
             this.setTocuhStart(true);
@@ -139,7 +139,6 @@ export default {
             this.$emit('hide');
             this.emitOnRoot('hidden::dropdown', this);
             this.setTocuhStart(false);
-            this._popper = null;
             this.$emit('hidden');
         },
         getPopperConfig() {

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -132,17 +132,17 @@ export default {
                 placement = AttachmentMap.BOTTOMEND;
             }
             const popperConfig = {
-                placement : placement,
-                modifiers : {
-                    offset : {
+                placement: placement,
+                modifiers: {
+                    offset: {
                         offset: this.offset || 0
                     },
-                    flip : {
+                    flip: {
                         enabled: !this.noFlip
                     },
                     applyStyle: {
                         // Disable Popper.js for Dropdown in Navbar
-                        enabled: !this.isNavbar;
+                        enabled: !this.isNav
                     }
                 }
             }

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,4 +1,4 @@
-import popper from 'popper';
+import Popper from 'popper';
 
 import clickoutMixin from './clickout';
 import listenOnRootMixin from './listen-on-root'

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,19 +1,15 @@
 import Popper from 'popper.js';
 
 import clickoutMixin from './clickout';
-import listenOnRootMixin from './listen-on-root'
-import { from as arrayFrom } from '../utils/array'
-import { assign } from '../utils/object'
+import listenOnRootMixin from './listen-on-root';
+import { from as arrayFrom } from '../utils/array';
+import { assign } from '../utils/object';
 
 // Determine if an HTML element is visible - Faster than CSS check
-function isVisible(el) {
-    return el && (el.offsetWidth > 0 || el.offsetHeight > 0);
-}
+const isVisible = el => el && (el.offsetWidth > 0 || el.offsetHeight > 0);
 
 // Return an Array of visible items
-function filterVisible(els) {
-    return els ? els.filter(el => isVisible(el)) : [];
-}
+const filterVisible = els => (els ? els.filter(el => isVisible(el)) : []);
 
 // Element closest polyfill, if needed
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
@@ -83,7 +79,7 @@ export default {
         },
         popperOps: {
             type: Object,
-            default: {}
+            default: () => {}
         }
     },
     data() {
@@ -109,7 +105,8 @@ export default {
     watch: {
         visible(state, old) {
             if (state === old) {
-                return; // Avoid duplicated emits
+                // Avoid duplicated emits
+                return;
             }
             if (state) {
                 this.showMenu();
@@ -119,16 +116,11 @@ export default {
         }
     },
     computed: {
-        toggler() {
-            if (this.split && this.$refs.toggle) {
-                return this.$refs.toggle.$el || this.$refs.toggle;
-            } 
-            return this.$refs.button.$el || this.$refs.button;
-        }
+        toggler: () => this.$refs.toggle.$el || this.$refs.toggle
     },
     destroyed() {
         if (this._popper) {
-            this_popper.destroy();
+            this._popper.destroy();
         }
         this._popper = null;
         this.setTouchStart(false);
@@ -145,29 +137,29 @@ export default {
 
             // Are we in a navbar ?
             if (this.inNavbar === null && this.isNav) {
-                this.inNavbar = this.$el.closest('.navbar') ? true : false;
+                this.inNavbar = Boolean(this.$el.closest('.navbar'));
             }
             // for dropup with alignment we use the parent element as popper container
-            let element = ((this.dropup && this.right) || this.split || this.inNavbar)
-                ? this.$el
-                : (this.$refs.button || this.$refs.toggle);
+            let element = ((this.dropup && this.right) || this.split || this.inNavbar) ?
+                this.$el :
+                this.$refs.toggle;
             // Make sure we have a reference to an element, not component.
             element = element.$el || element;
 
             // Instantiate popper.js
             this._popper = new Popper(element, this.$refs.menu, this.getPopperConfig());
 
-            this.setTocuhStart(true);
+            this.setTouchStart(true);
             this.$emit('shown');
 
             // Focus on the first item on show
-            this.$nextTick(() => { this.focusFirstItem() });
+            this.$nextTick(() => {this.focusFirstItem();});
         },
         hideMenu() {
             // TODO: move emit hide to visible watcher, to allow cancelling of hide
             this.$emit('hide');
             this.emitOnRoot('hidden::dropdown', this);
-            this.setTocuhStart(false);
+            this.setTouchStart(false);
             this.$emit('hidden');
         },
         getPopperConfig() {
@@ -179,11 +171,11 @@ export default {
                 // dropup + left
                 placement = AttachmentMap.TOP;
             } else if (this.right) {
-                // drowndown + right 
+                // drowndown + right
                 placement = AttachmentMap.BOTTOMEND;
             }
             const popperConfig = {
-                placement: placement,
+                placement,
                 modifiers: {
                     offset: {
                         offset: this.offset || 0
@@ -196,10 +188,11 @@ export default {
                         enabled: !this.inNavbar
                     }
                 }
-            }
+            };
             return assign(popperConfig, this.popperOpts || {});
         },
         setTouchStart(on) {
+
             /*
              If this is a touch-enabled device we add extra
              empty mouseover listeners to the body's immediate children;
@@ -228,12 +221,8 @@ export default {
                 this.visible = false;
                 return;
             }
-            if (this.split) {
-                this.$emit('click', e);
-                this.emitOnRoot('shown::dropdown', this);
-            } else {
-                this.toggle();
-            }
+
+            this.$emit('click', e);
         },
         toggle() {
             if (this.disabled) {
@@ -256,10 +245,10 @@ export default {
                 e.preventDefault();
                 e.stopPropagation();
                 // Return focus to original trigger button
-                this.$nextTick(() => { this.focusToggler() });
+                this.$nextTick(() => {this.focusToggler();});
             }
         },
-        onFocusout(evt) {
+        onFocusOut(evt) {
             if (this.$refs.menu.contains(evt.relatedTarget)) {
                 return;
             }
@@ -270,10 +259,10 @@ export default {
             // TODO: Special handling for inputs?
             // Inputs are in a special .dropdown-form container
             const item = evt.target;
-            if (item.classList.contains('dropdown-item')
-                    && !item.disabled
-                    && !item.classList.contains('disabled')
-                    && item.focus) {
+            if (item.classList.contains('dropdown-item') &&
+                    !item.disabled &&
+                    !item.classList.contains('disabled') &&
+                    item.focus) {
                 item.focus();
             }
         },
@@ -301,9 +290,9 @@ export default {
             });
         },
         focusItem(idx, items) {
-            let el = items.find((el, i) => i === idx)
+            let el = items.find((el, i) => i === idx);
             if (el && el.getAttribute('tabindex') !== "-1") {
-                el.focus()
+                el.focus();
             }
         },
         getItems() {
@@ -322,7 +311,7 @@ export default {
             }
         },
         focusToggler() {
-            let toggler = this.toggler
+            let toggler = this.toggler;
             if (toggler && toggler.focus) {
                 toggler.focus();
             }

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -38,22 +38,27 @@ export default {
             default: false
         },
         text: {
+            // Button label
             type: String,
             default: ''
         },
         dropup: {
+            // place on top if possible
             type: Boolean,
             default: false
         },
         right: {
+            // Right align menu (default is left align)
             type: Boolean,
             default: false
         },
         offset: {
-            type: Number,
+            // Number of pixels to offset menu, or a CSS unit value (i.e. 1px, 1rem, etc)
+            type: [Number, String],
             default: 0
         },
         noFlip: {
+            // Disable auto-flipping of menu from bottom<=>top
             type: Boolean,
             default: false
         }
@@ -98,6 +103,9 @@ export default {
         }
     },
     destroy() {
+        if (this._popper) {
+            this_popper.destroy();
+        }
         this._popper = null;
         this.setTouchStart(false);
     },

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -3,6 +3,7 @@ import Popper from 'popper.js';
 import clickoutMixin from './clickout';
 import listenOnRootMixin from './listen-on-root'
 import { from as arrayFrom } from '../utils/array'
+import { assign } from '../utils/object'
 
 // Determine if an HTML element is visible - Faster than CSS check
 function isVisible(el) {
@@ -61,6 +62,10 @@ export default {
             // Disable auto-flipping of menu from bottom<=>top
             type: Boolean,
             default: false
+        },
+        popperOps: {
+            type: Object,
+            default: {}
         }
     },
     data() {
@@ -114,9 +119,10 @@ export default {
             if (this.disabled) {
                 return;
             }
+            // TODO: move emit show to visible watcher, to allow cancelling of show
+            this.$emit('show');
             // Ensure other menus are closed
             this.emitOnRoot('shown::dropdown', this);
-            this.$emit('show');
 
             // for dropup with alignment we use the parent as popper container
             let element = this.dropup ? this.$el : this.$refs.menu;
@@ -129,10 +135,12 @@ export default {
             this.$nextTick(() => { this.focusFirstItem() });
         },
         hideMenu() {
+            // TODO: move emit hide to visible watcher, to allow cancelling of hide
+            this.$emit('hide');
             this.emitOnRoot('hidden::dropdown', this);
-            this.$emit('hidden');
             this.setTocuhStart(false);
             this._popper = null;
+            this.$emit('hidden');
         },
         getPopperConfig() {
             let placement = AttachmentMap.BOTTOM;
@@ -161,7 +169,7 @@ export default {
                     }
                 }
             }
-            return popperConfig;
+            return assign(popperConfig, this.popperOpts || {});
         },
         setTouchStart(on) {
             /*

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,3 +1,5 @@
+import popper from 'popper';
+
 import clickoutMixin from './clickout';
 import listenOnRootMixin from './listen-on-root'
 import { from as arrayFrom } from '../utils/array'

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -33,6 +33,10 @@ const AttachmentMap = {
 export default {
     mixins: [clickoutMixin, listenOnRootMixin],
     props: {
+        disabled: {
+            type: Boolean,
+            default: false
+        },
         text: {
             type: String,
             default: ''
@@ -41,11 +45,15 @@ export default {
             type: Boolean,
             default: false
         },
-        disabled: {
+        right: {
             type: Boolean,
             default: false
         },
-        right: {
+        offset: {
+            type: Number,
+            default: 0
+        },
+        noFlip: {
             type: Boolean,
             default: false
         }
@@ -53,7 +61,6 @@ export default {
     data() {
         return {
             visible: false,
-            config: {},
             _popper: null
         };
     },

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -125,7 +125,9 @@ export default {
             this.emitOnRoot('shown::dropdown', this);
 
             // for dropup with alignment we use the parent element as popper container
-            let element = ((this.dropup && this.right) || this.split) ? this.$el : (this.$refs.button || this.$refs.toggle);
+            let element = ((this.dropup && this.right) || this.split || this.isNav)
+                ? this.$el
+                : (this.$refs.button || this.$refs.toggle);
             this._popper = new Popper(element, this.$refs.menu, this.getPopperConfig());
 
             this.setTocuhStart(true);

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -1,4 +1,4 @@
-import Popper from 'popper';
+import Popper from 'popper.js';
 
 import clickoutMixin from './clickout';
 import listenOnRootMixin from './listen-on-root'
@@ -15,14 +15,24 @@ function filterVisible(els) {
 }
 
 // Dropdown item CSS selectors
+// TODO: .dropdown-form handling
 const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled])';
+
+// Popper attachment positions
+const AttachmentMap = {
+    // DropUp Left Align
+    TOP: 'top-start',
+    // DropUp Right Align
+    TOPEND: 'top-end',
+    // Dropdown left Align
+    BOTTOM: 'bottom-start',
+    // Dropdown Right Align
+    BOTTOMEND: 'bottom-end'
+};
 
 export default {
     mixins: [clickoutMixin, listenOnRootMixin],
     props: {
-        id: {
-            type: String
-        },
         text: {
             type: String,
             default: ''
@@ -42,7 +52,9 @@ export default {
     },
     data() {
         return {
-            visible: false
+            visible: false,
+            config: {},
+            _popper: null
         };
     },
     created() {
@@ -64,37 +76,9 @@ export default {
                 return; // Avoid duplicated emits
             }
             if (state) {
-                this.emitOnRoot('shown::dropdown', this);
-                this.$emit('shown');
-                /*
-                 If this is a touch-enabled device we add extra
-                 empty mouseover listeners to the body's immediate children;
-                 only needed because of broken event delegation on iOS
-                 https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
-                 */
-                if ('ontouchstart' in document.documentElement) {
-                    const children = arrayFrom(document.body.children);
-                    children.forEach(el => {
-                        el.addEventListener('mouseover', this.noop);
-                    });
-                }
-
-                // Focus on the first item on show
-                this.$nextTick(() => { this.focusFirstItem() });
-
+                this.showMenu();
             } else {
-                this.emitOnRoot('hidden::dropdown', this);
-                this.$emit('hidden');
-                /*
-                 If this is a touch-enabled device we remove the extra
-                 empty mouseover listeners we added for iOS support
-                 */
-                if ('ontouchstart' in document.documentElement) {
-                    const children = arrayFrom(document.body.children);
-                    children.forEach(el => {
-                        el.removeEventListener('mouseover', this.noop);
-                    });
-                }
+                this.hideMenu();
             }
         }
     },
@@ -106,7 +90,82 @@ export default {
             return this.$refs.button.$el || this.$refs.button;
         }
     },
+    destroy() {
+        this._popper = null;
+        this.setTouchStart(false);
+    },
     methods: {
+        showMenu() {
+            if (this.disabled) {
+                return;
+            }
+            // Ensure other menus are closed
+            this.emitOnRoot('shown::dropdown', this);
+            this.$emit('show');
+
+            // for dropup with alignment we use the parent as popper container
+            let element = this.dropup ? this.$el : this.$refs.menu;
+            this._popper = new Popper(element, this.$refs.menu, this.getPopperConfig());
+
+            this.setTocuhStart(true);
+            this.$emit('shown');
+
+            // Focus on the first item on show
+            this.$nextTick(() => { this.focusFirstItem() });
+        },
+        hideMenu() {
+            this.emitOnRoot('hidden::dropdown', this);
+            this.$emit('hidden');
+            this.setTocuhStart(false);
+            this._popper = null;
+        },
+        getPopperConfig() {
+            let placement = AttachmentMap.BOTTOM;
+            if (this.dropup && this.right) {
+                // dropup + right
+                placement = AttachmentMap.TOPEND;
+            } else if (this.dropup) {
+                // dropup + left
+                placement = AttachmentMap.TOP;
+            } else if (this.right) {
+                // drowndown + right 
+                placement = AttachmentMap.BOTTOMEND;
+            }
+            const popperConfig = {
+                placement : placement,
+                modifiers : {
+                    offset : {
+                        offset: this.offset || 0
+                    },
+                    flip : {
+                        enabled: !this.noFlip
+                    },
+                    applyStyle: {
+                        // Disable Popper.js for Dropdown in Navbar
+                        enabled: !this.isNavbar;
+                    }
+                }
+            }
+            return popperConfig;
+        },
+        setTouchStart(on) {
+            /*
+             If this is a touch-enabled device we add extra
+             empty mouseover listeners to the body's immediate children;
+             only needed because of broken event delegation on iOS
+             https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
+             */
+            if ('ontouchstart' in document.documentElement) {
+                const children = arrayFrom(document.body.children);
+                children.forEach(el => {
+                    if (on) {
+                        el.addEventListener('mouseover', this.noop);
+                    } else {
+                        el.removeEventListener('mouseover', this.noop);
+                    }
+                });
+            }
+        },
         noop() {
             // Do nothing event handler (used in visible watch)
         },
@@ -134,6 +193,9 @@ export default {
         },
         onTab() {
             if (this.visible) {
+                // TODO: Need special handler for dealing with form inputs
+                // Tab, if in a text-like input, we should just focus next item in the dropdown
+                // Note: Inputs are in a special .dropdown-form container
                 this.visible = false;
             }
         },
@@ -146,8 +208,16 @@ export default {
                 this.$nextTick(() => { this.focusToggler() });
             }
         },
+        onFocusout(evt) {
+            if (this.$refs.menu.contains(evt.relatedTarget)) {
+                return;
+            }
+            this.visible = false;
+        },
         onMouseOver(evt) {
             // Focus the item on hover
+            // TODO: Special handling for inputs?
+            // Inputs are in a special .dropdown-form container
             const item = evt.target;
             if (item.classList.contains('dropdown-item')
                     && !item.disabled

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -120,6 +120,7 @@ export default {
     },
     destroyed() {
         if (this._popper) {
+            // Ensure popper event listeners are removed cleanly
             this._popper.destroy();
         }
         this._popper = null;
@@ -159,6 +160,11 @@ export default {
             // TODO: move emit hide to visible watcher, to allow cancelling of hide
             this.$emit('hide');
             this.emitOnRoot('hidden::dropdown', this);
+            if (this._popper) {
+                // Ensure popper event listeners are removed cleanly
+                this._popper.destroy();
+            }
+            this._popper = null;
             this.setTouchStart(false);
             this.$emit('hidden');
         },
@@ -192,7 +198,6 @@ export default {
             return assign(popperConfig, this.popperOpts || {});
         },
         setTouchStart(on) {
-
             /*
              If this is a touch-enabled device we add extra
              empty mouseover listeners to the body's immediate children;
@@ -211,7 +216,7 @@ export default {
             }
         },
         noop() {
-            // Do nothing event handler (used in visible watch)
+            // Do nothing event handler (used in touchstart event handler)
         },
         clickOutListener() {
             this.visible = false;

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -128,6 +128,10 @@ export default {
             let element = ((this.dropup && this.right) || this.split || this.isNav)
                 ? this.$el
                 : (this.$refs.button || this.$refs.toggle);
+            // Make sure we have a reference to an element, not component.
+            element = element.$el || element;
+
+            // Instantiate popper.js
             this._popper = new Popper(element, this.$refs.menu, this.getPopperConfig());
 
             this.setTocuhStart(true);

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -15,6 +15,24 @@ function filterVisible(els) {
     return els ? els.filter(el => isVisible(el)) : [];
 }
 
+// Element closest polyfill, if needed
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+// Returns null of not found
+if (typeof document !== 'undefined' && window.Element && !Element.prototype.closest) {
+    Element.prototype.closest = function (s) {
+        const matches = (this.document || this.ownerDocument).querySelectorAll(s);
+        let el = this;
+        let i;
+        do {
+            i = matches.length;
+            // eslint-disable-next-line no-empty
+            while (--i >= 0 && matches.item(i) !== el) {
+            }
+        } while ((i < 0) && (el = el.parentElement));
+        return el;
+    };
+}
+
 // Dropdown item CSS selectors
 // TODO: .dropdown-form handling
 const ITEM_SELECTOR = '.dropdown-item:not(.disabled):not([disabled])';
@@ -71,7 +89,8 @@ export default {
     data() {
         return {
             visible: false,
-            _popper: null
+            _popper: null,
+            inNavbar: null
         };
     },
     created() {
@@ -124,8 +143,12 @@ export default {
             // Ensure other menus are closed
             this.emitOnRoot('shown::dropdown', this);
 
+            // Are we in a navbar ?
+            if (this.inNavbar === null && this.isNav) {
+                this.inNavbar = this.$el.closest('.navbar') ? true : false;
+            }
             // for dropup with alignment we use the parent element as popper container
-            let element = ((this.dropup && this.right) || this.split || this.isNav)
+            let element = ((this.dropup && this.right) || this.split || this.inNavbar)
                 ? this.$el
                 : (this.$refs.button || this.$refs.toggle);
             // Make sure we have a reference to an element, not component.
@@ -170,7 +193,7 @@ export default {
                     },
                     applyStyle: {
                         // Disable Popper.js for Dropdown in Navbar
-                        enabled: !this.isNav
+                        enabled: !this.inNavbar
                     }
                 }
             }


### PR DESCRIPTION
Migration of dropdown and nav-item-dropdown to use popper.js

Migration wasn't too bad.  a couple of new optional props (`offset` & `no-flip`), but I was able to make it work with our existing props (`dropup` & `right`)

By design, popper is disabled for menus in navbars (because of collapsing behavior of navbars)