### PR TITLE
fix(tab): typo aria-lablelledby

### DIFF
--- a/lib/components/tab.vue
+++ b/lib/components/tab.vue
@@ -6,7 +6,7 @@
                    :class="['tab-pane', {show, fade, disabled, active: localActive}]"
                    :aria-hidden="localActive ? 'false' : 'true'"
                    :aria-expanded="localActive ? 'true' : 'false'"
-                   :aria-lablelledby="controlledBy || null"
+                   :aria-labelledby="controlledBy || null"
                    v-if="localActive || !lazy"
                    v-show="localActive || lazy"
                    ref="panel"


### PR DESCRIPTION
There is a small type for the attribute `:aria-labelledby`.