### PR TITLE
fix(dropdowns): Allow gracefull fallback if Popper.js not defined

### DIFF
--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -4,6 +4,7 @@ import clickoutMixin from './clickout';
 import listenOnRootMixin from './listen-on-root';
 import { from as arrayFrom } from '../utils/array';
 import { assign } from '../utils/object';
+import { warn } from '../utils/warn';
 
 // Determine if an HTML element is visible - Faster than CSS check
 const isVisible = el => el && (el.offsetWidth > 0 || el.offsetHeight > 0);
@@ -117,6 +118,11 @@ export default {
     },
     computed: {
         toggler: () => this.$refs.toggle.$el || this.$refs.toggle
+    },
+    mounted() {
+        if (typeof Popper === 'undefiend') {
+            warn(`<${this.$options._componentTag}>: Popper.js not found! Propper positioning requires Popper.js`);
+        }
     },
     destroyed() {
         if (this._popper) {

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -136,19 +136,22 @@ export default {
             // Ensure other menus are closed
             this.emitOnRoot('shown::dropdown', this);
 
-            // Are we in a navbar ?
-            if (this.inNavbar === null && this.isNav) {
-                this.inNavbar = Boolean(this.$el.closest('.navbar'));
-            }
-            // for dropup with alignment we use the parent element as popper container
-            let element = ((this.dropup && this.right) || this.split || this.inNavbar) ?
-                this.$el :
-                this.$refs.toggle;
-            // Make sure we have a reference to an element, not component.
-            element = element.$el || element;
+            // If popper not installed, then fallback gracefully to dropdown only with left alignment
+            if (typeof Popper !== 'undefined') {
+                // Are we in a navbar ?
+                if (this.inNavbar === null && this.isNav) {
+                    this.inNavbar = Boolean(this.$el.closest('.navbar'));
+                }
+                // for dropup with alignment we use the parent element as popper container
+                let element = ((this.dropup && this.right) || this.split || this.inNavbar) ?
+                    this.$el :
+                    this.$refs.toggle;
+                // Make sure we have a reference to an element, not a component!
+                element = element.$el || element;
 
-            // Instantiate popper.js
-            this._popper = new Popper(element, this.$refs.menu, this.getPopperConfig());
+                // Instantiate popper.js
+                this._popper = new Popper(element, this.$refs.menu, this.getPopperConfig());
+            }
 
             this.setTouchStart(true);
             this.$emit('shown');

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -4,7 +4,7 @@ import clickoutMixin from './clickout';
 import listenOnRootMixin from './listen-on-root';
 import { from as arrayFrom } from '../utils/array';
 import { assign } from '../utils/object';
-import { warn } from '../utils/warn';
+import warn from '../utils/warn';
 
 // Determine if an HTML element is visible - Faster than CSS check
 const isVisible = el => el && (el.offsetWidth > 0 || el.offsetHeight > 0);

--- a/lib/mixins/dropdown.js
+++ b/lib/mixins/dropdown.js
@@ -78,7 +78,7 @@ export default {
             type: Boolean,
             default: false
         },
-        popperOps: {
+        popperOpts: {
             type: Object,
             default: () => {}
         }
@@ -120,7 +120,7 @@ export default {
         toggler: () => this.$refs.toggle.$el || this.$refs.toggle
     },
     mounted() {
-        if (typeof Popper === 'undefiend') {
+        if (typeof Popper === 'undefined') {
             warn(`<${this.$options._componentTag}>: Popper.js not found! Propper positioning requires Popper.js`);
         }
     },
@@ -143,7 +143,7 @@ export default {
             this.emitOnRoot('shown::dropdown', this);
 
             // If popper not installed, then fallback gracefully to dropdown only with left alignment
-            if (typeof Popper !== 'undefined') {
+            if (typeof Popper === 'function') {
                 // Are we in a navbar ?
                 if (this.inNavbar === null && this.isNav) {
                     this.inNavbar = Boolean(this.$el.closest('.navbar'));
@@ -207,6 +207,7 @@ export default {
             return assign(popperConfig, this.popperOpts || {});
         },
         setTouchStart(on) {
+
             /*
              If this is a touch-enabled device we add extra
              empty mouseover listeners to the body's immediate children;


### PR DESCRIPTION
IF Popper.js not found, fallback gracefully to dropdown that is always dropdown, left aligned, with no positioning available