### PR TITLE
feat(tooltips+popovers): Automatically hide when trigger element is no longer visible

### DIFF
--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -85,6 +85,11 @@ function elVisible(el) {
     return el && (el.offsetParent === null || !(el.offsetWidth > 0 || el.offsetHeight > 0));
 }
 
+// Determine if an element is disabled
+function elDisabled(el) {
+    return !el || el.disabled || el.classList.contains('disabled') || Boolean(el.getAttribute('disabled'));
+}
+
 /*
  * Polyfill for Element.closest() for IE :(
  * https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
@@ -547,7 +552,8 @@ class ToolTip {
     listen() {
         const triggers = this.$config.trigger.trim().split(/\s+/);
 
-        // Using "this" as the handler will get automagically directed to this.handleEvent
+        // Using 'this' as the handler will get automagically directed to this.handleEvent
+        // And maintain our binding to 'this'
         triggers.forEach(trigger => {
             if (trigger === 'click') {
                 this.$element.addEventListener('click', this);
@@ -583,6 +589,11 @@ class ToolTip {
         // This special method allows us to use "this" as the event handlers
         if (!e.target || e.target !== this.$element) {
             // If this event isn't for us, then just return
+            return;
+        }
+        if (elDisabled(this.$element)) {
+            // If disabled, don't do anything. Note: if tip is shown before element gets
+            // disabled, then tip not close until no longer disabled or forcefully closed.
             return;
         }
         if (e.type === 'click') {

--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -80,6 +80,11 @@ function generateId(name) {
     return `__BV_${name}_${NEXTID++}__`;
 }
 
+// Determine if an element is visible. Faster than CSS checks
+function elVisible(el) {
+    return el && (el.offsetParent === null || !(el.offsetWidth > 0 || el.offsetHeight > 0));
+}
+
 /*
  * Polyfill for Element.closest() for IE :(
  * https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
@@ -109,6 +114,7 @@ class ToolTip {
         // New tooltip object
         this.$fadeTimeout = null;
         this.$hoverTimeout = null;
+        this.$visibleInterval = null;
         this.$hoverState = '';
         this.$activeTrigger = {};
         this.$popper = null;
@@ -164,6 +170,8 @@ class ToolTip {
 
     // Destroy this instance
     destroy() {
+        clearInterval(this.$visibleInterval);
+        this.$visibleInterval = null
         clearTimeout(this.$hoverTimeout);
         this.$hoverTimeout = null;
         clearTimeout(this.$fadeTimeout);
@@ -278,16 +286,40 @@ class ToolTip {
         tip.classList.add(ClassName.SHOW);
         this.setOnTouchStartListener(true);
 
+        // Periodically check to make sure $element is visible
+        // For handling when tip is in <keepalive>, tabs, carousel, etc
+        this.$visibleInterval = setInterval(() => {
+            if (this.$tip && !elVisible(this.$element) && this.$tip.classList.contains(ClassName.SHOW)) {
+                // Element is no longer visible, so force-hide the tooltip
+                this.forceHide();
+            }
+        }, 100);
+
+        // Start the transition/animation
         this.transitionOnce(tip, complete);
     }
 
+    // force hide of tip (internal method)
+    forceHide() {
+        const tip = this.getTipElement();
+        // Remove animation for quicker hide
+        this.$tip.classList.remove(ClassName.FADE);
+        // Clear any hover enter/leave event
+        clearTimeout(this.$hoverTimeout);
+        this.$hoverTimeout = null;
+        this.$hoverState = '';
+        // Hide the tip
+        this.hide(null, true);
+    }
+
     // Hide tooltip
-    hide(callback) {
+    hide(callback, force) {
         const tip = this.getTipElement();
 
         // Create a canelable BvEvent
         const hideEvt = new BvEvent('hide', {
-            cancelable: true,
+            // We disable cancelling if force is true
+            cancelable: !Boolean(force),
             target: this.$element,
             relatedTarget: tip
         });
@@ -297,6 +329,10 @@ class ToolTip {
             return;
         }
 
+        // Stop checking for visibility of element.
+        clearInterval(this.$visibleInterval);
+        this.$visibleInterval = null;
+
         // Transitionend Callback
         const complete = () => {
             if (this.$hoverState !== HoverState.SHOW && tip.parentNode) {
@@ -305,7 +341,7 @@ class ToolTip {
             }
             this.removeAriaDescribedby();
             this.removePopper();
-            // Force a re-compile of tip in case template has changed.
+            // Force a re-compile (next time shown) of tip in case template has changed.
             this.$tip = null;
             if (callback) {
                 callback();
@@ -327,6 +363,7 @@ class ToolTip {
         this.$activeTrigger.focus = false;
         this.$activeTrigger.hover = false;
 
+        // Start the hide transition
         this.transitionOnce(tip, complete);
 
         this.$hoverState = '';
@@ -565,8 +602,8 @@ class ToolTip {
                     if (newVal === oldVal) {
                         return;
                     }
-                    // If route has changed, we hide the tooltip/popover
-                    this.hide();
+                    // If route has changed, we force hide the tooltip/popover
+                    this.forceHide();
                 });
             }
         } else {
@@ -588,11 +625,11 @@ class ToolTip {
         if (this.$root) {
             if (on) {
                 MODAL_CLOSE_EVENT.forEach(evtName => {
-                    this.$root.$on(evtName, this.hide.bind(this));
+                    this.$root.$on(evtName, this.forceHide.bind(this));
                 });
             } else {
                 MODAL_CLOSE_EVENT.forEach(evtName => {
-                    this.$root.$off(evtName, this.hide.bind(this));
+                    this.$root.$off(evtName, this.forceHide.bind(this));
                 });
             }
         }

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -84,7 +84,7 @@
                 this.popOver.updateConfig(this.getConfig());
             }
         },
-        destroyed() {
+        beforeDestroyed() {
             if (this.popOver) {
                 // Destroy the popover
                 this.popOver.destroy();

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -104,7 +104,7 @@
                     // offset can be a css distance string. if no units provided then pixels are assumed
                     offset: this.offset || 0,
                     animation: Boolean(this.noFade),
-                    triggers: isArray(this.triggers) ? this.triggers.join(' ') : this.triggers
+                    trigger: isArray(this.triggers) ? this.triggers.join(' ') : this.triggers
                 };
             }
         },

--- a/lib/components/tooltip.vue
+++ b/lib/components/tooltip.vue
@@ -78,7 +78,7 @@
                 this.toolTip.updateConfig(this.getConfig());
             }
         },
-        destroyed() {
+        beforeDestroy() {
             if (this.toolTip) {
                 this.toolTip.destroy();
                 this.tooltip = null;

--- a/lib/components/tooltip.vue
+++ b/lib/components/tooltip.vue
@@ -95,7 +95,7 @@
                     // Offset can be css distance. if no units, pixels are assumed
                     offset: this.offset || 0,
                     animation: Boolean(this.noFade),
-                    triggers: isArray(this.triggers) ? this.triggers.join(' ') : this.triggers
+                    trigger: isArray(this.triggers) ? this.triggers.join(' ') : this.triggers
                 };
             }
         },


### PR DESCRIPTION
If trigger element becomes hidden (such as in a `<keepalive>`, `<b-tabs>`, etc.), then force hide the tooltip or popover, so that it doesn't linger on the screen (fade animation will be disabled).

This is achieved by adding a visibility watcher that runs every 100ms.  The watcher only runs when the tooltip/popover is visible.

The `hide` event is still emitted, but cannot be cancelled.

Also changed the component version to use the `beforeDestroy()` hook instead of the `destroyed()` hook to remove tooltip/popover, preventing some Vue console log errors and warnings