### PR TITLE
feat(carousel): Use b-img component and id Mixin

### DIFF
--- a/docs/components/carousel/README.md
+++ b/docs/components/carousel/README.md
@@ -2,7 +2,7 @@
 
 >  The carousel is a slideshow for cycling through a series of content, built with CSS 3D transforms.
 It works with a series of images, text, or custom markup. It also includes support for previous/next
-controls and indicators.
+controls and indicators. Please be aware that nested carousels are **not** supported.
 
 ```html
 <template>
@@ -13,6 +13,8 @@ controls and indicators.
                 indicators
                 background="#ababab"
                 :interval="4000"
+                img-width="1024"
+                img-height="480"
                 v-model="slide"
                 @slide="onSlide"
                 @slid="onSlid"
@@ -21,27 +23,27 @@ controls and indicators.
       <!-- Text slides with image -->
       <b-carousel-slide caption="First slide"
                         text="Nulla vitae elit libero, a pharetra augue mollis interdum."
-                        img="https://lorempixel.com/1024/480/technics/2/"
+                        img-src="https://lorempixel.com/1024/480/technics/2/"
       ></b-carousel-slide>
 
       <!-- Slides with custom text -->
-      <b-carousel-slide img="https://lorempixel.com/1024/480/technics/4/">
+      <b-carousel-slide img-src="https://lorempixel.com/1024/480/technics/4/">
         <h1>Hello world!</h1>
       </b-carousel-slide>
 
       <!-- Slides with image only -->
-      <b-carousel-slide img="https://lorempixel.com/1024/480/technics/8/">
+      <b-carousel-slide img-src="https://lorempixel.com/1024/480/technics/8/">
       </b-carousel-slide>
 
       <!-- Slides with img slot -->
+      <!-- Note the classes .d-block and .img-fluid to prevent browser default image alignment -->
       <b-carousel-slide>
-        <img slot="img" class="d-block img-fluid"
+        <img slot="img" class="d-block img-fluid w-100" width="1024" height="480"
              src="https://lorempixel.com/1024/480/technics/5/" alt="image slot">
       </b-carousel-slide>
 
-      <!-- Slide with blank fluid image to maintain aspect ratio -->
-      <b-carousel-slide caption="Blank Image">
-        <b-img slot="img" width="1024" height="480" fluid blank alt="blank img"></b-img>
+      <!-- Slide with blank fluid image to maintain slide aspect ratio -->
+      <b-carousel-slide caption="Blank Image" img-blank img-alt="Blank image">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
           eros felis, tincidunt a tincidunt eget, convallis vel est. Ut pellentesque
@@ -78,16 +80,32 @@ export default {
 <!-- carousel-1.vue -->
 ```
 
+
 ### Sizing
 Carousels don’t automatically normalize slide dimensions. As such, you may need to use
 additional utilities or custom styles to appropriately size content. When using images
 in each slide, ensure they all have the same dimensions (or aspect ratio).
+
+When using `img-src` or `img-blank` on `<b-carousel-slide>`, you can set the image
+width and height via the `img-width` and `img-height` props on `<b-carousel>` and
+have these values automatically applied to each `carousel-slide` image.
+
+Note that images will stil be respnsive and automatically grow or shrink to fit
+within the width of its parent container.
+
+Internally, `<b-carousel-slide>` uses the [`<b-img>`](/docs/components/img)
+component to render the images. The `img-*` props map to the corresponsing props
+available to `<b-img>`.
 
 
 ### Interval
 Carousel defults to an interval of `5000`ms (5 seconds). To pause the caurousel from
 auto sliding, set the `interval` prop to `0`. To restart a paused carousel, set the
 `interval` back to the number of ms.
+
+In browsers where the [Page Visibility API](https://www.w3.org/TR/page-visibility/)
+is supported, the carousel will avoid sliding when the webpage is not visible to
+the user (such as when the browser tab is inactive, the browser window is minimized, etc.).
 
 
 ### Controls and Indicators
@@ -104,6 +122,9 @@ Programaticaly xontrol which slide is showing via `v-model` (which binds to the
 
 
 ### Accessibility
+Carousels are generally not fully compliant with accessibility standards, although
+we try to make them as accessible as possible.
+
 By providing a document unique value via the `id` prop, `<b-carousel>` will enable
 accessibility features.  It is highly recommended to always add an ID to all components.
 

--- a/docs/components/carousel/README.md
+++ b/docs/components/carousel/README.md
@@ -90,7 +90,7 @@ When using `img-src` or `img-blank` on `<b-carousel-slide>`, you can set the ima
 width and height via the `img-width` and `img-height` props on `<b-carousel>` and
 have these values automatically applied to each `carousel-slide` image.
 
-Note that images will stil be respnsive and automatically grow or shrink to fit
+Note that images will still be responsive and automatically grow or shrink to fit
 within the width of its parent container.
 
 Internally, `<b-carousel-slide>` uses the [`<b-img>`](/docs/components/img)
@@ -99,7 +99,7 @@ available to `<b-img>`.
 
 
 ### Interval
-Carousel defults to an interval of `5000`ms (5 seconds). To pause the caurousel from
+Carousel defaults to an interval of `5000`ms (5 seconds). To pause the carousel from
 auto sliding, set the `interval` prop to `0`. To restart a paused carousel, set the
 `interval` back to the number of ms.
 
@@ -117,8 +117,8 @@ Both indicators and controls can be set at the same time or independently.
 
 
 ### V-model support
-Programaticaly xontrol which slide is showing via `v-model` (which binds to the
-`value` prop). Note slides are indexed starting at `0`.
+Programmaticaly control which slide is showing via `v-model` (which binds to the
+`value` prop). Note, that slides are indexed starting at `0`.
 
 
 ### Accessibility
@@ -128,5 +128,5 @@ we try to make them as accessible as possible.
 By providing a document unique value via the `id` prop, `<b-carousel>` will enable
 accessibility features.  It is highly recommended to always add an ID to all components.
 
-All carousel controls and indicateors have aria labels.  These can be customized by
+All carousel controls and indicators have aria labels.  These can be customized by
 setting the various `label-*` props.

--- a/docs/components/carousel/README.md
+++ b/docs/components/carousel/README.md
@@ -39,13 +39,13 @@ controls and indicators.
              src="https://lorempixel.com/1024/480/technics/5/" alt="image slot">
       </b-carousel-slide>
 
-      <!-- Slide with blank image to maintain aspect ratio -->
-      <b-carousel-slide caption="Blank Image" :img="blankImg(1024,480)">
+      <!-- Slide with blank fluid image to maintain aspect ratio -->
+      <b-carousel-slide caption="Blank Image">
+        <b-img slot="img" width="1024" height="480" fluid blank alt="blank img"></b-img>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
           eros felis, tincidunt a tincidunt eget, convallis vel est. Ut pellentesque
-          ut lacus vel interdum. Nulla bibendum tincidunt erat, sed tincidunt
-          magna finibus ac.
+          ut lacus vel interdum.
         </p>
       </b-carousel-slide>
 
@@ -66,13 +66,6 @@ export default {
     sliding: null
   },
   methods: {
-    blankImg(x, y) {
-      // Return a blank SVG image with specified width and height
-      // Handy for maintaining aspect ratio for text only slides
-      return "data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D" +
-             "'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' " +
-             "viewBox%3D'0 0 " + x + " " + y + "'%2F%3E";
-    },
     onSlide(slide) {
         this.sliding = true;
     },

--- a/docs/components/carousel/README.md
+++ b/docs/components/carousel/README.md
@@ -16,8 +16,8 @@ controls and indicators. Please be aware that nested carousels are **not** suppo
                 img-width="1024"
                 img-height="480"
                 v-model="slide"
-                @slide="onSlide"
-                @slid="onSlid"
+                @sliding-start="onSlideStart"
+                @sliding-end="onSlideEnd"
     >
 
       <!-- Text slides with image -->
@@ -68,10 +68,10 @@ export default {
     sliding: null
   },
   methods: {
-    onSlide(slide) {
+    onSlideStart(slide) {
         this.sliding = true;
     },
-    onSlid(slide) {
+    onSlideEnd(slide) {
         this.sliding = false;
     }
   }

--- a/docs/components/carousel/meta.json
+++ b/docs/components/carousel/meta.json
@@ -4,7 +4,7 @@
   "components": ["bCarouselSlide"],
   "events": [
     {
-      "event": "slide",
+      "event": "sliding-start",
       "description": "Emitted when transitioning to a new slide has started.",
       "args": [
         {
@@ -14,8 +14,8 @@
       ]
     },
     {
-      "event": "slid",
-      "description": "Emitted when transitioning to a new slide has finished.",
+      "event": "sliding-end",
+      "description": "Emitted when transitioning to a new slide has ended.",
       "args": [
         {
           "arg": "slide",

--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -5,7 +5,7 @@
          :style="{background,height}"
     >
         <slot name="img">
-            <img class="d-block img-fluid" v-if="img" :src="img" :alt="imgAlt">
+            <b-img v-if="img" fluid-grow :src="img" :alt="imgAlt"></b-img>
         </slot>
         <div :is="contentTag" :class="contentClasses">
             <h3 v-if="caption" :is="captionTag" v-html="caption"></h3>
@@ -16,7 +16,10 @@
 </template>
 
 <script>
+    import bImg from './img';
+
     export default {
+        components: { bImg },
         props: {
             id: {
                 type: String

--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -5,7 +5,15 @@
          :style="{background,height}"
     >
         <slot name="img">
-            <b-img v-if="img" fluid-grow :src="img" :alt="imgAlt"></b-img>
+            <b-img v-if="imgSrc"
+                   fluid-grow
+                   block
+                   :blank="imgBlank"
+                   :blank-color="imgBlankColor"
+                   :src="imgSrc"
+                   :width="computedWidth"
+                   :height="computedHeight"
+                   :alt="imgAlt"></b-img>
         </slot>
         <div :is="contentTag" :class="contentClasses">
             <h3 v-if="caption" :is="captionTag" v-html="caption"></h3>
@@ -17,6 +25,7 @@
 
 <script>
     import bImg from './img';
+    import { warn } from '../utils';
 
     export default {
         components: { bImg },
@@ -24,11 +33,37 @@
             id: {
                 type: String
             },
-            img: {
+            imgSrc: {
+                type: String
+                default() {
+                    if (this && this.src) {
+                        // Deprecate src
+                        warn("b-carousel-slide: prop 'src' has been deprecated. Use 'img-src' instead");
+                        return this.src;
+                    }
+                    return null;
+                }
+            },
+            src: {
+                // Deprecated: use img-src instead
                 type: String
             },
             imgAlt: {
                 type: String
+            },
+            imgWidth: {
+                type: [Number, String]
+            },
+            imgHeight: {
+                type: [Number, String]
+            },
+            imgBlank: {
+                type: Boolean,
+                default: false
+            },
+            imgBlankColor: {
+                type: String
+                default: 'transparent'
             },
             contentVisibleUp: {
                 type: String
@@ -65,6 +100,14 @@
                     this.contentVisibleUp ? 'd-none' : '',
                     this.contentVisibleUp ? `d-${this.contentVisibleUp}-block` : ''
                 ];
+            },
+            computedWidth() {
+                // Use local width, or try parent width
+                return this.imgWidth || this.$parent.imgWidth;
+            },
+            computedHeight() {
+                // Use local height, or try parent height
+                return this.imgHeight || this.$parent.imgHeight;
             }
         }
     };

--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="carousel-item"
          role="listitem"
-         :id="id || null"
+         :id="safeId()"
          :style="{background,height}"
     >
         <slot name="img">
@@ -26,13 +26,12 @@
 <script>
     import bImg from './img';
     import { warn } from '../utils';
+    import { id } from '../mixins';
 
     export default {
         components: { bImg },
+        mixins: [ id ],
         props: {
-            id: {
-                type: String
-            },
             imgSrc: {
                 type: String,
                 default() {

--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -62,7 +62,7 @@
                 default: false
             },
             imgBlankColor: {
-                type: String
+                type: String,
                 default: 'transparent'
             },
             contentVisibleUp: {

--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -34,7 +34,7 @@
                 type: String
             },
             imgSrc: {
-                type: String
+                type: String,
                 default() {
                     if (this && this.src) {
                         // Deprecate src

--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -5,7 +5,7 @@
          :style="{background}"
     >
         <slot name="img">
-            <b-img v-if="imgSrc"
+            <b-img v-if="imgSrc || imgBlank"
                    fluid-grow
                    block
                    :blank="imgBlank"

--- a/lib/components/carousel-slide.vue
+++ b/lib/components/carousel-slide.vue
@@ -2,7 +2,7 @@
     <div class="carousel-item"
          role="listitem"
          :id="safeId()"
-         :style="{background,height}"
+         :style="{background}"
     >
         <slot name="img">
             <b-img v-if="imgSrc"
@@ -26,11 +26,11 @@
 <script>
     import bImg from './img';
     import { warn } from '../utils';
-    import { id } from '../mixins';
+    import { idMixin } from '../mixins';
 
     export default {
         components: { bImg },
-        mixins: [ id ],
+        mixins: [ idMixin ],
         props: {
             imgSrc: {
                 type: String,
@@ -86,9 +86,6 @@
                 default: "p"
             },
             background: {
-                type: String
-            },
-            height: {
                 type: String
             }
         },

--- a/lib/components/carousel.vue
+++ b/lib/components/carousel.vue
@@ -193,7 +193,7 @@
                 // Don't change slide while transitioning, wait until transition is done
                 if (this.isSliding) {
                     // Schedule slide after sliding complete
-                    this.$once('slid', () => this.setSlide(slide));
+                    this.$once('sliding-end', () => this.setSlide(slide));
                     return;
                 }
 
@@ -324,7 +324,7 @@
 
                 // Start animating
                 this.isSliding = true;
-                this.$emit('slide', val);
+                this.$emit('sliding-start', val);
 
                 // Update v-model
                 this.$emit('input', this.index);
@@ -378,7 +378,7 @@
 
                     this.isSliding = false;
                     // Notify ourselves that we're done sliding (slid)
-                    this.$nextTick(() => this.$emit('slid', val));
+                    this.$nextTick(() => this.$emit('sliding-end', val));
                 };
 
                 // Clear transition classes after transition ends

--- a/lib/components/carousel.vue
+++ b/lib/components/carousel.vue
@@ -2,7 +2,7 @@
     <div class="carousel slide"
          role="region"
          :id="id || null"
-         :style="{background,height}"
+         :style="{background}"
          :aria-busy="isSliding ? 'true' : 'false'"
          @mouseenter="pause"
          @mouseleave="start"
@@ -155,8 +155,13 @@
                 type: Boolean,
                 default: false
             },
-            height: {
-                type: String
+            imgWidth: {
+                // Sniffed by carousel-slide
+                type: [Number, String]
+            },
+            imgHeight: {
+                // Sniffed by carousel-slide
+                type: [Number, String]
             },
             background: {
                 type: String

--- a/lib/components/img.js
+++ b/lib/components/img.js
@@ -44,14 +44,13 @@ export const props = {
     },
     fluidGrow: {
         // Gives fluid images class `w-100` to make them grow to fit container
-        // Automatically adds d-block
         type: Boolean,
         default: false
     },
     rounded: {
         // rounded can be:
-        //   'false': no rounding of corners
-        //   'true': slightly rounded corners
+        //   false: no rounding of corners
+        //   true: slightly rounded corners
         //   'top': top corners rounded
         //   'right': right corners rounded
         //   'bottom': bottom corners rounded

--- a/lib/components/img.js
+++ b/lib/components/img.js
@@ -34,12 +34,17 @@ export const props = {
         type: [Number, String],
         default: null
     },
+    block: {
+        type: Boolean,
+        default: false
+    },
     fluid: {
         type: Boolean,
         default: false
     },
     fluidGrow: {
         // Gives fluid images class `w-100` to make them grow to fit container
+        // Automatically adds d-block
         type: Boolean,
         default: false
     },
@@ -90,7 +95,7 @@ export default {
         let width = Boolean(parseInt(props.width,10)) ? parseInt(props.width,10) : null;
         let height = Boolean(parseInt(props.height,10)) ? parseInt(props.height,10) : null;
         let align = null;
-        let block = null;
+        let block = props.block;
         if (props.blank) {
             if (!height && Boolean(width)) {
                 height = width;


### PR DESCRIPTION
Incorporate the new `<b-img>` component into `<carousel-slide>`, to allow for easy blank image creation (for maintaining a text only slides aspect ratio)

Incorporate the `id` mixin to auto ID the carousel client side (on mount) if no IDs are provided.

Additional props for setting image sizes.

Updated docs