### PR TITLE
[wip] feat(table): easier usage

### DIFF
--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -228,7 +228,6 @@ When fields is provided as an object, the following field properties are availab
 in the Vue.js guide._
  >- _Any additional properties added to the field objects will be left intact - so you can access
 them via the named scoped slots for custom data, header, and footer rendering._
->- _by design, slots and formatter are **mutually exclusive**. Ie. if formatter defined at field props, then slot will not be used even if it defined for this field._
 
 For information and usage about scoped slots and formatters, refer to
 the [**Custom Data Rendering**](#custom-data-rendering) section below.
@@ -330,18 +329,22 @@ event:
 
 ### Formatter callback
 
-Other option to make custom field output is to use formatter callback function.
+One more option to customize field output is to use formatter callback function.
 To enable this field's property `formatter` is used. Value of this property may be 
 String or function reference. In case of String value, function must be defined at parent component's methods, 
 to provide formatter as `Function`, it must be declared at global scope (window or as global mixin at Vue). 
 
-Callback function accepts one argument - `value`.
+Callback function accepts three arguments - `value`, `key`, `row`.
 
 **Example 6: Custom data rendering with formatter callback function**
 ```html
 <template>
   <div>
   <b-table :fields="fields" :items="items">
+<template slot="name" scope="data">
+      <a :href="data.index+1">{{data.item.name}}</a>
+    </template>
+
   </b-table>
   </div>
 </template>

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -3,7 +3,20 @@
 > For displaying tabular data. `<b-table>` supports pagination, filtering, sorting,
 custom rendering, events, and asynchronous data.
 
-**Basic usage example:**
+#### **Contents** 
+- [**Items (record data)**](#items-record-data-)
+- [**Fields (column definitions)**](#fields-column-definitions-)
+- [**Custom Data Rendering**](#custom-data-rendering)
+- [**Header/Footer custom rendering via scoped slots**](#header-footer-custom-rendering-via-scoped-slots)
+- [**v-model binding**](#-v-model-binding)
+- [**Filtering**](#filtering)
+- [**Sorting**](#sorting)
+- [**Using Items Provider Functions**](#using-items-provider-functions)
+- [**Server Side Rendering**](#server-side-rendering)
+- [**Complete Example**](#complete-example)
+- [**Table options**](#table-options)
+
+**Example 1: Basic usage**
 ```html
 <template>
   <div>
@@ -46,7 +59,7 @@ keyed objects. Example format:
     { age: 42, first_name: 'Robert' }
 ]
 ```
-`<b-table>` Automatically samples the first row to extract field names (they keys in the
+`<b-table>` automatically samples the first row to extract field names (they keys in the
 record data). Field names are automatically "humanized" by converting `kebab-case`, `snake_case`, 
 and `camelCase` to individual words and capitalizes each word. Example conversions:
 
@@ -57,7 +70,7 @@ and `camelCase` to individual words and capitalizes each word. Example conversio
  - `isActive` becomes `Is Active`
 
 These titles wil be displayed in the table header, in the order they appear in the
-**first** record of data.  See the **Fields** section below for cusomizing how field
+**first** record of data.  See the [**Fields**](#fields-column-definitions-) section below for cusomizing how field
 headings appear.
 
 Record data may also have additional special reserved name keys for colorizing
@@ -66,9 +79,10 @@ rows and individual cells (variants). Supported optional item record modifier pr
 
 | Property | Type | Description
 | ---------| ---- | -----------
-| `_rowVariant` | String | Bootstrap contextual state applied to row (Supported values: `active`, `success`, `info`, `warning`, `danger`)
 | `_cellVariants` | Object | Bootstrap contextual state applied to individual cells. Keyed by field (Supported values: `active`, `success`, `info`, `warning`, `danger`)
+| `_rowVariant` | String | Bootstrap contextual state applied to row (Supported values: `active`, `success`, `info`, `warning`, `danger`)
 
+**Example 2: Using variants for table cells**
 ```html
 <template>
   <div>
@@ -107,23 +121,7 @@ Provider functions can also be asynchronous:
 ready, with the data array as the only argument to the callback,
 - By returning a `Promise` that resolves to an array.
 
-See the **"Using Items Provider functions"** section below for more details.
-
-## Table options
-`<b-table>` provides several props to alter the style of the table:
-
-| prop | Description
-| ---- | -----------
-| `striped` | Add zebra-striping to the table rows within the `<tbody>`
-| `bordered` | For borders on all sides of the table and cells.
-| `inverse` | Invert the colors — with light text on dark backgrounds
-| `small` | To make tables more compact by cutting cell padding in half.
-| `hover` | To enable a hover highlighting state on table rows within a `<tbody>`
-| `responsive` | Create responsive table to make it scroll horizontally on small devices (under 768px)
-| `foot-clone` | Turns on the table footer, and defaults with the same contents a the table header
-| `head-variant` | Use `default` or `inverse` to make `<thead>` appear light or dark gray, respectively
-| `foot-variant` | Use `default` or `inverse` to make `<tfoot>` appear light or dark gray, respectively. Has no effect if `foot-clone` is not set
-
+See the [**"Using Items Provider functions"**](#using-items-provider-functions) section below for more details.
 
 ## Fields (column definitions)
 The `fields` prop is used to customize the table columns headings,
@@ -135,6 +133,7 @@ each item (record) row, and to provide additional fetures such as sorting
 Fields can be a simple array, for defining the order of the columns, and
 which columns to display:
 
+**Example 3: Using `array` fields definition**
 ```html
 <template>
   <div>
@@ -146,7 +145,7 @@ which columns to display:
 export default {
   data: {
     // Note 'isActive' is left out and will not appear in the rendered table
-    fileds: [ 'first_name', 'last_name', 'age' ],
+    fields: [ 'first_name', 'last_name', 'age' ],
     items: [
       { isActive: true,  age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
       { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
@@ -162,10 +161,11 @@ export default {
 ```
 
 ### Fields as an object
-Or fields can be a an object providing additional control over the fields (such
+Also fields can be a an object providing additional control over the fields (such
 as sorting, formatting, etc). Only columns listed in the fields object will be shown,
 and will be shown in the order defined in the object:
 
+**Example 4: Using `object` fields definition**
 ```html
 <template>
   <div>
@@ -177,7 +177,7 @@ and will be shown in the order defined in the object:
 export default {
   data: {
     // Note 'isActive' is left out and will not appear in the rendered table
-    fileds: {
+    fields: {
       last_name: {
           label: 'Person last name',
           sortable: true
@@ -211,27 +211,27 @@ When fields is provided as an object, the following field properties are availab
 
 | Property | Type | Description
 | ---------| ---- | -----------
+| `class` | String or Array | Class name (or array of class names) to add to `<th>` **and** `<td>` in the column
+| `formatter` | String or Function | A formatter callback function, can be used instead of slots for real table fields (i.e. fields, that have corresponding data at items array).
 | `label` | String | Appears in the columns table header (and footer if `foot-clone` is set). Defaults to the field's key
 | `sortable` | Boolean | Enable sorting on this column
-| `variant` | String | Apply contextual class to the `<th>` **and** `<td>` in the column (`active`, `success`, `info`, `warning`, `danger`)
-| `class` | String or Array | Class name (or array of class names) to add to `<th>` **and** `<td>` in the column
-| `thClass` | String or Array | Class name (or array of class names) to add to header/footer `<th>` cell
 | `tdClass` | String or Array | Class name (or array of class names) to add to data `<td>` cells in the column
+| `thClass` | String or Array | Class name (or array of class names) to add to header/footer `<th>` cell
 | `thStyle` | Object | JavaScript object representing CSS styles you would like to apply to the table field `<th>`
-| `formatter` | String or Function | A formatter callback function, can be used instead of slots for real table fields (i.e. fields, that have corresponding data at items array)
+| `variant` | String | Apply contextual class to the `<th>` **and** `<td>` in the column (`active`, `success`, `info`, `warning`, `danger`)
 
-Notes:
- - Field properties, if not present, default to null unless otherwise stated above.
- - `thClass` and `tdClass` will not work with classes that are defined in scoped CSS
- - For information on the syntax supported by `thStyle`, see
+>**Notes:**
+ >- _Field properties, if not present, default to `null` unless otherwise stated above._
+ >- _`thClass` and `tdClass` will not work with classes that are defined in scoped CSS_
+ >- _For information on the syntax supported by `thStyle`, see
 [Class and Style Bindings](https://vuejs.org/v2/guide/class-and-style.html#Binding-Inline-Styles)
-in the Vue.js guide.
- - Any additional properties added to the field objects will be left intact - so you can access
-them via the named scoped slots for custom data, header, and footer rendering.
-- by design, slots and formatter are **mutually exclusive**. Ie. if formatter defined at field props, then slot will not be used even if it defined for this field.
+in the Vue.js guide._
+ >- _Any additional properties added to the field objects will be left intact - so you can access
+them via the named scoped slots for custom data, header, and footer rendering._
+>- _by design, slots and formatter are **mutually exclusive**. Ie. if formatter defined at field props, then slot will not be used even if it defined for this field._
 
 For information and usage about scoped slots and formatters, refer to
-the **Custom Data Rendering** section below.
+the [**Custom Data Rendering**](#custom-data-rendering) section below.
 
 ## Custom Data Rendering
 Custom rendering for each data field in a row is possible using either 
@@ -241,13 +241,14 @@ Custom rendering for each data field in a row is possible using either
 Scoped slots give you greater control over how the record data apepars.
 If you want to add an extra field which does not exist in the records,
 just add it to the `fields` array, And then reference the field(s) in the scoped
-slot(s).  Example:
+slot(s).  
 
+**Example 5: Custom data rendering with `slots`**
 ```html
 <template>
   <div>
   <b-table :fields="fields" :items="items">
-    <!-- A Virtul column -->
+    <!-- A virtual column -->
     <template slot="index" scope="data">
       {{data.index + 1}}
     </template>
@@ -255,7 +256,7 @@ slot(s).  Example:
     <template slot="name" scope="data">
       {{data.value.first}} {{data.value.last}}
     </template>
-    <!-- A Virtul composite column -->
+    <!-- A virtual composite column -->
     <template slot="nameage" scope="data">
       {{data.item.name.first}} is {{data.item.age}} years old
     </template>
@@ -298,21 +299,22 @@ export default {
 }
 </script>
 
-<!-- table-data-slots-1.vue -->
+<!-- table-data-slots.vue -->
 ```
 
 The slot's scope variable (`data` in the above sample) will have the following properties:
 
 | Property | Type | Description
 | -------- | ---- | -----------
-| `value` | Any | The value for this key in the record (`null` or `undefined` if a virtual column)
-| `item` | Object | The entire record (i.e. `items[index]`) for this row
 | `index` | Number | The row number (indexed from zero)
+| `item` | Object | The entire record (i.e. `items[index]`) for this row
+| `value` | Any | The value for this key in the record (`null` or `undefined` if a virtual column)
 
-**Note:** `index` will not always be the actual row's index number, as it is
+
+>**Note:** *`index` will not always be the actual row's index number, as it is
 computed after pagination and filtering have been applied to the original
 table data. The `index` value will refer to the **displayed row number**. This
-number will align with the indexes from the optional `v-model` bound variable.
+number will align with the indexes from the optional `v-model` bound variable.*
 
 When placing inputs, buttons, selects or links within a data cell scoped slot,
 be sure to add a `@click.stop` handler (which can be empty) to prevent the
@@ -331,25 +333,54 @@ event:
 Other option to make custom field output is to use formatter callback function.
 To enable this field's property `formatter` is used. Value of this property may be 
 String or function reference. In case of String value, function must be defined at parent component's methods, 
-to provide formatter as `Function`, it must be declared at global scope (window or as global mixin at Vue).  
+to provide formatter as `Function`, it must be declared at global scope (window or as global mixin at Vue). 
 
-Example:
-```js
-{
-    name: {
-        label: 'Person Full name',
-        sortable: true,
-        formatter: 'personFullName'
+Callback function accepts one argument - `value`.
+
+**Example 6: Custom data rendering with formatter callback function**
+```html
+<template>
+  <div>
+  <b-table :fields="fields" :items="items">
+  </b-table>
+  </div>
+</template>
+
+<script>
+export default {
+  data: {
+    fields: {
+      name: {
+        // A column that needs custom formatting
+        label: 'Full Name',
+        formatter:'fullName'
+      },
+      age: {
+        // A regular column
+        label: 'Sex'
+      },
+      sex: {
+        // A regular column
+        label: 'Sex'
+      },
     },
-    age: {
-        label: 'Person age',
-        sortable: false,
-        fomatter: personAge
-    }
+    items: [
+      { name: { first: 'John', last: 'Doe' }, sex: 'Male', age: 42 },
+      { name: { first: 'Jane', last: 'Doe' }, sex: 'Female', age: 36 },
+      { name: { first: 'Rubin', last: 'Kincade' }, sex: 'Male', age: 73 },
+      { name: { first: 'Shirley', last: 'Partridge' }, sex: 'Female', age: 62 }
+    ]
+  }, 
+  methods: {
+      fullName(value){
+          return `${value.first} ${value.last}`
+      }
+  }
 }
+</script>
+
+<!-- table-data-formatter.vue -->
 ```
-
-
 ## Header/Footer custom rendering via scoped slots
 It is also possible to provide custom rendering for the tables `thead` and
 `tfoot` elements. Note by default the table footer is not rendered unless
@@ -381,9 +412,9 @@ The slot's scope variable (`data` in the above example) will have the following 
 
 | Property | Type | Description
 | -------- | ---- | -----------
-| `label` | String | The fileds label value (also available as `data.field.label`)
 | `column` | String | The fields's `key` value
 | `field` | Object | the field's object (from the `fields` prop)
+| `label` | String | The fileds label value (also available as `data.field.label`)
 
 When placing inputs, buttons, selects or links within a `HEAD_` or `FOOT_` slot,
 be sure to add a `@click.stop` handler (which can be empty) to prevent the
@@ -398,7 +429,7 @@ or a `head-clicked` event.
 ```
 
 
-## `v-model` Binding
+## `v-model` binding
 If you bind a variable to the `v-model` prop, the contents of this variable will
 be the currently disaplyed item records (zero based index, up to `page-size` - 1).
 This variable (the `value` prop) should usually be treated as readonly.
@@ -409,7 +440,7 @@ the original `items` array (except when `items` is set to a provider function).
 Deleting a record from the v-model will **not** remove the record from the
 original items array.
 
-**Note:** Do not bind any value directly to the `value` prop. Use the `v-model` binding.
+>**Note:** *Do not bind any value directly to the `value` prop. Use the `v-model` binding.*
 
 ## Filtering
 Filtering, when used, is aplied to the original items array data, and hence it is not
@@ -427,7 +458,7 @@ will emit the `filtered` event, passing a single argument which is the complete 
 items passing the filter routine. Treat this argument as read-only.
 
 ## Sorting
-As mentioned above in the **fields** section above, you can make columns sortable. Clciking on
+As mentioned above in the [**Fields**](#fields-column-definitions-) section above, you can make columns sortable. Clciking on
 sortable a column header will sort the column in ascending direction, while clicking
 on it again will switch the direction or sorting.  Clicking on a non-sortable column
 will clear the sorting.
@@ -462,7 +493,7 @@ The default sort-compare routine works as follows:
 ```js
 if (typeof a[key] === 'number' && typeof b[key] === 'number') {
     // If both compared fields are native numbers
-    return a[key] < b[key] ? -1 : (a[key] > b[key] ? : 1 : 0);
+    return a[key] < b[key] ? -1 : (a[key] > b[key] ? 1 : 0);
 } else {
     // Stringify the field data and use String.localeCompare
     return toString(a[key]).localeCompare(toString(b[key]), undefined, {
@@ -470,21 +501,8 @@ if (typeof a[key] === 'number' && typeof b[key] === 'number') {
     });
 }
 ```
-
-## Advanced Table Options
-
-`<b-table>` provides several props to alter the features of the table:
-
-| prop | Description
-| ---- | -----------
-| `busy` | If set to `true` will make the table opaque and disable click events. Handy when using items provider functions.
-| `show-empty` | If `true`, Show a message if no records can be displayed (see `empty-text` and `empty-filter-text`)
-| `empty-text` | Text to display if there are no records in the original `items` array. You can also use the named slot `empty` to set the content for `empty-text`
-| `empty-filtered-text` | Text to display if there are no records in the **filtered** `items` array. You can also use the named slot `emptyfiltered` to set the content for `empty-filtered-text`
-
-
 ## Using Items Provider Functions
-As mentioned under the `items` prop section, it is possible to use a function to provide
+As mentioned under the [**Items**](#items-record-data-) prop section, it is possible to use a function to provide
 the row data (items), by specifying a function reference via the `items` prop.
 
 The provider function is called with the following signature:
@@ -506,7 +524,7 @@ following five properties:
 
 The second argument `callback` is an optional parameter for when using the callback asynchronous method.
 
-**Example 1: returning an array of data (synchronous):**
+**Example 7: returning an array of data (synchronous):**
 ```js
 function myProvider(ctx) {
     let items = [];
@@ -518,7 +536,7 @@ function myProvider(ctx) {
 }
 ```
 
-**Example 2: Using callback to return data (asynchronous):**
+**Example 8: Using callback to return data (asynchronous):**
 ```js
 function myProvider(ctx, callback) {
     let params = '?page=' + ctx.currentPage + '&size=' + ctx.perPage;
@@ -537,7 +555,7 @@ function myProvider(ctx, callback) {
 }
 ```
 
-**Example 3: Using a Promise to return data (asynchronous):**
+**Example 9: Using a Promise to return data (asynchronous):**
 ```js
 function myProvider(ctx) {
     let promise = axios.get('/some/url?page=' + ctx.currentPage + '&size=' + ctx.perPage);
@@ -556,9 +574,9 @@ function myProvider(ctx) {
 a `busy` prop that can be used either to override inner `busy`state, or to monitor
 `<b-table>`'s current busy state in your application using the 2-way `.sync` modifier.
 
-**Note:** in order to allow `<b-table>` fully track it's `busy` state, custom items
+>**Note:** _in order to allow `<b-table>` fully track it's `busy` state, custom items
 provider function should handle errors from data sources and return an empty
-array to `<b-table>`.
+array to `<b-table>`._
 
 `<b-table>` provides a `busy` prop that will flag the table as busy, which you can
 set to `true` just before your async fetch, and then set it to `false` once you have
@@ -595,12 +613,12 @@ methods: {
  }
 ```
 
-**Notes:**
- - If you manually place the table in the `busy` state, the items provider will
-__not__ be called/refreshed until the `busy` state has been set to `false`.
- - All click related and hover events, and sort-changed events will __not__ be
+>**Notes:**
+>- _If you manually place the table in the `busy` state, the items provider will
+__not__ be called/refreshed until the `busy` state has been set to `false`._
+>- _All click related and hover events, and sort-changed events will __not__ be
  emiited when in the `busy` state (either set automatically during provider update,
- or when manually set).
+ or when manually set)._
 
 ### Provider Paging, Filtering, and Sorting
 By default, the items provider function is responsible for **all paging, filtering, and sorting**
@@ -618,10 +636,10 @@ following `b-table` prop(s) to `true`:
 When `no-provider-paging` is `false` (default), you should only return at
 maximum, `perPage` number of records.
 
-Note that `<b-table>` needs reference to your pagination and filtering values in order to
+>**Note** _`<b-table>` needs reference to your pagination and filtering values in order to
 trigger the calling of the provider function.  So be sure to bind to the `per-page`,
 `current-page` and `filter` props on `b-table` to trigger the provider update function call
-(unless you have the respective `no-provider-*` prop set to `true`).
+(unless you have the respective `no-provider-*` prop set to `true`)._
 
 ### Event based refreshing of data:
 You may also trigger the refresh of the provider function by emitting the
@@ -665,13 +683,12 @@ methods: {
 ```
 
 You can also obtain the current sortBy and sortDesc values by using the `:sort-by.sync` and
-`:sort-desc.sync` two-way props respectively (see section **Sorting** above for details).
+`:sort-desc.sync` two-way props respectively (see section [**Sorting**](#sorting) above for details).
 
 ```html
 <b-table :sort-by.sync="mySortBy" :sort-desc.sync="mySortDesc" ...>
 </b-table>
 ```
-
 
 ## Server Side Rendering
 Special care must be taken when using server side rendering (SSR) and an `items` provider
@@ -794,3 +811,19 @@ export default {
 
 <!-- table-complete-1.vue -->
 ```
+## Table options
+`<b-table>` provides several props to alter the style of the table:
+
+| prop | Description
+| ---- | -----------
+| `striped` | Add zebra-striping to the table rows within the `<tbody>`
+| `bordered` | For borders on all sides of the table and cells.
+| `inverse` | Invert the colors — with light text on dark backgrounds
+| `small` | To make tables more compact by cutting cell padding in half.
+| `hover` | To enable a hover highlighting state on table rows within a `<tbody>`
+| `responsive` | Create responsive table to make it scroll horizontally on small devices (under 768px)
+| `foot-clone` | Turns on the table footer, and defaults with the same contents a the table header
+| `head-variant` | Use `default` or `inverse` to make `<thead>` appear light or dark gray, respectively
+| `foot-variant` | Use `default` or `inverse` to make `<tfoot>` appear light or dark gray, respectively. Has no effect if `foot-clone` is not set
+
+

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -3,141 +3,211 @@
 > For displaying tabular data. `<b-table>` supports pagination, filtering, sorting,
 custom rendering, events, and asynchronous data.
 
+**Basic usage example:**
 ```html
 <template>
-<div>
-  <div class="my-1 row">
-    <div class="col-md-6">
-      <b-form-fieldset horizontal label="Rows per page" :label-cols="6">
-        <b-form-select :options="pageOptions" v-model="perPage" />
-      </b-form-fieldset>
-    </div>
-    <div class="col-md-6">
-      <b-form-fieldset horizontal label="Filter" :label-cols="3">
-        <b-form-input v-model="filter" placeholder="Type to Search" />
-      </b-form-fieldset>
-    </div>
+  <div>
+    <b-table striped hover :items="items"></b-table>
   </div>
-
-  <div class="row my-1">
-    <div class="col-sm-8">
-      <b-pagination :total-rows="totalRows" :per-page="perPage" v-model="currentPage" />
-    </div>
-    <div class="col-sm-4 text-md-right">
-      <b-button :disabled="!sortBy" @click="sortBy = null">Clear Sort</b-button>
-    </div>
-  </div>
-
-  <!-- Main table element -->
-  <b-table striped hover show-empty
-           :items="items"
-           :fields="fields"
-           :current-page="currentPage"
-           :per-page="perPage"
-           :filter="filter"
-           :sort-by.sync="sortBy"
-           :sort-desc.sync="sortDesc"
-           @filtered="onFiltered"
-  >
-    <template slot="name" scope="row">{{row.value.first}} {{row.value.last}}</template>
-    <template slot="isActive" scope="row">{{row.value?'Yes :)':'No :('}}</template>
-    <template slot="actions" scope="row">
-      <!-- We use click.stop here to prevent a 'row-clicked' event from also happening -->
-      <b-btn size="sm" @click.stop="details(row.item,row.index,$event.target)">Details</b-btn>
-    </template>
-  </b-table>
-
-  <p>
-    Sort By: {{ sortBy || 'n/a' }}, Direction: {{ sortDesc ? 'descending' : 'ascending' }}
-  </p>
-
-  <!-- Details modal -->
-  <b-modal id="modal1" @hide="resetModal" ok-only>
-    <h4 class="my-1 py-1" slot="modal-header">Index: {{ modalDetails.index }}</h4>
-    <pre>{{ modalDetails.data }}</pre>
-  </b-modal>
-
-</div>
 </template>
 
 <script>
 const items = [
-  { isActive: true,  age: 40, name: { first: 'Dickerson', last: 'Macdonald' } },
-  { isActive: false, age: 21, name: { first: 'Larsen', last: 'Shaw' } },
-  { _rowVariant: 'success',
-    isActive: false, age: 9,  name: { first: 'Mini', last: 'Navarro' } },
-  { isActive: false, age: 89, name: { first: 'Geneva', last: 'Wilson' } },
-  { isActive: true,  age: 38, name: { first: 'Jami', last: 'Carney' } },
-  { isActive: false, age: 27, name: { first: 'Essie', last: 'Dunlap' } },
-  { isActive: true,  age: 40, name: { first: 'Thor', last: 'Macdonald' } },
-  { _cellVariants: { age: 'danger', isActive: 'warning' },
-    isActive: true,  age: 87, name: { first: 'Larsen', last: 'Shaw' } },
-  { isActive: false, age: 26, name: { first: 'Mitzi', last: 'Navarro' } },
-  { isActive: false, age: 22, name: { first: 'Genevive', last: 'Wilson' } },
-  { isActive: true,  age: 38, name: { first: 'John', last: 'Carney' } },
-  { isActive: false, age: 29, name: { first: 'Dick', last: 'Dunlap' } }
+  { isActive: true,  age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
+  { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
+  { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson' },
+  { isActive: true,  age: 38, first_name: 'Jami', last_name: 'Carney' },
+  { isActive: false, age: 27, first_name: 'Essie', last_name: 'Dunlap' },
+  { isActive: true,  age: 40, first_name: 'Thor', last_name: 'Macdonald' },
+  { isActive: false, age: 26, first_name: 'Mitzi', last_name: 'Navarro' },
+  { isActive: false, age: 22, first_name: 'Genevive', last_name: 'Wilson' },
+  { isActive: true,  age: 38, first_name: 'John', last_name: 'Carney' },
+  { isAactive: false, age: 29, first_name: 'Dick', last_name: 'Dunlap' }
 ];
 
 export default {
   data: {
-    items: items,
-    fields: {
-      name:     { label: 'Person Full name', sortable: true },
-      age:      { label: 'Person age', sortable: true, 'class': 'text-center'  },
-      isActive: { label: 'is Active' },
-      actions:  { label: 'Actions' }
-    },
-    currentPage: 1,
-    perPage: 5,
-    totalRows: items.length,
-    pageOptions: [{text:5,value:5},{text:10,value:10},{text:15,value:15}],
-    sortBy: null,
-    sortDesc: false,
-    filter: null,
-    modalDetails: { index:'', data:'' }
-  },
-  methods: {
-    details(item, index, button) {
-      this.modalDetails.data = JSON.stringify(item, null, 2);
-      this.modalDetails.index = index;
-      this.$root.$emit('show::modal','modal1', button);
-    },
-    resetModal() {
-      this.modalDetails.data = '';
-      this.modalDetails.index = '';
-    },
-    onFiltered(filteredItems) {
-      // Trigger pagination to update the number of buttons/pages due to filtering
-      this.totalRows = filteredItems.length;
-      this.currentPage = 1;
-    }
+    items: items
   }
 }
 </script>
 
-<!-- table-1.vue -->
+<!-- table-basic-1.vue -->
 ```
+
+## Items (record data)
+`items` is the table data in array format, where each record (row) data are
+keyed objects. Example format:
+
+```js
+[
+    { age: 32, first_name: 'Cyndi' },
+    { age: 27, first_name: 'Havij' },
+    { age: 42, first_name: 'Robert' }
+]
+```
+`<b-table>` Automatically samples the first row to extract field names (they keys in the
+record data). Field names are automatically "humanized" by converting `kebab-case`, `snake_case`, 
+and `camelCase` to individual words and capitalizes each word. Example conversions:
+
+ - `first_name` becomes `First Name`
+ - `last-name` becomes `Last Name`
+ - `age` becoms `Age`
+ - `YEAR` becomes `Year`
+ - `isActive` becomes `Is Active`
+
+These titles wil be displayed in the table header, in the order they appear in the
+**first** record of data.  See the **Fields** section below for cusomizing how field
+headings appear.
+
+Record data may also have additional special reserved name keys for colorizing
+rows and individual cells (variants). Supported optional item record modifier properties
+(make sure your field keys do not conflict with these names):
+
+| Property | Type | Description
+| ---------| ---- | -----------
+| `_rowVariant` | String | Bootstrap contextual state applied to row (Supported values: `active`, `success`, `info`, `warning`, `danger`)
+| `_cellVariants` | Object | Bootstrap contextual state applied to individual cells. Keyed by field (Supported values: `active`, `success`, `info`, `warning`, `danger`)
+
+```html
+<template>
+  <div>
+    <b-table striped hover :items="items"></b-table>
+  </div>
+</template>
+
+<script>
+const items = [
+  { isActive: true,  age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
+  { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
+  {
+    isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson',
+    _rowVariant: 'danger'
+  },
+  { 
+    isActive: true,  age: 40, first_name: 'Thor', last_name: 'Macdonald',
+    _cellVariants: { isActive: 'success', age: 'info', first_name: 'warning' }
+  },
+  { isAactive: false, age: 29, first_name: 'Dick', last_name: 'Dunlap' }
+];
+
+export default {
+  data: {
+    items: items
+  }
+}
+</script>
+
+<!-- table-variants-1.vue -->
+```
+
+`items` can also be a reference to a *provider* function, which returns an `Array` of items data.
+Provider functions can also be asynchronous:
+- By returning `null` (or `undefined`) and calling a callback, when the data is
+ready, with the data array as the only argument to the callback,
+- By returning a `Promise` that resolves to an array.
+
+See the **"Using Items Provider functions"** section below for more details.
+
+## Table options
+`<b-table>` provides several props to alter the style of the table:
+
+| prop | Description
+| ---- | -----------
+| `striped` | Add zebra-striping to the table rows within the `<tbody>`
+| `bordered` | For borders on all sides of the table and cells.
+| `inverse` | Invert the colors — with light text on dark backgrounds
+| `small` | To make tables more compact by cutting cell padding in half.
+| `hover` | To enable a hover highlighting state on table rows within a `<tbody>`
+| `responsive` | Create responsive table to make it scroll horizontally on small devices (under 768px)
+| `foot-clone` | Turns on the table footer, and defaults with the same contents a the table header
+| `head-variant` | Use `default` or `inverse` to make `<thead>` appear light or dark gray, respectively
+| `foot-variant` | Use `default` or `inverse` to make `<tfoot>` appear light or dark gray, respectively. Has no effect if `foot-clone` is not set
+
 
 ## Fields (column definitions)
-The `fields` prop is used to display table columns. Keys (i.e. `age` or `name`
-as shown below) are used to extract real value from each row.
+The `fields` prop is used to customize the table columns headings,
+and in which order the columns of data are displayed. The field object keys
+(i.e. `age` or `first_name` as shown below) are used to extract the value from
+each item (record) row, and to provide additional fetures such as sorting
 
-Example format:
-```js
-{
-    name: {
-        label: 'Person Full name',
-        sortable: true,
-        formatter: 'personFullName'
-    },
-    age: {
-        label: 'Person age',
-        sortable: false
-    }
-}
+### Fields as a simple array
+Fields can be a simple array, for defining the order of the columns, and
+which columns to display:
+
+```html
+<template>
+  <div>
+    <b-table striped hover :items="items" :fields="fields"></b-table>
+  </div>
+</template>
+
+<script>
+export default {
+  data: {
+    // Note 'isActive' is left out and will not appear in the rendered table
+    fileds: [ 'first_name', 'last_name', 'age' ],
+    items: [
+      { isActive: true,  age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
+      { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
+      { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson' },
+      { isActive: true,  age: 38, first_name: 'Jami', last_name: 'Carney' },
+      { isActive: false, age: 27, first_name: 'Essie', last_name: 'Dunlap' }
+    ]
+  }
+};
+</script>
+
+<!-- table-fields-1.vue -->
 ```
 
-Supported field properties:
+### Fields as an object
+Or fields can be a an object providing additional control over the fields (such
+as sorting, formatting, etc). Only columns listed in the fields object will be shown,
+and will be shown in the order defined in the object:
+
+```html
+<template>
+  <div>
+    <b-table striped hover :items="items" :fields="fields"></b-table>
+  </div>
+</template>
+
+<script>
+export default {
+  data: {
+    // Note 'isActive' is left out and will not appear in the rendered table
+    fileds: {
+      last_name: {
+          label: 'Person last name',
+          sortable: true
+      },
+      first_name: {
+          label: 'Person first name',
+          sortable: false
+      },
+      age: {
+          label: 'Person age',
+          sortable: true,
+          // Variant applies to teh whole column, including the header and footer
+          variant: 'danger'
+      }
+    },
+    items: [
+      { isActive: true,  age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
+      { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
+      { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson' },
+      { isActive: true,  age: 38, first_name: 'Jami', last_name: 'Carney' },
+      { isAactive: false, age: 29, first_name: 'Dick', last_name: 'Dunlap' }
+    ]
+  }
+};
+</script>
+
+<!-- table-fields-2.vue -->
+```
+
+When fields is provided as an object, the following field properties are available:
 
 | Property | Type | Description
 | ---------| ---- | -----------
@@ -160,135 +230,76 @@ in the Vue.js guide.
 them via the named scoped slots for custom data, header, and footer rendering.
 - by design, slots and formatter are **mutually exclusive**. Ie. if formatter defined at field props, then slot will not be used even if it defined for this field.
 
-## Items (record data)
-`items` are real table data record objects in array format. Example format:
-
-```js
-[
-    {
-        age: 32,
-        name: 'Cyndi'
-    },
-    {
-        _rowVariant: 'success', // Displays record row green
-        age: 27,
-        name: 'Havij'
-    },
-    {
-        _cellVariants: {
-            age: 'danger',  // Displays cell for field 'age' red
-            name: 'success' // Displays cell for field 'name' green
-        },
-        age: 42,
-        name: 'Robert'
-    }
-]
-```
-
-Supported optional item record modifier properties (make sure your field keys do not conflict with these names):
-
-| Property | Type | Description
-| ---------| ---- | -----------
-| `_rowVariant` | String | Bootstrap contextual state applied to row (Supported values: `active`, `success`, `info`, `warning`, `danger`)
-| `_cellVariants` | Object | Bootstrap contextual state applied to individual cells. Keyed by field (Supported values: `active`, `success`, `info`, `warning`, `danger`)
-
-
-`items` can also be a reference to a *provider* function, which returns an `Array` of items data.
-Provider functions can also be asynchronous:
-- By returning `null` (or `undefined`) and calling a callback, when the data is
-ready, with the data array as the only argument to the callback,
-- By returning a `Promise` that resolves to an array.
-
-See the **"Using Items Provider functions"** section below for more details.
-
-## Table Options
-
-`<b-table>` provides several props to alter the style of the table:
-
-| prop | Description
-| ---- | -----------
-| `striped` | Add zebra-striping to the table rows within the `<tbody>`
-| `bordered` | For borders on all sides of the table and cells.
-| `inverse` | Invert the colors — with light text on dark backgrounds
-| `small` | To make tables more compact by cutting cell padding in half.
-| `hover` | To enable a hover state on table rows within a `<tbody>`
-| `responsive` | Create responsive table to make it scroll horizontally on small devices (under 768px)
-| `foot-clone` | Turns on the table footer, and defaults with the same contents a the table header
-| `head-variant` | Use `default` or `inverse` to make `<thead>` appear light or dark gray, respectively
-| `foot-variant` | Use `default` or `inverse` to make `<tfoot>` appear light or dark gray, respectively. Has no effect if `foot-clone` is not set
-| `busy` | If set to `true` will make the table opaque and disable click events. Handy when using items provider functions.
-| `show-empty` | If `true`, Show a message if no records can be displayed (see `empty-text` and `empty-filter-text`)
-| `empty-text` | Text to display if there are no records in the original `items` array. You can also use the named slot `empty` to set the content for `empty-text`
-| `empty-filtered-text` | Text to display if there are no records in the **filtered** `items` array. You can also use the named slot `emptyfiltered` to set the content for `empty-filtered-text`
-
+For information and usage about scoped slots and formatters, refer to
+the **Custom Data Rendering** section below.
 
 ## Custom Data Rendering
 Custom rendering for each data field in a row is possible using either 
 [scoped slots](http://vuejs.org/v2/guide/components.html#Scoped-Slots) or formatter callback function.
 
-### Slots
+### Scoped Field Slots
+Scoped slots give you greater control over how the record data apepars.
 If you want to add an extra field which does not exist in the records,
-just add it to the `fields` array.  Example:
-
-```js
- fields: {
-    index: {
-        // A virtual column
-        label: 'Index'
-    },
-    name: {
-        // A column that needs custom formatting
-        label: 'Full Name'
-    },
-    sex: {
-        // A regular column
-        label: 'Sex'
-    },
-    nameage: {
-        // A virtual column
-        label: 'First name and age'
-    }
- },
- items: [
-    {
-        name: { first: 'John', last: 'Doe' },
-        sex: 'Male',
-        age: 42
-    },
-    {
-        name: { first: 'Jane', last: 'Doe' },
-        sex: 'Female',
-        age: 36
-    }
- ]
-```
-
-And then reference the field in the scoped slots:
+just add it to the `fields` array, And then reference the field(s) in the scoped
+slot(s).  Example:
 
 ```html
-<b-table :fields="fields" :items="items">
-  <template slot="index" scope="data">
+<template>
+  <div>
+  <b-table :fields="fields" :items="items">
     <!-- A Virtul column -->
-    {{data.index + 1}}
-  </template>
-  <template slot="name" scope="data">
+    <template slot="index" scope="data">
+      {{data.index + 1}}
+    </template>
     <!-- A custom formatted column -->
-    {{data.value.first}} {{data.value.last}}
-  </template>
-  <template slot="nameage" scope="data">
+    <template slot="name" scope="data">
+      {{data.value.first}} {{data.value.last}}
+    </template>
     <!-- A Virtul composite column -->
-    {{data.item.name.first}} is {{data.item.age}} years old
-  </template>
-</b-table>
+    <template slot="nameage" scope="data">
+      {{data.item.name.first}} is {{data.item.age}} years old
+    </template>
+  </b-table>
+  </div>
+</template>
+
+<script>
+export default {
+  data: {
+    fields: {
+      index: {
+        // A virtual column that doesn't exist in items
+        label: 'Index'
+      },
+      name: {
+        // A column that needs custom formatting
+        label: 'Full Name'
+      },
+      age: {
+        // A regular column
+        label: 'Sex'
+      },
+      sex: {
+        // A regular column
+        label: 'Sex'
+      },
+      nameage: {
+        // A virtual column made up from two fields
+        label: 'First name and age'
+      }
+    },
+    items: [
+      { name: { first: 'John', last: 'Doe' }, sex: 'Male', age: 42 },
+      { name: { first: 'Jane', last: 'Doe' }, sex: 'Female', age: 36 },
+      { name: { first: 'Rubin', last: 'Kincade' }, sex: 'Male', age: 73 },
+      { name: { first: 'Shirley', last: 'Partridge' }, sex: 'Female', age: 62 }
+    ]
+  }
+}
+</script>
+
+<!-- table-data-slots-1.vue -->
 ```
-
-will render a table like so:
-
-| Index | Full Name | Sex | First name and age
-| ----- | --------- | --- | ------------------
-| 1 | John Doe | Male | John is 42 years old
-| 2 | Jane Doe | Female | Jane is 36 years old
-
 
 The slot's scope variable (`data` in the above sample) will have the following properties:
 
@@ -296,7 +307,7 @@ The slot's scope variable (`data` in the above sample) will have the following p
 | -------- | ---- | -----------
 | `value` | Any | The value for this key in the record (`null` or `undefined` if a virtual column)
 | `item` | Object | The entire record (i.e. `items[index]`) for this row
-| `index` | Number | The row number (zero based)
+| `index` | Number | The row number (indexed from zero)
 
 **Note:** `index` will not always be the actual row's index number, as it is
 computed after pagination and filtering have been applied to the original
@@ -314,6 +325,7 @@ event:
   <b-btn size="sm" @click.stop="details(cell.item,cell.index,$event.target)">Details</b-btn>
 </template>
 ```
+
 ### Formatter callback
 
 Other option to make custom field output is to use formatter callback function.
@@ -415,7 +427,7 @@ will emit the `filtered` event, passing a single argument which is the complete 
 items passing the filter routine. Treat this argument as read-only.
 
 ## Sorting
-As mentioned above in the **fields** section, you can make columns sortable. Clciking on
+As mentioned above in the **fields** section above, you can make columns sortable. Clciking on
 sortable a column header will sort the column in ascending direction, while clicking
 on it again will switch the direction or sorting.  Clicking on a non-sortable column
 will clear the sorting.
@@ -458,6 +470,18 @@ if (typeof a[key] === 'number' && typeof b[key] === 'number') {
     });
 }
 ```
+
+## Advanced Table Options
+
+`<b-table>` provides several props to alter the features of the table:
+
+| prop | Description
+| ---- | -----------
+| `busy` | If set to `true` will make the table opaque and disable click events. Handy when using items provider functions.
+| `show-empty` | If `true`, Show a message if no records can be displayed (see `empty-text` and `empty-filter-text`)
+| `empty-text` | Text to display if there are no records in the original `items` array. You can also use the named slot `empty` to set the content for `empty-text`
+| `empty-filtered-text` | Text to display if there are no records in the **filtered** `items` array. You can also use the named slot `emptyfiltered` to set the content for `empty-filtered-text`
+
 
 ## Using Items Provider Functions
 As mentioned under the `items` prop section, it is possible to use a function to provide
@@ -654,3 +678,119 @@ Special care must be taken when using server side rendering (SSR) and an `items`
 function. Make sure you handle any special situations that may be needed server side
 when fetching your data!
 
+## Complete Example
+
+```html
+<template>
+<div>
+  <div class="my-1 row">
+    <div class="col-md-6">
+      <b-form-fieldset horizontal label="Rows per page" :label-cols="6">
+        <b-form-select :options="pageOptions" v-model="perPage" />
+      </b-form-fieldset>
+    </div>
+    <div class="col-md-6">
+      <b-form-fieldset horizontal label="Filter" :label-cols="3">
+        <b-form-input v-model="filter" placeholder="Type to Search" />
+      </b-form-fieldset>
+    </div>
+  </div>
+
+  <div class="row my-1">
+    <div class="col-sm-8">
+      <b-pagination :total-rows="totalRows" :per-page="perPage" v-model="currentPage" />
+    </div>
+    <div class="col-sm-4 text-md-right">
+      <b-button :disabled="!sortBy" @click="sortBy = null">Clear Sort</b-button>
+    </div>
+  </div>
+
+  <!-- Main table element -->
+  <b-table striped hover show-empty
+           :items="items"
+           :fields="fields"
+           :current-page="currentPage"
+           :per-page="perPage"
+           :filter="filter"
+           :sort-by.sync="sortBy"
+           :sort-desc.sync="sortDesc"
+           @filtered="onFiltered"
+  >
+    <template slot="name" scope="row">{{row.value.first}} {{row.value.last}}</template>
+    <template slot="isActive" scope="row">{{row.value?'Yes :)':'No :('}}</template>
+    <template slot="actions" scope="row">
+      <!-- We use click.stop here to prevent a 'row-clicked' event from also happening -->
+      <b-btn size="sm" @click.stop="details(row.item,row.index,$event.target)">Details</b-btn>
+    </template>
+  </b-table>
+
+  <p>
+    Sort By: {{ sortBy || 'n/a' }}, Direction: {{ sortDesc ? 'descending' : 'ascending' }}
+  </p>
+
+  <!-- Details modal -->
+  <b-modal id="modal1" @hide="resetModal" ok-only>
+    <h4 class="my-1 py-1" slot="modal-header">Index: {{ modalDetails.index }}</h4>
+    <pre>{{ modalDetails.data }}</pre>
+  </b-modal>
+
+</div>
+</template>
+
+<script>
+const items = [
+  { isActive: true,  age: 40, name: { first: 'Dickerson', last: 'Macdonald' } },
+  { isActive: false, age: 21, name: { first: 'Larsen', last: 'Shaw' } },
+  { _rowVariant: 'success',
+    isActive: false, age: 9,  name: { first: 'Mini', last: 'Navarro' } },
+  { isActive: false, age: 89, name: { first: 'Geneva', last: 'Wilson' } },
+  { isActive: true,  age: 38, name: { first: 'Jami', last: 'Carney' } },
+  { isActive: false, age: 27, name: { first: 'Essie', last: 'Dunlap' } },
+  { isActive: true,  age: 40, name: { first: 'Thor', last: 'Macdonald' } },
+  { _cellVariants: { age: 'danger', isActive: 'warning' },
+    isActive: true,  age: 87, name: { first: 'Larsen', last: 'Shaw' } },
+  { isActive: false, age: 26, name: { first: 'Mitzi', last: 'Navarro' } },
+  { isActive: false, age: 22, name: { first: 'Genevive', last: 'Wilson' } },
+  { isActive: true,  age: 38, name: { first: 'John', last: 'Carney' } },
+  { isActive: false, age: 29, name: { first: 'Dick', last: 'Dunlap' } }
+];
+
+export default {
+  data: {
+    items: items,
+    fields: {
+      name:     { label: 'Person Full name', sortable: true },
+      age:      { label: 'Person age', sortable: true, 'class': 'text-center'  },
+      isActive: { label: 'is Active' },
+      actions:  { label: 'Actions' }
+    },
+    currentPage: 1,
+    perPage: 5,
+    totalRows: items.length,
+    pageOptions: [{text:5,value:5},{text:10,value:10},{text:15,value:15}],
+    sortBy: null,
+    sortDesc: false,
+    filter: null,
+    modalDetails: { index:'', data:'' }
+  },
+  methods: {
+    details(item, index, button) {
+      this.modalDetails.data = JSON.stringify(item, null, 2);
+      this.modalDetails.index = index;
+      this.$root.$emit('show::modal','modal1', button);
+    },
+    resetModal() {
+      this.modalDetails.data = '';
+      this.modalDetails.index = '';
+    },
+    onFiltered(filteredItems) {
+      // Trigger pagination to update the number of buttons/pages due to filtering
+      this.totalRows = filteredItems.length;
+      this.currentPage = 1;
+    }
+  }
+}
+</script>
+
+<!-- table-complete-1.vue -->
+```

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -418,7 +418,7 @@
                     }
                     // Label shortcut
                     if (typeof fields[k] === 'string') {
-                        fields[k] =  { label: fields[k] }
+                        fields[k] =  { label: startCase(k) }
                     }
                 })
 

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -498,7 +498,7 @@
         },
         methods: {
             keys,
-            fieldClass(field, key) {
+            fieldClass (field, key) {
                 return [
                     field.sortable ? 'sorting' : '',
                     (field.sortable && this.localSortBy === key) ? 'sorting_' + (this.localSortDesc ? 'desc' : 'asc') : '',
@@ -507,7 +507,7 @@
                     field.thClass ? field.thClass : ''
                 ];
             },
-            tdClass(field, item, key) {
+            tdClass (field, item, key) {
                 let cellVariant = '';
                 if (item._cellVariants && item._cellVariants[key]) {
                     cellVariant = (this.inverse ? 'bg-' : 'table-') + item._cellVariants[key];
@@ -519,12 +519,12 @@
                     field.tdClass ? field.tdClass : ''
                 ];
             },
-            rowClass(item) {
+            rowClass (item) {
                 return [
                     item._rowVariant ? ((this.inverse ? 'bg-' : 'table-') + item._rowVariant) : ''
                 ];
             },
-            rowClicked(e, item, index) {
+            rowClicked (e, item, index) {
                 if (this.computedBusy) {
                     // If table is busy (via provider) then don't propagate
                     e.preventDefault();
@@ -533,7 +533,7 @@
                 }
                 this.$emit('row-clicked', item, index, e);
             },
-            rowDblClicked(e, item, index) {
+            rowDblClicked (e, item, index) {
                 if (this.computedBusy) {
                     // If table is busy (via provider) then don't propagate
                     e.preventDefault();
@@ -542,7 +542,7 @@
                 }
                 this.$emit('row-dblclicked', item, index, e);
             },
-            rowHovered(e, item, index) {
+            rowHovered (e, item, index) {
                 if (this.computedBusy) {
                     // If table is busy (via provider) then don't propagate
                     e.preventDefault();
@@ -551,7 +551,7 @@
                 }
                 this.$emit('row-hovered', item, index, e);
             },
-            headClicked(e, field, key) {
+            headClicked (e, field, key) {
                 if (this.computedBusy) {
                     // If table is busy (via provider) then don't propagate
                     e.preventDefault();
@@ -581,19 +581,19 @@
                     this.$emit('sort-changed', this.context);
                 }
             },
-            refresh() {
+            refresh () {
                 // Expose refresh method
                 if (this.hasProvider) {
                     this._providerUpdate();
                 }
             },
-            _providerSetLocal(items) {
+            _providerSetLocal (items) {
                 this.localItems = (items && items.length > 0) ? items.slice() : [];
                 this.localBusy = false;
                 this.$emit('refreshed');
                 this.emitOnRoot('table::refreshed', this.id);
             },
-            _providerUpdate() {
+            _providerUpdate () {
                 // Refresh the provider items
                 if (this.computedBusy || !this.hasProvider) {
                     // Don't refresh remote data if we are 'busy' or if no provider
@@ -606,10 +606,7 @@
                 // Call provider function with context and optional callback
                 const data = this.items(this.context, this._providerSetLocal);
 
-                if (!data) {
-                    // Provider is using callback
-                    return;
-                } else if (data.then && typeof data.then === 'function') {
+                if (data) if (data.then && typeof data.then === 'function') {
                     // Provider returned Promise
                     data.then(items => {
                         this._providerSetLocal(items);
@@ -619,17 +616,14 @@
                     this._providerSetLocal(data);
                 }
             },
-            hasFormatter(field) {
-                return field.formatter && ((typeof (field.formatter) === 'function') || (typeof (field.formatter) === 'string'));
-            },
-            callFormatter(item, key, field) {
+            hasFormatter: (field) => field.formatter && ((typeof (field.formatter) === 'function') || (typeof (field.formatter) === 'string')),
+            callFormatter (item, key, field) {
                 if (field.formatter && (typeof (field.formatter) === 'function'))
                     return field.formatter(item[key], key, item);
 
                 if (field.formatter && (typeof (this.$parent[field.formatter]) === 'function'))
                     return this.$parent[field.formatter](item[key], key, item);
             }
-
         }
     };
 </script>

--- a/lib/utils/identity.js
+++ b/lib/utils/identity.js
@@ -1,3 +1,3 @@
 export default function identity(x) {
-    return x
+    return x;
 }

--- a/lib/utils/lowerFirst.js
+++ b/lib/utils/lowerFirst.js
@@ -1,7 +1,7 @@
 /**
  * @param {string} str
  */
-export default function upperFirst(str) {
+export default function lowerFirst(str) {
     if (typeof str !== "string") {
         str = String(str);
     }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "jest": "^20.0.4",
     "jest-vue-preprocessor": "^1.1.0",
     "lodash": "latest",
+    "lodash.startcase": "^4.4.0",
     "markdown-loader": "^2.0.1",
     "marked": "^0.3.6",
     "nuxt": "1.0.0-rc6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4278,6 +4278,10 @@ lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
 
+lodash.startcase@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
+
 lodash.template@^4.0.2, lodash.template@^4.2.4, lodash.template@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"


### PR DESCRIPTION
While working on tables on some quick cases, the current API is little hard to use and some times there are really some extra works for easy tasks (like changing column titles for each field or even when need a quick representation of data) The solution was using computed props.

Example of new usage:
```vue
<template>
  <b-table :items="logs"/>
</templte>

<script>
export default {
 data: () => ({
  logs: [
    {log_type: 'CHECK_IN', deviceId: '123', user: 'A'},
    {log_type: 'CHECK_OUT', deviceId: '44', user: 'B'},
    {log_type: 'CHECK_IN', deviceId: '3343434', user: 'C'}
  ]
  })
}
```

Renders:
![image](https://user-images.githubusercontent.com/5158436/29588234-f6e0bf66-87a5-11e7-9836-b2a676142608.png)

Actually, with example above, fields is auto sampled from first record and it's column names are auto formatted using [startCase](https://lodash.com/docs/4.17.4#startCase)

Fields property can now be either an array (of needed fields) or a more flexible object:

```js
// will render two columns "Log Type" and "User Name"
let fieldsArray = [ 'log_type', 'user_name' ]

fields = {
 // Old style style possible
 a: { label: 'Foo' },
 // Auto generate column with label "B ID"
 bId: true,
 // Hide c 
 c: false, 
 // Column "User Name" with username value
 userName: r => r && r.user && r.user.username 
}
```

#### TODO

- [x] Currently, somewhere callFormatter is being called with null value

- [x] We may also simplify at least first example in Table docs maybe moving current main example to the end as "Advanced Usage"

- [x] There is a hidden performance typo currently in Table implementation of `hasFormatter` and `callFormatter`
Adding `console.log` or this to one of those functions for debug:
```js
if(!window.hasFormatter) window.hasFormatter = {} ; if(!window.hasFormatter[field])window.hasFormatter[field]=0 ; window.hasFormatter[field]++ 
```
shows a huge number of hasFormatter calls:
```
window.hasFormatter
02:02:26.058 {[object Object]: 312}
```
