### PR TITLE
fix(tooltip+popover): Hide original element title attribute

### DIFF
--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -151,7 +151,10 @@ class ToolTip {
         if (config.content && typeof config.content === 'number') {
             updatedConfig.content = config.content.toString();
         }
-
+        
+        // Hide element original title if needed
+        this.fixTitle();
+        // Update the config
         this.$config = updatedConfig;
         // Stop/Restart listening
         this.unListen();
@@ -210,6 +213,7 @@ class ToolTip {
 
         // Build tooltip element (also sets this.$tip)
         const tip = this.getTipElement();
+        this.fixTitle();
         this.setContent(tip);
         if (!this.isWithContent(tip)) {
             // if No content, dont bother showing
@@ -611,10 +615,11 @@ class ToolTip {
     }
 
     fixTitle() {
-        const titleType = typeof this.$element.getAttribute('data-original-title');
-        if (this.$element.getAttribute('title') || titleType !== 'string') {
-            this.$element.setAttribute('data-original-title', this.$element.getAttribute('title') || '');
-            this.$element.setAttribute('title', '');
+        const el = this.$element;
+        const titleType = typeof el.getAttribute('data-original-title');
+        if (el.getAttribute('title') || titleType !== 'string') {
+            el.setAttribute('data-original-title', el.getAttribute('title') || '');
+            el.setAttribute('title', '');
         }
     }
 


### PR DESCRIPTION
Addresses issue #955 
