### PR TITLE
fix(scrollspy): Undefined value during bind()

### DIFF
--- a/lib/directives/scrollspy.js
+++ b/lib/directives/scrollspy.js
@@ -533,59 +533,57 @@ ScrollSpy.prototype._setParentsSiblingActiveState = function (element, selector,
     }
 };
 
+function addBVSS(el, binding, vnode) {
+    if (!el[BVSS]) {
+        el[BVSS] = new ScrollSpy(el, binding, vnode);
+        el[BVSS].listen();
+    } else {
+        el[BVSS].updateConfig(binding).listen();
+    }
+    return el[BVSS];
+}
+
+function removeBVSS(el) {
+    if (el[BVSS]) {
+        el[BVSS].unListen().dispose();
+        el[BVSS] = null;
+    }
+}
+
 /*
  * Export our directive
  */
 
 export default {
     bind(el, binding, vnode) {
-        if (isServer || el[BVSS]) {
+        if (isServer) {
             return;
         }
-        el[BVSS] = new ScrollSpy(el, binding);
+        addBVSS(el, binding, vnode).scheduleRefresh();
     },
     inserted(el, binding, vnode) {
         if (isServer) {
             return;
         }
-        if (!el[BVSS]) {
-            el[BVSS] = new ScrollSpy(el, binding, vnode);
-            el[BVSS].listen();
-        } else {
-            el[BVSS].updateConfig(binding).listen();
-        }
-        el[BVSS].refresh().process().scheduleRefresh();
+        addBVSS(el, binding, vnode).refresh().process().scheduleRefresh();
     },
     update(el, binding, vnode) {
         if (isServer) {
             return;
         }
-        if (!el[BVSS]) {
-            el[BVSS] = new ScrollSpy(el, binding, vnode);
-            el[BVSS].listen();
-        } else {
-            el[BVSS].updateConfig(binding);
-        }
-        el[BVSS].refresh().process().scheduleRefresh();
+        addBVSS(el, binding, vnode).refresh().process().scheduleRefresh();
     },
     componentUpdated(el, binding, vnode) {
         if (isServer) {
             return;
         }
-        if (!el[BVSS]) {
-            el[BVSS] = new ScrollSpy(el, binding, vnode);
-            el[BVSS].listen();
-        } else {
-            el[BVSS].updateConfig(binding);
-        }
-        el[BVSS].refresh().process().scheduleRefresh();
+        addBVSS(el, binding, vnode).refresh().process().scheduleRefresh();
     },
     unbind(el) {
-        if (isServer || !el[BVSS]) {
+        if (isServer) {
             return;
         }
         // Remove scroll event listener on scrollElId
-        el[BVSS].unListen().dispose();
-        el[BVSS] = null;
+        removeBVSS(el);
     }
 };


### PR DESCRIPTION
Fixes missing reference to `vnode` on initial bind()

Addresses issue #963 
