### PR TITLE
feat(tooltip+popover): Allow element and component reference for target

### DIFF
--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -42,7 +42,7 @@ using the `v-b-popover` directive and enable the `html` modifer if needed._
         <b-btn :id="'exPopover1-'+placement" variant="primary">
           {{ placement }}
         </b-btn>
-        <b-popover :target-id="'exPopover1-'+placement"
+        <b-popover :target="'exPopover1-'+placement"
                    :placement="placement"
                    title="Popover!"
                    triggers="hover focus"
@@ -55,7 +55,7 @@ using the `v-b-popover` directive and enable the `html` modifer if needed._
     <b-row>
       <b-col md="6" class="py-4 text-center">
         <b-btn id="exPopover2" variant="primary">Using properties</b-btn>
-        <b-popover target-id="exPopover2" 
+        <b-popover target="exPopover2" 
             title="Prop Examples"
             triggers="hover focus"
             content="Embedding content using properties is easy">
@@ -63,7 +63,7 @@ using the `v-b-popover` directive and enable the `html` modifer if needed._
       </b-col>
       <b-col md="6" class="py-4 text-center">
         <b-btn id="exPopover3" variant="primary">Using slots</b-btn>
-        <b-popover target-id="exPopover3" triggers="hover focus">
+        <b-popover target="exPopover3" triggers="hover focus">
            <template slot="title">Content via Slots</template>
            Embedding content <span class="text-danger">using slots</span>
            affords you <em>greater <strong>control.</strong></em> and
@@ -82,7 +82,7 @@ using the `v-b-popover` directive and enable the `html` modifer if needed._
 
 | Prop | Default | Description | Supported values
 | ---- | ------- | ----------- | ----------------
-| `target-id` | `null` | ID of element that you want to trigger the popover. **Required** | Any valid, in-document unique element ID
+| `target` | `null` | String ID of element, or a reference to an element or component, that you want to trigger the popover. **Required** | Any valid, in-document unique element ID, or in-document element/component reference
 | `title` | `null` | Title of popover (text only, no HTML). if HTML is required, place it in the `title` named slot | Plain text
 | `content` | `null` | Content of popover (text only, no HTML). if HTML is required, place it in the default slot | Plain text
 | `placement` | `top` | Positioning of the popover, relative to the trigger element. | `top`, `bottom`, `left`, `right`, `auto`
@@ -172,7 +172,7 @@ small screens can be harder to deal with on mobile devices (such as smart-phones
 
     <!-- Our popover title and content render container -->
     <!-- We use placement 'auto' so popover fits in the best spot on viewport -->
-    <b-popover target-id="exPopoverReactive1"
+    <b-popover target="exPopoverReactive1"
                triggers="click",
                placement="auto"
                ref="popover"

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -44,10 +44,10 @@ prop does not have this behavior. For simple tooltips, we recommend using the
   </b-row>
 
   <!-- Tooltip title specified via prop title -->
-  <b-tooltip target-id="exButton1" title="Online!"></b-tooltip>
+  <b-tooltip target="exButton1" title="Online!"></b-tooltip>
 
   <!-- HTML title specified via default slot -->
-  <b-tooltip target-id="exButton2" placement="bottom">
+  <b-tooltip target="exButton2" placement="bottom">
     Hello <strong>World!</strong>
   </b-tooltip>
 </b-container>
@@ -59,10 +59,10 @@ prop does not have this behavior. For simple tooltips, we recommend using the
 
 | Prop | Default | Description | Supported values
 | ---- | ------- | ----------- | ----------------
-| `target-id` | `null` | ID of element that you want to trigger the tooltip. **Required** | Any valid, in-document unique element ID
+| `target` | `null` | String ID of element, or a reference to an element or component, that you want to trigger the tooltip. **Required** | Any valid, in-document unique element ID, element reference or component reference
 | `title` | `null` | Content of tooltip (text only, no HTML). if HTML is required, place it in the default slot | Plain text
 | `placement` | `top` | Positioning of the tooltip, relative to the trigger element. | `top`, `bottom`, `left`, `right`, `auto`
-| `triggers` | `hover focus` |  Space separated list of which event(s) will trigger open/close of tooltip | `hover`, `focus`, `click`. Note `blur` is a special use case to close tooltip on next click.
+| `triggers` | `hover focus` |  Space separated list of which event(s) will trigger open/close of tooltip | `hover`, `focus`, `click`. Note `blur` is a special use case to close tooltip on next click, usually used in conjunction with `click`.
 | `no-fade` | `false` | Disable fade animation when set to `true` | `true` or `false`
 | `delay` | `0` | Number of milliseconds to delay showing and hidding of tooltip | `0` and up, integers only.
 | `offset` | `0` | Number of pixels to shift the center of the tooltip | Any negative or positive integer
@@ -70,7 +70,7 @@ prop does not have this behavior. For simple tooltips, we recommend using the
 
 ## `v-b-tooltip` Directive Usage
 
-The `v-b-tooltip` directive makes adding tooltips even easier:
+The `v-b-tooltip` directive makes adding tooltips even easier, without additional placeholder markup:
 
 ```html
 <b-container fluid>

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -12,8 +12,7 @@
     import PopOver from '../classes/popover';
     import { isArray } from '../utils/array';
     import { assign } from '../utils/object';
-    import { warn } from '../utils';
-    import observeDom from '../utils/observe-dom';
+    import { observeDom, warn } from '../utils';
 
     export default {
         data() {
@@ -23,20 +22,18 @@
         },
         props: {
             target: {
-                // ID of element to place popover on
-                // Or a reference to an emlement or component
+                // ID of element, or a reference to an element or component
                 type: [String, Object],
                 default() {
                     if (this.targetId) {
                         warn("b-popover: Prop 'target-id' is deprecated. Please use 'target' instead");
                         return this.targetId;
                     }
-                    return null
+                    return null;
                 }
             },
             targetId: {
-                // ID of element to place popover on
-                // Must be in DOM
+                // Deprecated: ID of element to place popver on
                 type: String,
                 default: null
             },
@@ -70,37 +67,26 @@
             }
         },
         mounted() {
-            if (this.targetId) {
-                let target = this.target;
-                let el = null;
-                this.$nextTick(() => {
-                    if (typeof target === 'string') {
-                        // Assume ID of element
-                        el = document.getElementById(/^#/.test(target) ? target.slice(1) : target);
-                    } else if (typeof target === 'object' && target.$el) {
-                        // Component referece
-                        el = target.$el;
-                    } else if (typeof target === 'object' && target.tagName) {
-                        // Element reference
-                        el = target;
-                    }
-                    if (el && !this.popOver) {
-                        // We pass the title & content as part of the config
-                        this.popOver = new PopOver(el, this.getConfig(), this.$root);
-                        // Listen to close signals from others
-                        this.$on('close', this.onClose);
-                        // Observe content Child changes so we can notify popper of possible size change
-                        observeDom(this.$refs.content, this.updatePosition.bind(this), {
-                            subtree: true,
-                            childList: true,
-                            attributes: true,
-                            attributeFilter: ['class', 'style']
-                        });
-                    } else {
-                        warn("b-popover: 'target' element not found!");
-                    }
-                });
-            }
+            // We do this in a $nextTick in hopes that the target element is in the DOM
+            // And that our children have rendered
+            this.$nextTick(() => {
+                const target = this.getTarget();
+                if (target) {
+                    // Instaniate popover on target
+                    this.popOver = new PopOver(target, this.getConfig(), this.$root);
+                    // Listen to close signals from others
+                    this.$on('close', this.onClose);
+                    // Observe content Child changes so we can notify popper of possible size change
+                    observeDom(this.$refs.content, this.updatePosition.bind(this), {
+                        subtree: true,
+                        childList: true,
+                        attributes: true,
+                        attributeFilter: ['class', 'style']
+                    });
+                } else {
+                    warn("b-popover: 'target' element not found!");
+                }
+            });
         },
         updated() {
             // If content changes, etc
@@ -109,6 +95,7 @@
             }
         },
         beforeDestroyed() {
+            this.$off('close', this.onClose);
             if (this.popOver) {
                 // Destroy the popover
                 this.popOver.destroy();
@@ -116,7 +103,6 @@
                 // Bring our stuff back if necessary
                 this.bringItBack();
             }
-            this.$off('close', this.onClose);
         },
         computed: {
             baseConfig() {
@@ -166,6 +152,20 @@
                 };
                 return cfg;
             },
+            getTarget() {
+                const target = this.target;
+                if (typeof target === 'string') {
+                    // Assume ID of element
+                    return document.getElementById(/^#/.test(target) ? target.slice(1) : target) || null;
+                } else if (typeof target === 'object' && target.$el) {
+                    // Component reference
+                    return target.$el;
+                } else if (typeof target === 'object' && target.tagName) {
+                    // Element reference
+                    return target;
+                }
+                return null;
+            },
             onShow(evt) {
                 this.$emit('show', evt);
             },
@@ -176,8 +176,8 @@
                 this.$emit('hide', evt);
             },
             onHidden(evt) {
-                // bring our content back if needed to keep Vue happy
-                // Tooltip class will move it back to $tip when shown again
+                // Bring our content back if needed to keep Vue happy
+                // PopOver class will move it back to $tip when shown again
                 this.bringItBack();
                 this.$emit('hidden', evt);
             },

--- a/lib/components/popover.vue
+++ b/lib/components/popover.vue
@@ -100,9 +100,9 @@
                 // Destroy the popover
                 this.popOver.destroy();
                 this.popOver = null;
-                // Bring our stuff back if necessary
-                this.bringItBack();
             }
+            // Bring our stuff back if necessary
+            this.bringItBack();
         },
         computed: {
             baseConfig() {

--- a/lib/components/tooltip.vue
+++ b/lib/components/tooltip.vue
@@ -88,12 +88,13 @@
             }
         },
         beforeDestroy() {
+            this.$off('close', this.onClose);
             if (this.toolTip) {
                 this.toolTip.destroy();
                 this.tooltip = null;
-                // bring our content back if needed
-                this.bringItBack();
             }
+            // bring our content back if needed
+            this.bringItBack();
         },
         computed: {
             baseConfig() {

--- a/lib/components/tooltip.vue
+++ b/lib/components/tooltip.vue
@@ -67,6 +67,8 @@
                 if (target) {
                     // Instantiate ToolTip on target
                     this.toolTip = new ToolTip(target, this.getConfig(), this.$root);
+                    // Listen to close signals from others
+                    this.$on('close', this.onClose);
                     // Observe content Child changes so we can notify popper of possible size change
                     observeDom(this.$refs.title, this.updatePosition.bind(this), {
                         subtree: true,
@@ -107,6 +109,13 @@
             }
         },
         methods: {
+            onClose(callback) {
+                if (this.toolTip) {
+                    this.toolTip.hide(callback);
+                } else if (typeof callback === 'function') {
+                    callback();
+                }
+            },
             updatePosition() {
                 if (this.toolTip) {
                     // Instruct popper to reposition popover if necessary


### PR DESCRIPTION
For component version of tooltip and popover, allow target to be given as an element or component reference, besides a string ID.

Deprecates the `target-id` prop