### PR TITLE
feat(table): Refactor field formatter support + optimized sort-compare handling

### DIFF
--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -337,7 +337,7 @@ parent component's methods. Providing formatter as `Function`, it must be declar
 global scope (window or as global mixin at Vue). 
 
 Callback function accepts three arguments - `value`, `key`, and `item`, and should
-return the formatted value as a string (note that HTML is not supported)
+return the formatted value as a string (basic HTML is supported)
 
 **Example 6: Custom data rendering with formatter callback function**
 ```html

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -368,7 +368,7 @@ export default {
       },
       sex: {
         // A regular column with custom formatter
-        label: 'Sex'
+        label: 'Sex',
         formatter: (value) => { return value.charAt(0).toUpperCase(); }
       },
       birthYear: {

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -102,7 +102,7 @@ const items = [
     isActive: true,  age: 40, first_name: 'Thor', last_name: 'Macdonald',
     _cellVariants: { isActive: 'success', age: 'info', first_name: 'warning' }
   },
-  { isAactive: false, age: 29, first_name: 'Dick', last_name: 'Dunlap' }
+  { isActive: false, age: 29, first_name: 'Dick', last_name: 'Dunlap' }
 ];
 
 export default {
@@ -198,7 +198,7 @@ export default {
       { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
       { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson' },
       { isActive: true,  age: 38, first_name: 'Jami', last_name: 'Carney' },
-      { isAactive: false, age: 29, first_name: 'Dick', last_name: 'Dunlap' }
+      { isActive: false, age: 29, first_name: 'Dick', last_name: 'Dunlap' }
     ]
   }
 };
@@ -212,21 +212,21 @@ When fields is provided as an object, the following field properties are availab
 | Property | Type | Description
 | ---------| ---- | -----------
 | `class` | String or Array | Class name (or array of class names) to add to `<th>` **and** `<td>` in the column
-| `formatter` | String or Function | A formatter callback function, can be used instead of slots for real table fields (i.e. fields, that have corresponding data at items array).
+| `formatter` | String or Function | A formatter callback function, can be used instead of (or in conjunction with) slots for real table fields (i.e. fields, that have corresponding data at items array).
 | `label` | String | Appears in the columns table header (and footer if `foot-clone` is set). Defaults to the field's key
 | `sortable` | Boolean | Enable sorting on this column
 | `tdClass` | String or Array | Class name (or array of class names) to add to data `<td>` cells in the column
 | `thClass` | String or Array | Class name (or array of class names) to add to header/footer `<th>` cell
 | `thStyle` | Object | JavaScript object representing CSS styles you would like to apply to the table field `<th>`
-| `variant` | String | Apply contextual class to the `<th>` **and** `<td>` in the column (`active`, `success`, `info`, `warning`, `danger`)
+| `variant` | String | Apply contextual class to the `<th>` **and** `<td>` in the column - `active`, `success`, `info`, `warning`, `danger` (these variants map to classes `thead-${variant}`, `table-${variant}`, or `bg-${variant}` accordingly)
 
->**Notes:**
- >- _Field properties, if not present, default to `null` unless otherwise stated above._
- >- _`thClass` and `tdClass` will not work with classes that are defined in scoped CSS_
- >- _For information on the syntax supported by `thStyle`, see
+**Notes:**
+ - _Field properties, if not present, default to `null` unless otherwise stated above._
+ - _`thClass` and `tdClass` will not work with classes that are defined in scoped CSS_
+ - _For information on the syntax supported by `thStyle`, see
 [Class and Style Bindings](https://vuejs.org/v2/guide/class-and-style.html#Binding-Inline-Styles)
 in the Vue.js guide._
- >- _Any additional properties added to the field objects will be left intact - so you can access
+ - _Any additional properties added to the field objects will be left intact - so you can access
 them via the named scoped slots for custom data, header, and footer rendering._
 
 For information and usage about scoped slots and formatters, refer to
@@ -307,17 +307,14 @@ The slot's scope variable (`data` in the above sample) will have the following p
 | -------- | ---- | -----------
 | `index` | Number | The row number (indexed from zero)
 | `item` | Object | The entire record (i.e. `items[index]`) for this row (deep clone)
-| `value` | Any | The value for this key in the record (`null` or `undefined` if a virtual column)
+| `value` | Any | The value for this key in the record (`null` or `undefined` if a virtual column), or the output of thr field's `formatter` function
+| `unformatted` | Any | The value for this key in the record (`null` or `undefined` if a virtual column), before bing pased to the field's `formtter` function
 
 
->**Note:** *`index` will not always be the actual row's index number, as it is
+**Note:** *`index` will not always be the actual row's index number, as it is
 computed after pagination and filtering have been applied to the original
 table data. The `index` value will refer to the **displayed row number**. This
 number will align with the indexes from the optional `v-model` bound variable.*
-
-`<b-table>` always deep clones the items array data before pagination, sorting,
-filtering and display. Hence any changes made to the item data passed to
-the custom rendered slot will **not** affect the original provided items array.
 
 When placing inputs, buttons, selects or links within a data cell scoped slot,
 be sure to add a `@click.stop` handler (which can be empty) to prevent the
@@ -335,10 +332,11 @@ event:
 
 One more option to customize field output is to use formatter callback function.
 To enable this field's property `formatter` is used. Value of this property may be 
-String or function reference. In case of String value, function must be defined at parent component's methods, 
-to provide formatter as `Function`, it must be declared at global scope (window or as global mixin at Vue). 
+String or function reference. In case of a String value, function must be defined at
+parent component's methods. Providing formatter as `Function`, it must be declared at
+global scope (window or as global mixin at Vue). 
 
-Callback function accepts three arguments - `value`, `key`, `row`.
+Callback function accepts three arguments - `value`, `key`, and `item`.
 
 **Example 6: Custom data rendering with formatter callback function**
 ```html
@@ -447,7 +445,7 @@ the original `items` array (except when `items` is set to a provider function).
 Deleting a record from the v-model will **not** remove the record from the
 original items array.
 
->**Note:** *Do not bind any value directly to the `value` prop. Use the `v-model` binding.*
+**Note:** *Do not bind any value directly to the `value` prop. Use the `v-model` binding.*
 
 ## Filtering
 Filtering, when used, is aplied to the original items array data, and hence it is not
@@ -465,10 +463,10 @@ will emit the `filtered` event, passing a single argument which is the complete 
 items passing the filter routine. Treat this argument as read-only.
 
 ## Sorting
-As mentioned above in the [**Fields**](#fields-column-definitions-) section above, you can make columns sortable. Clciking on
-sortable a column header will sort the column in ascending direction, while clicking
-on it again will switch the direction or sorting.  Clicking on a non-sortable column
-will clear the sorting.
+As mentioned above in the [**Fields**](#fields-column-definitions-) section above,
+you can make columns sortable. Clicking on a sortable column header will sort the
+column in ascending direction, while clicking on it again will switch the direction
+of sorting.  Clicking on a non-sortable column will clear the sorting.
 
 You can control which column is pre-sorted and the order of sorting (ascending or
 descending). To pre-specify the column to be sorted, set the `sort-by` prop to 
@@ -482,18 +480,21 @@ on the `.sync` prop modifier
 
 ### Sort-Compare routine
 The built-in default `sort-compare` function sorts the specified field `key` based
-on the data in the underlying record object. The field value is first stringified
-if it is an object, and then sorted.
+on the data in the underlying record object (not by the foratted value). The field
+value is first stringified if it is an object, and then sorted.
 
 The default `sort-compare` routine **cannot** sort virtual columns, nor sort based
-on the custom rendering of the field data (which is used only for presentation).
-For this reason, you can provide your own custom sort compare routine by passing a
-function reference to the prop `sort-compare`.
+on the custom rendering (formatter function or scoped slots) of the field data
+(which is used only for presentation). For this reason, you can provide your own
+custom sort compare routine by passing a function reference to the prop `sort-compare`.
 
 The `sort-compare` routine is passed three arguments. The first two arguments
 (`a` and `b`) are the record objects for the rows being compared, and the third
-argument is the field `key` being sorted on. The routine should return
+argument is the field `key` being sorted on (`sortBy`). The routine should return
 either `-1`, `0`, or `1` based on the result of the comparing of the two records.
+If the routine returns `null`, then the default sort-compare rouine will be used.
+You can use this feature (returning `null`) to have your custom sort-compare routine
+handle only certain fields (keys).
 
 The default sort-compare routine works as follows:
 
@@ -581,7 +582,7 @@ function myProvider(ctx) {
 a `busy` prop that can be used either to override inner `busy`state, or to monitor
 `<b-table>`'s current busy state in your application using the 2-way `.sync` modifier.
 
->**Note:** _in order to allow `<b-table>` fully track it's `busy` state, custom items
+**Note:** _in order to allow `<b-table>` fully track it's `busy` state, custom items
 provider function should handle errors from data sources and return an empty
 array to `<b-table>`._
 
@@ -620,10 +621,10 @@ methods: {
  }
 ```
 
->**Notes:**
->- _If you manually place the table in the `busy` state, the items provider will
+**Notes:**
+- _If you manually place the table in the `busy` state, the items provider will
 __not__ be called/refreshed until the `busy` state has been set to `false`._
->- _All click related and hover events, and sort-changed events will __not__ be
+- _All click related and hover events, and sort-changed events will __not__ be
  emiited when in the `busy` state (either set automatically during provider update,
  or when manually set)._
 
@@ -643,7 +644,7 @@ following `b-table` prop(s) to `true`:
 When `no-provider-paging` is `false` (default), you should only return at
 maximum, `perPage` number of records.
 
->**Note** _`<b-table>` needs reference to your pagination and filtering values in order to
+**Note** _`<b-table>` needs reference to your pagination and filtering values in order to
 trigger the calling of the provider function.  So be sure to bind to the `per-page`,
 `current-page` and `filter` props on `b-table` to trigger the provider update function call
 (unless you have the respective `no-provider-*` prop set to `true`)._
@@ -832,5 +833,4 @@ export default {
 | `foot-clone` | Turns on the table footer, and defaults with the same contents a the table header
 | `head-variant` | Use `default` or `inverse` to make `<thead>` appear light or dark gray, respectively
 | `foot-variant` | Use `default` or `inverse` to make `<tfoot>` appear light or dark gray, respectively. Has no effect if `foot-clone` is not set
-
 

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -429,7 +429,7 @@ The slot's scope variable (`data` in the above example) will have the following 
 | -------- | ---- | -----------
 | `column` | String | The fields's `key` value
 | `field` | Object | the field's object (from the `fields` prop)
-| `label` | String | The fileds label value (also available as `data.field.label`)
+| `label` | String | The fields label value (also available as `data.field.label`)
 
 When placing inputs, buttons, selects or links within a `HEAD_` or `FOOT_` slot,
 be sure to add a `@click.stop` handler (which can be empty) to prevent the
@@ -439,7 +439,7 @@ or a `head-clicked` event.
 ```html
 <template slot="HEAD_actions" scope="foo">
   <!-- We use click.stop here to prevent 'sort-changed' or 'head-clicked' events -->
-  <input tyep="checkbox" :value="foo.column" v-model="selected" @click.stop>
+  <input type="checkbox" :value="foo.column" v-model="selected" @click.stop>
 </template>
 ```
 
@@ -458,7 +458,7 @@ original items array.
 **Note:** *Do not bind any value directly to the `value` prop. Use the `v-model` binding.*
 
 ## Filtering
-Filtering, when used, is aplied to the original items array data, and hence it is not
+Filtering, when used, is applied to the original items array data, and hence it is not
 possible to filter data based on custom rendering of virtual columns. The items row data
 is stringified and the filter searches that stringified data (excluding any properties
 that begin with an underscore (`_`) and the deprecated property `state`.
@@ -490,7 +490,7 @@ on the `.sync` prop modifier
 
 ### Sort-Compare routine
 The built-in default `sort-compare` function sorts the specified field `key` based
-on the data in the underlying record object (not by the foratted value). The field
+on the data in the underlying record object (not by the formatted value). The field
 value is first stringified if it is an object, and then sorted.
 
 The default `sort-compare` routine **cannot** sort virtual columns, nor sort based
@@ -601,13 +601,13 @@ set to `true` just before your async fetch, and then set it to `false` once you 
 your data, and just before you send it to the table for display. Example:
 
 ```html
-<b-table id="my-table" :busy.sync="isBusy" :items="myProvider" :fields="fields" ....>
-</b-table>
+<b-table id="my-table" :busy.sync="isBusy" :items="myProvider" :fields="fields" ...></b-table>
 ```
+
 ```js
 data () {
     return {
-        isBusy = false
+        isBusy: false
     };
 }
 methods: {
@@ -670,9 +670,9 @@ You must have a unique ID on your table for this to work.
 
 Or by calling the refresh method on the table reference
 ```html
-<b-table ref="table" ... >
-</b-table>
+<b-table ref="table" ... ></b-table>
 ```
+
 ```js
     this.$refs.table.refresh();
 ```
@@ -684,8 +684,7 @@ By listening on `<b-table>` `sort-changed` event, you can detect when the sortin
 and direction have changed.
 
 ```html
-<b-table @sort-changed="sortingChanged" ...>
-</b-table>
+<b-table @sort-changed="sortingChanged" ...></b-table>
 ```
 
 The `sort-changed` event provides a single argument of the table's current state context object.
@@ -785,7 +784,7 @@ const items = [
   { _cellVariants: { age: 'danger', isActive: 'warning' },
     isActive: true,  age: 87, name: { first: 'Larsen', last: 'Shaw' } },
   { isActive: false, age: 26, name: { first: 'Mitzi', last: 'Navarro' } },
-  { isActive: false, age: 22, name: { first: 'Genevive', last: 'Wilson' } },
+  { isActive: false, age: 22, name: { first: 'Genevieve', last: 'Wilson' } },
   { isActive: true,  age: 38, name: { first: 'John', last: 'Carney' } },
   { isActive: false, age: 29, name: { first: 'Dick', last: 'Dunlap' } }
 ];
@@ -829,6 +828,7 @@ export default {
 
 <!-- table-complete-1.vue -->
 ```
+
 ## Table options
 `<b-table>` provides several props to alter the style of the table:
 

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -454,7 +454,7 @@ export default {
             const filter = this.filter;
             const sortBy = this.localSortBy;
             const sortDesc = this.localSortDesc;
-            const sortCompare = this.sortCompare || defaultSortCompare;
+            const sortCompare = this.sortCompare;
 
             let items = this.hasProvider ? this.localItems : this.items;
 
@@ -464,7 +464,8 @@ export default {
             }
 
             // Array copy for sorting, filtering, etc.
-            items = items.slice()
+            items = items.slice();
+
             // Apply local filter
             if (filter && !this.providerFiltering) {
                 if (filter instanceof Function) {
@@ -491,7 +492,17 @@ export default {
             // Apply local Sort
             if (sortBy && !this.providerSorting) {
                 items = items.sort(function sortItemsFn(a, b) {
-                    return sortCompare(a, b, sortBy) * (sortDesc ? -1 : 1);
+                    let ret = null;
+                    if (typeof sortCompare === 'function') {
+                        // Call user provided sortCompare routine
+                        ret = sortCompare(a, b, sortBy);
+                    }
+                    if (ret === null or ret === undefined) {
+                        // Fallback to defaultSortCompare if sortCompare not defined or returns null
+                        ret = defaultSortCompare(a, b, sortBy));
+                    }
+                    // Handle sorting direction
+                    return (ret || 0) * (sortDesc ? -1 : 1);
                 });
             }
 

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -497,9 +497,9 @@ export default {
                         // Call user provided sortCompare routine
                         ret = sortCompare(a, b, sortBy);
                     }
-                    if (ret === null or ret === undefined) {
+                    if (ret === null || ret === undefined) {
                         // Fallback to defaultSortCompare if sortCompare not defined or returns null
-                        ret = defaultSortCompare(a, b, sortBy));
+                        ret = defaultSortCompare(a, b, sortBy);
                     }
                     // Handle sorting direction
                     return (ret || 0) * (sortDesc ? -1 : 1);

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -66,14 +66,21 @@
                 @dblclick="rowDblClicked($event,item,index)"
                 @mouseenter="rowHovered($event,item,index)">
                 <template v-for="(field,key) in computedFields">
-                    <td :class="tdClass(field, item, key)"
+                    <td v-if="$scopedSlots[key]"
+                        :class="tdClass(field, item, key)"
                         :key="key">
                         <slot :name="key"
                               :value="getFormattedValue(item, key, field)"
                               :unformatted="item[key]"
                               :item="item"
-                              :index="index"><div v-html="getFormattedValue(item, key, field)"></div></slot>
+                              :index="index"
+                        ></slot>
                     </td>
+                    <td v-else
+                        :class="tdClass(field, item, key)"
+                        :key="key"
+                        v-html="getFormattedValue(item, key, field)"
+                    ></td>
                 </template>
             </tr>
             <tr v-if="showEmpty && (!computedItems || computedItems.length === 0)">

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -69,8 +69,8 @@
                     <td :class="tdClass(field, item, key)"
                         :key="key">
                         <slot :name="key"
-                              :value="item[key]"
-                              :formatted-value="getFormattedValue(item, key, field)"
+                              :value="getFormattedValue(item, key, field)"
+                              :unformatted="item[key]"
                               :item="item"
                               :index="index">{{ getFormattedValue(item, key, field) }}</slot>
                     </td>

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -1,676 +1,697 @@
 <template>
     <table :id="id || null"
            :aria-busy="computedBusy ? 'true' : 'false'"
-           :class="tableClass"
-    >
+           :class="tableClass">
         <thead :class="headClass">
-        <tr>
-            <th v-for="(field,key) in computedFields"
-                @click.stop.prevent="headClicked($event,field,key)"
-                @keydown.enter.stop.prevent="headClicked($event,field,key)"
-                @keydown.space.stop.prevent="headClicked($event,field,key)"
-                :key="key"
-                :class="fieldClass(field,key)"
-                :style="field.thStyle || {}"
-                :aria-label="field.sortable ? ((localSortDesc && localSortBy === key) ? labelSortAsc : labelSortDesc) : null"
-                :aria-sort="(field.sortable && localSortBy === key) ? (localSortDesc ? 'descending' : 'ascending') : null"
-                :tabindex="field.sortable?'0':null"
-            >
-                <slot :name="'HEAD_'+key" :label="field.label" :column="key" :field="field">
-                    <div v-html="field.label"></div>
-                </slot>
-            </th>
-        </tr>
+            <tr>
+                <th v-for="(field,key) in computedFields"
+                    @click.stop.prevent="headClicked($event,field,key)"
+                    @keydown.enter.stop.prevent="headClicked($event,field,key)"
+                    @keydown.space.stop.prevent="headClicked($event,field,key)"
+                    :key="key"
+                    :class="fieldClass(field,key)"
+                    :style="field.thStyle || {}"
+                    :aria-label="field.sortable ? ((localSortDesc && localSortBy === key) ? labelSortAsc : labelSortDesc) : null"
+                    :aria-sort="(field.sortable && localSortBy === key) ? (localSortDesc ? 'descending' : 'ascending') : null"
+                    :tabindex="field.sortable?'0':null">
+                    <slot :name="'HEAD_'+key"
+                          :label="field.label"
+                          :column="key"
+                          :field="field">
+                        <div v-html="field.label"></div>
+                    </slot>
+                </th>
+            </tr>
         </thead>
-        <tfoot v-if="footClone" :class="footClass">
-        <tr>
-            <th v-for="(field,key) in computedFields"
-                @click.stop.prevent="headClicked($event,field,key)"
-                @keydown.enter.stop.prevent="headClicked($event,field,key)"
-                @keydown.space.stop.prevent="headClicked($event,field,key)"
-                :key="key"
-                :class="fieldClass(field,key)"
-                :style="field.thStyle || {}"
-                :aria-label="field.sortable ? ((localSortDesc && localSortBy === key) ? labelSortAsc : labelSortDesc) : null"
-                :aria-sort="(field.sortable && localSortBy === key) ? (localSortDesc ? 'descending' : 'ascending') : null"
-                :tabindex="field.sortable?'0':null"
-            >
-                <slot v-if="$scopedSlots['FOOT_'+key]" :name="'FOOT_'+key" :label="field.label" :column="key"
-                      :field="field">
-                    <div v-html="field.label"></div>
-                </slot>
-                <slot v-else :name="'HEAD_'+key" :label="field.label" :column="key" :field="field">
-                    <div v-html="field.label"></div>
-                </slot>
-            </th>
-        </tr>
+        <tfoot v-if="footClone"
+               :class="footClass">
+            <tr>
+                <th v-for="(field,key) in computedFields"
+                    @click.stop.prevent="headClicked($event,field,key)"
+                    @keydown.enter.stop.prevent="headClicked($event,field,key)"
+                    @keydown.space.stop.prevent="headClicked($event,field,key)"
+                    :key="key"
+                    :class="fieldClass(field,key)"
+                    :style="field.thStyle || {}"
+                    :aria-label="field.sortable ? ((localSortDesc && localSortBy === key) ? labelSortAsc : labelSortDesc) : null"
+                    :aria-sort="(field.sortable && localSortBy === key) ? (localSortDesc ? 'descending' : 'ascending') : null"
+                    :tabindex="field.sortable?'0':null">
+                    <slot v-if="$scopedSlots['FOOT_'+key]"
+                          :name="'FOOT_'+key"
+                          :label="field.label"
+                          :column="key"
+                          :field="field">
+                        <div v-html="field.label"></div>
+                    </slot>
+                    <slot v-else
+                          :name="'HEAD_'+key"
+                          :label="field.label"
+                          :column="key"
+                          :field="field">
+                        <div v-html="field.label"></div>
+                    </slot>
+                </th>
+            </tr>
         </tfoot>
         <tbody>
-        <tr v-if="$scopedSlots['top-row']">
-            <slot name="top-row" :columns="keys(fields).length" :fields="fields"></slot>
-        </tr>
-        <tr v-for="(item,index) in computedItems"
-            :key="index"
-            :class="rowClass(item)"
-            @click="rowClicked($event,item,index)"
-            @dblclick="rowDblClicked($event,item,index)"
-            @mouseenter="rowHovered($event,item,index)"
-        >
-            <template v-for="(field,key) in computedFields">
-                <td :class="tdClass(field, item, key)" :key="key">
-                    <slot :name="key" :value="item[key]" :item="item" :index="index">{{item[key]}}</slot>
+            <tr v-if="$scopedSlots['top-row']">
+                <slot name="top-row"
+                      :columns="keys(fields).length"
+                      :fields="fields"></slot>
+            </tr>
+            <tr v-for="(item,index) in computedItems"
+                :key="index"
+                :class="rowClass(item)"
+                @click="rowClicked($event,item,index)"
+                @dblclick="rowDblClicked($event,item,index)"
+                @mouseenter="rowHovered($event,item,index)">
+                <template v-for="(field,key) in computedFields">
+                    <td :class="tdClass(field, item, key)"
+                        :key="key">
+                        <slot :name="key"
+                              :value="item[key]"
+                              :formatted-value="getFormattedValue(item, key, field)"
+                              :item="item"
+                              :index="index">{{ getFormattedValue(item, key, field) }}</slot>
+                    </td>
+                </template>
+            </tr>
+            <tr v-if="showEmpty && (!computedItems || computedItems.length === 0)">
+                <td :colspan="keys(computedFields).length">
+                    <div v-if="filter"
+                         role="alert"
+                         aria-live="polite">
+                        <slot name="emptyfiltered">
+                            <div class="text-center my-2"
+                                 v-html="emptyFilteredText"></div>
+                        </slot>
+                    </div>
+                    <div v-else
+                         role="alert"
+                         aria-live="polite">
+                        <slot name="empty">
+                            <div class="text-center my-2"
+                                 v-html="emptyText"></div>
+                        </slot>
+                    </div>
                 </td>
-            </template>
-        </tr>
-        <tr v-if="showEmpty && (!computedItems  || computedItems.length === 0)">
-            <td :colspan="keys(computedFields).length">
-                <div v-if="filter" role="alert" aria-live="polite">
-                    <slot name="emptyfiltered">
-                        <div class="text-center my-2" v-html="emptyFilteredText"></div>
-                    </slot>
-                </div>
-                <div v-else role="alert" aria-live="polite">
-                    <slot name="empty">
-                        <div class="text-center my-2" v-html="emptyText"></div>
-                    </slot>
-                </div>
-            </td>
-        </tr>
-        <tr v-if="$scopedSlots['bottom-row']">
-            <slot name="bottom-row" :columns="keys(fields).length" :fields="fields"></slot>
-        </tr>
+            </tr>
+            <tr v-if="$scopedSlots['bottom-row']">
+                <slot name="bottom-row"
+                      :columns="keys(fields).length"
+                      :fields="fields"></slot>
+            </tr>
         </tbody>
     </table>
 </template>
 
 <script>
-    import { warn, pluckProps } from '../utils';
-    import { keys } from '../utils/object';
-    import { isArray } from '../utils/array'
-    import { listenOnRootMixin } from '../mixins';
-    import startCase from 'lodash.startcase';
+import { warn, pluckProps } from '../utils';
+import { keys } from '../utils/object';
+import { isArray } from '../utils/array'
+import { listenOnRootMixin } from '../mixins';
+import startCase from 'lodash.startcase';
 
-    const toString = v => {
-        if (!v) {
-            return '';
-        }
-        if (v instanceof Object) {
-            return keys(v).map(k => toString(v[k])).join(' ');
-        }
-        return String(v);
-    };
+function toString(v) {
+    if (!v) {
+        return '';
+    }
+    if (v instanceof Object) {
+        return keys(v).map(k => toString(v[k])).join(' ');
+    }
+    return String(v);
+}
 
-    const recToString = obj => {
-        if (!(obj instanceof Object)) {
-            return '';
-        }
+function recToString(obj) {
+    if (!(obj instanceof Object)) {
+        return '';
+    }
 
-        return toString(keys(obj).reduce((o, k) => {
-            // Ignore fields 'state' and ones that start with _
-            if (!(/^_/.test(k) || k === 'state')) {
-                o[k] = obj[k];
+    return toString(keys(obj).reduce((o, k) => {
+        // Ignore fields 'state' and ones that start with _
+        if (!(/^_/.test(k) || k === 'state')) {
+            o[k] = obj[k];
+        }
+        return o;
+    }, {}));
+}
+
+function defaultSortCompare(a, b, sortBy) {
+    if (typeof a[sortBy] === 'number' && typeof b[sortBy] === 'number') {
+        return ((a[sortBy] < b[sortBy]) && -1) || ((a[sortBy] > b[sortBy]) && 1) || 0;
+    }
+    return toString(a[sortBy]).localeCompare(toString(b[sortBy]), undefined, {
+        numeric: true
+    });
+}
+
+function hasFormatter(field) {
+    return field.formatter && (typeof field.formatter === "function" || typeof field.formatter === "string")
+}
+
+export default {
+    mixins: [listenOnRootMixin],
+    data() {
+        return {
+            localSortBy: this.sortBy || '',
+            localSortDesc: this.sortDesc || false,
+            localItems: [],
+            // Note: filteredItems only used to determine if # of items changed
+            filteredItems: [],
+            localBusy: this.busy
+        };
+    },
+    props: {
+        id: {
+            type: String,
+            default: ''
+        },
+        items: {
+            type: [Array, Function],
+            default() {
+                return [];
             }
-            return o;
-        }, {}));
-    };
-
-    const defaultSortCompare = (a, b, sortBy) => {
-        if (typeof a[sortBy] === 'number' && typeof b[sortBy] === 'number') {
-            return ((a[sortBy] < b[sortBy]) && -1) || ((a[sortBy] > b[sortBy]) && 1) || 0;
+        },
+        sortBy: {
+            type: String,
+            default: null
+        },
+        sortDesc: {
+            type: Boolean,
+            default: false
+        },
+        apiUrl: {
+            type: String,
+            default: ''
+        },
+        fields: {
+            type: [Object, Array],
+            default: null
+        },
+        striped: {
+            type: Boolean,
+            default: false
+        },
+        bordered: {
+            type: Boolean,
+            default: false
+        },
+        inverse: {
+            type: Boolean,
+            default: false
+        },
+        hover: {
+            type: Boolean,
+            default: false
+        },
+        small: {
+            type: Boolean,
+            default: false
+        },
+        responsive: {
+            type: Boolean,
+            default: false
+        },
+        headVariant: {
+            type: String,
+            default: ''
+        },
+        footVariant: {
+            type: String,
+            default: ''
+        },
+        perPage: {
+            type: Number,
+            default: null
+        },
+        currentPage: {
+            type: Number,
+            default: 1
+        },
+        filter: {
+            type: [String, RegExp, Function],
+            default: null
+        },
+        sortCompare: {
+            type: Function,
+            default: null
+        },
+        noProviderPaging: {
+            type: Boolean,
+            default: false
+        },
+        noProviderSorting: {
+            type: Boolean,
+            default: false
+        },
+        noProviderFiltering: {
+            type: Boolean,
+            default: false
+        },
+        busy: {
+            type: Boolean,
+            default: false
+        },
+        value: {
+            type: Array,
+            default: () => []
+        },
+        footClone: {
+            type: Boolean,
+            default: false
+        },
+        labelSortAsc: {
+            type: String,
+            default: 'Click to sort Ascending'
+        },
+        labelSortDesc: {
+            type: String,
+            default: 'Click to sort Descending'
+        },
+        showEmpty: {
+            type: Boolean,
+            default: false
+        },
+        emptyText: {
+            type: String,
+            default: 'There are no records to show'
+        },
+        emptyFilteredText: {
+            type: String,
+            default: 'There are no records matching your request'
         }
-        return toString(a[sortBy]).localeCompare(toString(b[sortBy]), undefined, {
-            numeric: true
+    },
+    watch: {
+        items(newVal, oldVal) {
+            if (oldVal !== newVal) {
+                this._providerUpdate();
+            }
+        },
+        filteredItems(newVal, oldVal) {
+            if (!this.providerFiltering && newVal.length !== oldVal.length) {
+                // Emit a filtered notification event, as number of filtered items has changed
+                this.$emit('filtered', newVal);
+            }
+        },
+        sortDesc(newVal, oldVal) {
+            if (newVal === this.localSortDesc) {
+                return;
+            }
+            this.localSortDesc = newVal || false;
+        },
+        localSortDesc(newVal, oldVal) {
+            // Emit update to sort-desc.sync
+            if (newVal !== oldVal) {
+                this.$emit('update:sortDesc', newVal);
+                if (!this.noProviderSorting) {
+                    this._providerUpdate();
+                }
+            }
+        },
+        sortBy(newVal, oldVal) {
+            if (newVal === this.localSortBy) {
+                return;
+            }
+            this.localSortBy = newVal || null;
+        },
+        localSortBy(newVal, oldVal) {
+            if (newVal !== oldVal) {
+                this.$emit('update:sortBy', newVal);
+                if (!this.noProviderSorting) {
+                    this._providerUpdate();
+                }
+            }
+        },
+        perPage(newVal, oldVal) {
+            if (oldVal !== newVal && !this.noProviderPaging) {
+                this._providerUpdate();
+            }
+        },
+        currentPage(newVal, oldVal) {
+            if (oldVal !== newVal && !this.noProviderPaging) {
+                this._providerUpdate();
+            }
+        },
+        filter(newVal, oldVal) {
+            if (oldVal !== newVal && !this.noProviderFiltering) {
+                this._providerUpdate();
+            }
+        },
+        localBusy(newVal, oldVal) {
+            if (newVal !== oldVal) {
+                this.$emit('update:busy', newVal);
+            }
+        }
+    },
+    mounted() {
+        this.localSortBy = this.sortBy;
+        this.localSortDesc = this.sortDesc;
+        this.localBusy = this.busy;
+        if (this.hasProvider) {
+            this._providerUpdate();
+        }
+        this.listenOnRoot('table::refresh', id => {
+            if (id === this.id) {
+                this._providerUpdate();
+            }
         });
-    };
-
-    export default {
-        mixins: [listenOnRootMixin],
-        data() {
+    },
+    computed: {
+        tableClass() {
+            return [
+                'table',
+                'b-table',
+                this.striped ? 'table-striped' : '',
+                this.hover ? 'table-hover' : '',
+                this.inverse ? 'table-inverse' : '',
+                this.bordered ? 'table-bordered' : '',
+                this.responsive ? 'table-responsive' : '',
+                this.small ? 'table-sm' : ''
+            ];
+        },
+        headClass() {
+            return this.headVariant ? 'thead-' + this.headVariant : '';
+        },
+        footClass() {
+            const variant = this.footVariant || this.headVariant || null;
+            return variant ? 'thead-' + variant : '';
+        },
+        hasProvider() {
+            return this.items instanceof Function;
+        },
+        providerFiltering() {
+            return Boolean(this.hasProvider && !this.noProviderFiltering);
+        },
+        providerSorting() {
+            return Boolean(this.hasProvider && !this.noProviderSorting);
+        },
+        providerPaging() {
+            return Boolean(this.hasProvider && !this.noProviderPaging);
+        },
+        context() {
             return {
-                localSortBy: this.sortBy || '',
-                localSortDesc: this.sortDesc || false,
-                localItems: [],
-                // Note: filteredItems only used to determine if # of items changed
-                filteredItems: [],
-                localBusy: this.busy
+                perPage: this.perPage,
+                currentPage: this.currentPage,
+                filter: this.filter,
+                apiUrl: this.apiUrl,
+                sortBy: this.localSortBy,
+                sortDesc: this.localSortDesc
             };
         },
-        props: {
-            id: {
-                type: String,
-                default: ''
-            },
-            items: {
-                type: [Array, Function],
-                default() {
-                    return [];
+        computedFields() {
+            let fields
+
+            // Normalize array Form
+            if (isArray(this.fields)) {
+                fields = {}
+                this.fields.filter(f => f).forEach(f => {
+                    fields[f.key || f] = f
+                })
+            } else {
+                fields = this.fields || {}
+            }
+
+            // If no field provided, take a sample from first record (if exits)
+            if (keys(fields).length === 0 && this.computedItems.length > 0) {
+                const sample = this.computedItems[0]
+                keys(sample).forEach(k => {
+                    fields[k] = true
+                })
+            }
+
+            // Normalize fields
+            keys(fields).forEach(k => {
+                // Hidden
+                if (fields[k] === false) {
+                    delete fields[k]
+                    return
                 }
-            },
-            sortBy: {
-                type: String,
-                default: null
-            },
-            sortDesc: {
-                type: Boolean,
-                default: false
-            },
-            apiUrl: {
-                type: String,
-                default: ''
-            },
-            fields: {
-                type: [Object, Array],
-                default: null
-            },
-            striped: {
-                type: Boolean,
-                default: false
-            },
-            bordered: {
-                type: Boolean,
-                default: false
-            },
-            inverse: {
-                type: Boolean,
-                default: false
-            },
-            hover: {
-                type: Boolean,
-                default: false
-            },
-            small: {
-                type: Boolean,
-                default: false
-            },
-            responsive: {
-                type: Boolean,
-                default: false
-            },
-            headVariant: {
-                type: String,
-                default: ''
-            },
-            footVariant: {
-                type: String,
-                default: ''
-            },
-            perPage: {
-                type: Number,
-                default: null
-            },
-            currentPage: {
-                type: Number,
-                default: 1
-            },
-            filter: {
-                type: [String, RegExp, Function],
-                default: null
-            },
-            sortCompare: {
-                type: Function,
-                default: null
-            },
-            noProviderPaging: {
-                type: Boolean,
-                default: false
-            },
-            noProviderSorting: {
-                type: Boolean,
-                default: false
-            },
-            noProviderFiltering: {
-                type: Boolean,
-                default: false
-            },
-            busy: {
-                type: Boolean,
-                default: false
-            },
-            value: {
-                type: Array,
-                default: () => []
-            },
-            footClone: {
-                type: Boolean,
-                default: false
-            },
-            labelSortAsc: {
-                type: String,
-                default: 'Click to sort Ascending'
-            },
-            labelSortDesc: {
-                type: String,
-                default: 'Click to sort Descending'
-            },
-            showEmpty: {
-                type: Boolean,
-                default: false
-            },
-            emptyText: {
-                type: String,
-                default: 'There are no records to show'
-            },
-            emptyFilteredText: {
-                type: String,
-                default: 'There are no records matching your request'
+                // Humanize field label
+                if (fields[k] === true) {
+                    fields[k] = { label: startCase(k) }
+                    return
+                }
+                // Formatter shortcut
+                if (typeof fields[k] === 'function') {
+                    fields[k] = {
+                        label: startCase(k),
+                        formatter: fields[k]
+                    }
+                    return
+                }
+                // Label shortcut
+                if (typeof fields[k] === 'string') {
+                    fields[k] = { label: startCase(k) }
+                }
+            })
+
+            return fields
+        },
+        computedItems() {
+            // Grab some props/data to ensure reactivity
+            const perPage = this.perPage;
+            const currentPage = this.currentPage;
+            const filter = this.filter;
+            const sortBy = this.localSortBy;
+            const sortDesc = this.localSortDesc;
+            const sortCompare = this.sortCompare || defaultSortCompare;
+
+            let items = this.hasProvider ? this.localItems : this.items;
+
+            if (!items) {
+                this.$nextTick(this._providerUpdate);
+                return [];
+            }
+
+            // Array copy for sorting, filtering, etc.
+            items = items.slice()
+            // Apply local filter
+            if (filter && !this.providerFiltering) {
+                if (filter instanceof Function) {
+                    items = items.filter(filter);
+                } else {
+                    let regex;
+                    if (filter instanceof RegExp) {
+                        regex = filter;
+                    } else {
+                        regex = new RegExp('.*' + filter + '.*', 'ig');
+                    }
+                    items = items.filter(item => {
+                        const test = regex.test(recToString(item));
+                        regex.lastIndex = 0;
+                        return test;
+                    });
+                }
+            }
+            if (!this.providerFiltering) {
+                // Make a local copy of filtered items to trigger filtered event
+                this.filteredItems = items.slice();
+            }
+
+            // Apply local Sort
+            if (sortBy && !this.providerSorting) {
+                items = items.sort(function sortItemsFn(a, b) {
+                    return sortCompare(a, b, sortBy) * (sortDesc ? -1 : 1);
+                });
+            }
+
+            // Apply local pagination
+            if (perPage && !this.providerPaging) {
+                // Grab the current page of data (which may be past filtered items)
+                items = items.slice((currentPage - 1) * perPage, currentPage * perPage);
+            }
+
+            // Update the value model with the filtered/sorted/paginated data set
+            this.$emit('input', items);
+            return items;
+        },
+        computedBusy() {
+            return this.busy || this.localBusy;
+        }
+    },
+    methods: {
+        keys,
+        fieldClass(field, key) {
+            return [
+                field.sortable ? 'sorting' : '',
+                (field.sortable && this.localSortBy === key) ? 'sorting_' + (this.localSortDesc ? 'desc' : 'asc') : '',
+                field.variant ? ('table-' + field.variant) : '',
+                field.class ? field.class : '',
+                field.thClass ? field.thClass : ''
+            ];
+        },
+        tdClass(field, item, key) {
+            let cellVariant = '';
+            if (item._cellVariants && item._cellVariants[key]) {
+                cellVariant = (this.inverse ? 'bg-' : 'table-') + item._cellVariants[key];
+            }
+            return [
+                (field.variant && !cellVariant) ? ((this.inverse ? 'bg-' : 'table-') + field.variant) : '',
+                cellVariant,
+                field.class ? field.class : '',
+                field.tdClass ? field.tdClass : ''
+            ];
+        },
+        rowClass(item) {
+            return [
+                item._rowVariant ? ((this.inverse ? 'bg-' : 'table-') + item._rowVariant) : ''
+            ];
+        },
+        rowClicked(e, item, index) {
+            if (this.computedBusy) {
+                // If table is busy (via provider) then don't propagate
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+            }
+            this.$emit('row-clicked', item, index, e);
+        },
+        rowDblClicked(e, item, index) {
+            if (this.computedBusy) {
+                // If table is busy (via provider) then don't propagate
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+            }
+            this.$emit('row-dblclicked', item, index, e);
+        },
+        rowHovered(e, item, index) {
+            if (this.computedBusy) {
+                // If table is busy (via provider) then don't propagate
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+            }
+            this.$emit('row-hovered', item, index, e);
+        },
+        headClicked(e, field, key) {
+            if (this.computedBusy) {
+                // If table is busy (via provider) then don't propagate
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+            }
+            let sortChanged = false;
+            if (field.sortable) {
+                if (key === this.localSortBy) {
+                    // Change sorting direction on current column
+                    this.localSortDesc = !this.localSortDesc;
+                } else {
+                    // Start sorting this column ascending
+                    this.localSortBy = key;
+                    this.localSortDesc = false;
+                }
+                sortChanged = true;
+            } else if (this.localSortBy) {
+                this.localSortBy = null;
+                this.localSortDesc = false;
+                sortChanged = true;
+            }
+
+            this.$emit('head-clicked', key, field, e);
+            if (sortChanged) {
+                // Sorting parameters changed
+                this.$emit('sort-changed', this.context);
             }
         },
-        watch: {
-            items(newVal, oldVal) {
-                if (oldVal !== newVal) {
-                    this._providerUpdate();
-                }
-            },
-            filteredItems(newVal, oldVal) {
-                if (!this.providerFiltering && newVal.length !== oldVal.length) {
-                    // Emit a filtered notification event, as number of filtered items has changed
-                    this.$emit('filtered', newVal);
-                }
-            },
-            sortDesc(newVal, oldVal) {
-                if (newVal === this.localSortDesc) {
-                    return;
-                }
-                this.localSortDesc = newVal || false;
-            },
-            localSortDesc(newVal, oldVal) {
-                // Emit update to sort-desc.sync
-                if (newVal !== oldVal) {
-                    this.$emit('update:sortDesc', newVal);
-                    if (!this.noProviderSorting) {
-                        this._providerUpdate();
-                    }
-                }
-            },
-            sortBy(newVal, oldVal) {
-                if (newVal === this.localSortBy) {
-                    return;
-                }
-                this.localSortBy = newVal || null;
-            },
-            localSortBy(newVal, oldVal) {
-                if (newVal !== oldVal) {
-                    this.$emit('update:sortBy', newVal);
-                    if (!this.noProviderSorting) {
-                        this._providerUpdate();
-                    }
-                }
-            },
-            perPage(newVal, oldVal) {
-                if (oldVal !== newVal && !this.noProviderPaging) {
-                    this._providerUpdate();
-                }
-            },
-            currentPage(newVal, oldVal) {
-                if (oldVal !== newVal && !this.noProviderPaging) {
-                    this._providerUpdate();
-                }
-            },
-            filter(newVal, oldVal) {
-                if (oldVal !== newVal && !this.noProviderFiltering) {
-                    this._providerUpdate();
-                }
-            },
-            localBusy(newVal, oldVal) {
-                if (newVal !== oldVal) {
-                    this.$emit('update:busy', newVal);
-                }
-             }
-        },
-        mounted() {
-            this.localSortBy = this.sortBy;
-            this.localSortDesc = this.sortDesc;
-            this.localBusy = this.busy;
+        refresh() {
+            // Expose refresh method
             if (this.hasProvider) {
                 this._providerUpdate();
             }
-            this.listenOnRoot('table::refresh', id => {
-                if (id === this.id) {
-                    this._providerUpdate();
-                }
-            });
         },
-        computed: {
-            tableClass() {
-                return [
-                    'table',
-                    'b-table',
-                    this.striped ? 'table-striped' : '',
-                    this.hover ? 'table-hover' : '',
-                    this.inverse ? 'table-inverse' : '',
-                    this.bordered ? 'table-bordered' : '',
-                    this.responsive ? 'table-responsive' : '',
-                    this.small ? 'table-sm' : ''
-                ];
-            },
-            headClass() {
-                return this.headVariant ? 'thead-' + this.headVariant : '';
-            },
-            footClass() {
-                const variant = this.footVariant || this.headVariant || null;
-                return variant ? 'thead-' + variant : '';
-            },
-            hasProvider() {
-                return this.items instanceof Function;
-            },
-            providerFiltering() {
-                return Boolean(this.hasProvider && !this.noProviderFiltering);
-            },
-            providerSorting() {
-                return Boolean(this.hasProvider && !this.noProviderSorting);
-            },
-            providerPaging() {
-                return Boolean(this.hasProvider && !this.noProviderPaging);
-            },
-            context() {
-                return {
-                    perPage: this.perPage,
-                    currentPage: this.currentPage,
-                    filter: this.filter,
-                    apiUrl: this.apiUrl,
-                    sortBy: this.localSortBy,
-                    sortDesc: this.localSortDesc
-                };
-            },
-            computedFields() {
-                let fields
+        _providerSetLocal(items) {
+            this.localItems = items && items.length > 0 ? items.slice() : [];
+            this.localBusy = false;
+            this.$emit('refreshed');
+            this.emitOnRoot('table::refreshed', this.id);
+        },
+        _providerUpdate() {
+            // Refresh the provider items
+            if (this.computedBusy || !this.hasProvider) {
+                // Don't refresh remote data if we are 'busy' or if no provider
+                return;
+            }
 
-                // Normalize array Form
-                if (isArray(this.fields)) {
-                    fields = {}
-                    this.fields.filter(f => f).forEach(f => {
-                        fields[f.key || f] = f
-                    })
-                } else {
-                    fields = this.fields || {}
-                }
+            // Set internal busy state
+            this.localBusy = true;
 
-                // If no field provided, take a sample from first record (if exits)
-                if (keys(fields).length === 0 && this.computedItems.length > 0) {
-                    const sample = this.computedItems[0]
-                    keys(sample).forEach(k => {
-                        fields[k] = true
-                    })
-                }
+            // Call provider function with context and optional callback
+            const data = this.items(this.context, this._providerSetLocal);
 
-                // Normalize fields
-                keys(fields).forEach(k => {
-                    // Hidden
-                    if (fields[k] === false) {
-                        delete fields[k]
-                        return
-                    }
-                    // Humanize field label
-                    if (fields[k] === true) {
-                         fields[k] = { label: startCase(k) }
-                         return
-                    }
-                    // Formatter shortcut
-                    if (typeof fields[k] === 'function') {
-                        fields[k] = {
-                            label: startCase(k),
-                            formatter: fields[k]
-                        }
-                        return
-                    }
-                    // Label shortcut
-                    if (typeof fields[k] === 'string') {
-                        fields[k] =  { label: startCase(k) }
-                    }
-                })
-
-                return fields
-            },
-            computedItems() {
-                // Grab some props/data to ensure reactivity
-                const perPage = this.perPage;
-                const currentPage = this.currentPage;
-                const filter = this.filter;
-                const sortBy = this.localSortBy;
-                const sortDesc = this.localSortDesc;
-                const sortCompare = this.sortCompare || defaultSortCompare;
-
-                let items = this.hasProvider ? this.localItems : this.items;
-
-                if (!items) {
-                    this.$nextTick(this._providerUpdate);
-                    return [];
-                }
-
-                // Shallow copy of items, so we don't mutate the original array order/size
-
-                items = JSON.parse(JSON.stringify(items))
-
-                // Apply formatter only if fields object defined
-                if (this.fields && this.fields.toString() === '[object Object]'){
-                    const keysToFormat = keys(this.fields).filter((k, i, a) => this.hasFormatter(this.fields[k]))
-                    keysToFormat.forEach(k =>{
-                        items.forEach(item =>{
-                            item[k] = this.callFormatter(item, k, this.fields[k])
-                        }, this)
-                    }, this)
-                }
-
-                // Apply local filter
-                if (filter && !this.providerFiltering) {
-                    if (filter instanceof Function) {
-                        items = items.filter(filter);
-                    } else {
-                        let regex;
-                        if (filter instanceof RegExp) {
-                            regex = filter;
-                        } else {
-                            regex = new RegExp('.*' + filter + '.*', 'ig');
-                        }
-                        items = items.filter(item => {
-                            const test = regex.test(recToString(item));
-                            regex.lastIndex = 0;
-                            return test;
-                        });
-                    }
-                }
-                if (!this.providerFiltering) {
-                    // Make a local copy of filtered items to trigger filtered event
-                    this.filteredItems = items.slice();
-                }
-
-                // Apply local Sort
-                if (sortBy && !this.providerSorting) {
-                    items = items.sort((a, b) => {
-                        const r = sortCompare(a, b, sortBy);
-                        return sortDesc ? (r * -1) : r;
-                    });
-                }
-
-                // Apply local pagination
-                if (perPage && !this.providerPaging) {
-                    // Grab the current page of data (which may be past filtered items)
-                    items = items.slice((currentPage - 1) * perPage, currentPage * perPage);
-                }
-
-                // Update the value model with the filtered/sorted/paginated data set
-                this.$emit('input', items);
-                return items;
-            },
-            computedBusy() {
-                return this.busy || this.localBusy;
+            if (data) if (data.then && typeof data.then === 'function') {
+                // Provider returned Promise
+                data.then(items => {
+                    this._providerSetLocal(items);
+                });
+            } else {
+                // Provider returned Array data
+                this._providerSetLocal(data);
             }
         },
-        methods: {
-            keys,
-            fieldClass (field, key) {
-                return [
-                    field.sortable ? 'sorting' : '',
-                    (field.sortable && this.localSortBy === key) ? 'sorting_' + (this.localSortDesc ? 'desc' : 'asc') : '',
-                    field.variant ? ('table-' + field.variant) : '',
-                    field.class ? field.class : '',
-                    field.thClass ? field.thClass : ''
-                ];
-            },
-            tdClass (field, item, key) {
-                let cellVariant = '';
-                if (item._cellVariants && item._cellVariants[key]) {
-                    cellVariant = (this.inverse ? 'bg-' : 'table-') + item._cellVariants[key];
-                }
-                return [
-                    (field.variant && !cellVariant) ? ((this.inverse ? 'bg-' : 'table-') + field.variant) : '',
-                    cellVariant,
-                    field.class ? field.class : '',
-                    field.tdClass ? field.tdClass : ''
-                ];
-            },
-            rowClass (item) {
-                return [
-                    item._rowVariant ? ((this.inverse ? 'bg-' : 'table-') + item._rowVariant) : ''
-                ];
-            },
-            rowClicked (e, item, index) {
-                if (this.computedBusy) {
-                    // If table is busy (via provider) then don't propagate
-                    e.preventDefault();
-                    e.stopPropagation();
-                    return;
-                }
-                this.$emit('row-clicked', item, index, e);
-            },
-            rowDblClicked (e, item, index) {
-                if (this.computedBusy) {
-                    // If table is busy (via provider) then don't propagate
-                    e.preventDefault();
-                    e.stopPropagation();
-                    return;
-                }
-                this.$emit('row-dblclicked', item, index, e);
-            },
-            rowHovered (e, item, index) {
-                if (this.computedBusy) {
-                    // If table is busy (via provider) then don't propagate
-                    e.preventDefault();
-                    e.stopPropagation();
-                    return;
-                }
-                this.$emit('row-hovered', item, index, e);
-            },
-            headClicked (e, field, key) {
-                if (this.computedBusy) {
-                    // If table is busy (via provider) then don't propagate
-                    e.preventDefault();
-                    e.stopPropagation();
-                    return;
-                }
-                let sortChanged = false;
-                if (field.sortable) {
-                    if (key === this.localSortBy) {
-                        // Change sorting direction on current column
-                        this.localSortDesc = !this.localSortDesc;
-                    } else {
-                        // Start sorting this column ascending
-                        this.localSortBy = key;
-                        this.localSortDesc = false;
-                    }
-                    sortChanged = true;
-                } else if (this.localSortBy) {
-                    this.localSortBy = null;
-                    this.localSortDesc = false;
-                    sortChanged = true;
-                }
-
-                this.$emit('head-clicked', key, field, e);
-                if (sortChanged) {
-                    // Sorting parameters changed
-                    this.$emit('sort-changed', this.context);
-                }
-            },
-            refresh () {
-                // Expose refresh method
-                if (this.hasProvider) {
-                    this._providerUpdate();
-                }
-            },
-            _providerSetLocal (items) {
-                this.localItems = (items && items.length > 0) ? items.slice() : [];
-                this.localBusy = false;
-                this.$emit('refreshed');
-                this.emitOnRoot('table::refreshed', this.id);
-            },
-            _providerUpdate () {
-                // Refresh the provider items
-                if (this.computedBusy || !this.hasProvider) {
-                    // Don't refresh remote data if we are 'busy' or if no provider
-                    return;
-                }
-
-                // Set internal busy state
-                this.localBusy = true;
-
-                // Call provider function with context and optional callback
-                const data = this.items(this.context, this._providerSetLocal);
-
-                if (data) if (data.then && typeof data.then === 'function') {
-                    // Provider returned Promise
-                    data.then(items => {
-                        this._providerSetLocal(items);
-                    });
-                } else {
-                    // Provider returned Array data
-                    this._providerSetLocal(data);
-                }
-            },
-            hasFormatter: (field) => field.formatter && ((typeof (field.formatter) === 'function') || (typeof (field.formatter) === 'string')),
-            callFormatter (item, key, field) {
-                if (field.formatter && (typeof (field.formatter) === 'function'))
+        getFormattedValue(item, key, field) {
+            return hasFormatter(field) ? this.callFormatter(item, key, field) : item[key]
+        },
+        callFormatter(item, key, field) {
+            if (field.formatter) {
+                if (typeof field.formatter === 'function') {
                     return field.formatter(item[key], key, item);
+                }
 
-                if (field.formatter && (typeof (this.$parent[field.formatter]) === 'function'))
+                if (typeof this.$parent[field.formatter] === 'function') {
                     return this.$parent[field.formatter](item[key], key, item);
+                }
+            } else {
+                return item[key]
             }
         }
-    };
+    }
+}
 </script>
 
 <style>
     /* Based on https://cdn.datatables.net/1.10.13/css/dataTables.bootstrap4.css */
 
-    table.b-table > thead > tr > .sorting,
-    table.b-table > tfoot > tr > .sorting {
+    table.b-table>thead>tr>.sorting,
+    table.b-table>tfoot>tr>.sorting {
         padding-right: 30px;
         cursor: pointer;
         position: relative;
     }
 
-    table.b-table thead > tr > .sorting:before,
-    table.b-table thead > tr > .sorting:after,
-    table.b-table tfoot > tr > .sorting:before,
-    table.b-table tfoot > tr > .sorting:after {
+    table.b-table thead>tr>.sorting:before,
+    table.b-table thead>tr>.sorting:after,
+    table.b-table tfoot>tr>.sorting:before,
+    table.b-table tfoot>tr>.sorting:after {
         position: absolute;
         bottom: 0.9em;
         display: block;
         opacity: 0.3;
     }
 
-    table.b-table.table-sm > thead > tr > .sorting:before,
-    table.b-table.table-sm > thead > tr > .sorting:after,
-    table.b-table.table-sm > tfoot > tr > .sorting:before,
-    table.b-table.table-sm > tfoot > tr > .sorting:after {
+    table.b-table.table-sm>thead>tr>.sorting:before,
+    table.b-table.table-sm>thead>tr>.sorting:after,
+    table.b-table.table-sm>tfoot>tr>.sorting:before,
+    table.b-table.table-sm>tfoot>tr>.sorting:after {
         bottom: 0.45em;
     }
 
-    table.b-table > thead > tr > .sorting:before,
-    table.b-table > tfoot > tr > .sorting:before {
+    table.b-table>thead>tr>.sorting:before,
+    table.b-table>tfoot>tr>.sorting:before {
         right: 1em;
         content: "\2191";
     }
 
-    table.b-table > thead > tr > .sorting:after,
-    table.b-table > tfoot > tr > .sorting:after {
+    table.b-table>thead>tr>.sorting:after,
+    table.b-table>tfoot>tr>.sorting:after {
         right: 0.5em;
         content: "\2193";
     }
 
-    table.b-table > thead > tr > .sorting_asc:after,
-    table.b-table > thead > tr > .sorting_desc:before,
-    table.b-table > tfoot > tr > .sorting_asc:after,
-    table.b-table > tfoot > tr > .sorting_desc:before {
+    table.b-table>thead>tr>.sorting_asc:after,
+    table.b-table>thead>tr>.sorting_desc:before,
+    table.b-table>tfoot>tr>.sorting_asc:after,
+    table.b-table>tfoot>tr>.sorting_desc:before {
         opacity: 1;
     }
 

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -72,7 +72,7 @@
                               :value="getFormattedValue(item, key, field)"
                               :unformatted="item[key]"
                               :item="item"
-                              :index="index">{{ getFormattedValue(item, key, field) }}</slot>
+                              :index="index"><div v-html="getFormattedValue(item, key, field)"></div></slot>
                     </td>
                 </template>
             </tr>

--- a/tests/components/table.spec.js
+++ b/tests/components/table.spec.js
@@ -1,627 +1,634 @@
-import {loadFixture, testVM, setData, nextTick, sleep} from '../helpers';
+import { loadFixture, testVM, setData, nextTick, sleep } from "../helpers";
 
-describe('table', async() => {
-    beforeEach(loadFixture('table'));
+describe("table", async () => {
+    beforeEach(loadFixture("table"));
     testVM();
 
-    it('all example tables should contain class names', async() => {
-        const { app: { $refs, $el } } = window
+    it("all example tables should contain class names", async () => {
+        const { app: { $refs, $el } } = window;
 
-        expect($refs.table_basic).toHaveAllClasses([
-            'table', 'b-table', 'table-striped', 'table-hover'
-        ])
+        expect($refs.table_basic).toHaveAllClasses(["table", "b-table", "table-striped", "table-hover"]);
 
         expect($refs.table_paginated).toHaveAllClasses([
-            'table', 'b-table', 'table-sm', 'table-striped', 'table-bordered', 'table-hover', 'table-responsive'
-        ])
+            "table",
+            "b-table",
+            "table-sm",
+            "table-striped",
+            "table-bordered",
+            "table-hover",
+            "table-responsive"
+        ]);
 
         expect($refs.table_inverse).toHaveAllClasses([
-            'table', 'b-table', 'table-sm', 'table-bordered', 'table-inverse'
-        ])
-    })
-    
-    it('table_basic should have thead and tbody', async() => {
-        const { app: { $refs, $el } } = window
+            "table",
+            "b-table",
+            "table-sm",
+            "table-bordered",
+            "table-inverse"
+        ]);
+    });
 
-        const parts = [...$refs.table_basic.$el.children]
+    it("table_basic should have thead and tbody", async () => {
+        const { app: { $refs, $el } } = window;
 
-        const thead = parts.find(el => el.tagName && el.tagName === 'THEAD')
-        expect(thead).toBeDefined()
+        const parts = [...$refs.table_basic.$el.children];
 
-        const tbody = parts.find(el => el.tagName && el.tagName === 'TBODY')
-        expect(tbody).toBeDefined()
+        const thead = parts.find(el => el.tagName && el.tagName === "THEAD");
+        expect(thead).toBeDefined();
 
-        const tfoot = parts.find(el => el.tagName && el.tagName === 'TFOOT')
-        expect(tfoot).not.toBeDefined()
-    })
+        const tbody = parts.find(el => el.tagName && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
 
-    it('table_paginated should have thead, tbody and tfoot', async() => {
-        const { app: { $refs, $el } } = window
+        const tfoot = parts.find(el => el.tagName && el.tagName === "TFOOT");
+        expect(tfoot).not.toBeDefined();
+    });
 
-        const parts = [...$refs.table_paginated.$el.children]
+    it("table_paginated should have thead, tbody and tfoot", async () => {
+        const { app: { $refs, $el } } = window;
 
-        const thead = parts.find(el => el.tagName && el.tagName === 'THEAD')
-        expect(thead).toBeDefined()
+        const parts = [...$refs.table_paginated.$el.children];
 
-        const tbody = parts.find(el => el.tagName && el.tagName === 'TBODY')
-        expect(tbody).toBeDefined()
+        const thead = parts.find(el => el.tagName && el.tagName === "THEAD");
+        expect(thead).toBeDefined();
 
-        const tfoot = parts.find(el => el.tagName && el.tagName === 'TFOOT')
-        expect(tfoot).toBeDefined()
-    })
+        const tbody = parts.find(el => el.tagName && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
 
-    it('table_inverse should have thead and tbody', async() => {
-        const { app: { $refs, $el } } = window
+        const tfoot = parts.find(el => el.tagName && el.tagName === "TFOOT");
+        expect(tfoot).toBeDefined();
+    });
 
-        const parts = [...$refs.table_inverse.$el.children]
+    it("table_inverse should have thead and tbody", async () => {
+        const { app: { $refs, $el } } = window;
 
-        const thead = parts.find(el => el.tagName && el.tagName === 'THEAD')
-        expect(thead).toBeDefined()
+        const parts = [...$refs.table_inverse.$el.children];
 
-        const tbody = parts.find(el => el.tagName && el.tagName === 'TBODY')
-        expect(tbody).toBeDefined()
+        const thead = parts.find(el => el.tagName && el.tagName === "THEAD");
+        expect(thead).toBeDefined();
 
-        const tfoot = parts.find(el => el.tagName && el.tagName === 'TFOOT')
-        expect(tfoot).not.toBeDefined()
-    })
+        const tbody = parts.find(el => el.tagName && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
 
-    it('table_paginated thead should contain class thead-inverse', async() => {
-        const { app: { $refs, $el } } = window
-        const thead = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === 'THEAD')
+        const tfoot = parts.find(el => el.tagName && el.tagName === "TFOOT");
+        expect(tfoot).not.toBeDefined();
+    });
+
+    it("table_paginated thead should contain class thead-inverse", async () => {
+        const { app: { $refs, $el } } = window;
+        const thead = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === "THEAD");
         expect(thead).toBeDefined();
         if (thead) {
-            expect(thead.classList.contains('thead-inverse')).toBe(true)
+            expect(thead.classList.contains("thead-inverse")).toBe(true);
         }
-    })
+    });
 
-    it('table_paginated tfoot should contain class thead-default', async() => {
-        const { app: { $refs, $el } } = window
-        const tfoot = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === 'TFOOT')
+    it("table_paginated tfoot should contain class thead-default", async () => {
+        const { app: { $refs, $el } } = window;
+        const tfoot = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === "TFOOT");
         expect(tfoot).toBeDefined();
         if (tfoot) {
-            expect(tfoot.classList.contains('thead-default')).toBe(true)
+            expect(tfoot.classList.contains("thead-default")).toBe(true);
         }
-    })
+    });
 
-    it('all examples have correct number of columns', async() => {
-        const { app: { $refs, $el } } = window
+    it("all examples have correct number of columns", async () => {
+        const { app: { $refs, $el } } = window;
 
-        const tables = [ 'table_basic', 'table_paginated', 'table_inverse' ]
+        const tables = ["table_basic", "table_paginated", "table_inverse"];
 
         tables.forEach((table, idx) => {
-            const vm = $refs[table]
-            const thead = [...vm.$el.children].find(el => el && el.tagName === 'THEAD')
+            const vm = $refs[table];
+            const thead = [...vm.$el.children].find(el => el && el.tagName === "THEAD");
             expect(thead).toBeDefined();
             if (thead) {
-                const tr = [...thead.children].find(el => el && el.tagName === 'TR')
-                expect(tr).toBeDefined()
+                const tr = [...thead.children].find(el => el && el.tagName === "TR");
+                expect(tr).toBeDefined();
                 if (tr) {
-                    expect(tr.children.length).toBe(Object.keys(vm.fields).length)
+                    expect(tr.children.length).toBe(Object.keys(vm.fields).length);
                 }
             }
-        })
-    })
+        });
+    });
 
-    it('all examples should show the correct number of visible rows', async() => {
-        const { app: { $refs, $el } } = window
-        const app = window.app
+    it("all examples should show the correct number of visible rows", async () => {
+        const { app: { $refs, $el } } = window;
+        const app = window.app;
 
-        const tables = [ 'table_basic', 'table_paginated', 'table_inverse' ]
-
-        tables.forEach((table, idx) => {
-            const vm = $refs[table]
-            const tbody = [...vm.$el.children].find(el => el && el.tagName === 'TBODY')
-            expect(tbody).toBeDefined()
-            if (tbody) {
-                expect(tbody.children.length).toBe(vm.perPage || app.items.length)
-            }
-        })
-    })
-
-    it('all examples have sortable & unsortable headers', async() => {
-        const { app: { $refs, $el } } = window
-        
-        const tables = [ 'table_basic', 'table_paginated', 'table_inverse' ]
-        const sortables = [ true, true, false, false ]
-
-        tables.forEach( table => {
-            const vm = $refs[table]
-            const thead = [...vm.$el.children].find(el => el && el.tagName === 'THEAD')
-            expect(thead).toBeDefined()
-            if (thead) {
-                const tr = [...thead.children].find(el => el && el.tagName === 'TR')
-                expect(tr).toBeDefined()
-                if (tr) {
-                    const fieldKeys = Object.keys(vm.fields)
-                    const ths = [...tr.children]
-                    expect(ths.length).toBe(fieldKeys.length)
-                    ths.forEach((th, idx) => {
-                        expect(th.classList.contains('sorting')).toBe(vm.fields[fieldKeys[idx]].sortable || false)
-                    })
-                }
-            }
-        })
-    })
-
-    it('table_paginated has sortable & unsortable footers', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const fieldKeys = Object.keys(vm.fields)
-
-        const tfoot = [...vm.$el.children].find(el => el && el.tagName === 'TFOOT')
-        expect(tfoot).toBeDefined()
-        if (tfoot) {
-            const tr = [...tfoot.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                const ths = [...tr.children]
-                expect(ths.length).toBe(fieldKeys.length)
-                ths.forEach((th, idx) => {
-                    expect(th.classList.contains('sorting')).toBe(vm.fields[fieldKeys[idx]].sortable || false)
-                })
-            }
-        }
-    })
-
-    it('all example tables should have attribute aria-busy="false" when busy is false', async() => {
-        const { app: { $refs, $el } } = window
-
-        const tables = [ 'table_basic', 'table_paginated', 'table_inverse' ]
-
-        await setData(app, 'isBusy', false)
-        await nextTick()
-
-        tables.forEach(table => {
-            expect($refs[table].$el.getAttribute('aria-busy')).toBe('false')
-        })
-    })
-
-    it('table_paginated should have attribute aria-busy="true" when busy is true', async() => {
-        const { app: { $refs, $el } } = window
-        const app = window.app
-
-        await setData(app, 'isBusy', true)
-        await nextTick()
-        expect($refs.table_paginated.$el.getAttribute('aria-busy')).toBe('true')
-
-        await setData(app, 'isBusy', false)
-        await nextTick()
-        expect($refs.table_paginated.$el.getAttribute('aria-busy')).toBe('false')
-    })
-
-    it('sortable columns should have ARIA labels in thead', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const ariaLabel = vm.labelSortDesc
-
-        const thead = [...vm.$el.children].find(el => el && el.tagName === 'THEAD')
-        expect(thead).toBeDefined()
-        if (thead) {
-            const tr = [...thead.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                expect(tr.children[0].getAttribute('aria-label')).toBe(ariaLabel)
-                expect(tr.children[1].getAttribute('aria-label')).toBe(ariaLabel)
-                expect(tr.children[2].getAttribute('aria-label')).toBe(null)
-                expect(tr.children[3].getAttribute('aria-label')).toBe(null)
-            }
-        }
-    })
-
-    it('sortable columns should have ARIA labels in tfoot', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const ariaLabel = vm.labelSortDesc
-
-        const tfoot = [...vm.$el.children].find(el => el && el.tagName === 'THEAD')
-        expect(tfoot).toBeDefined()
-        if (tfoot) {
-            const tr = [...tfoot.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                expect(tr.children[0].getAttribute('aria-label')).toBe(ariaLabel)
-                expect(tr.children[1].getAttribute('aria-label')).toBe(ariaLabel)
-                expect(tr.children[2].getAttribute('aria-label')).toBe(null)
-                expect(tr.children[3].getAttribute('aria-label')).toBe(null)
-            }
-        }
-    })
-
-    it('all examples should have variant "success" on 1st row', async() => {
-        const { app: { $refs, $el } } = window
-        const app = window.app
-
-        const tables = [ 'table_basic', 'table_paginated', 'table_inverse' ]
-
-        const items = app.items.slice()
-        items[0]._rowVariant = 'success'
-        await setData(app, 'items', items)
-        await nextTick()
+        const tables = ["table_basic", "table_paginated", "table_inverse"];
 
         tables.forEach((table, idx) => {
-            const vm = $refs[table]
-            const tbody = [...vm.$el.children].find(el => el && el.tagName == 'TBODY')
+            const vm = $refs[table];
+            const tbody = [...vm.$el.children].find(el => el && el.tagName === "TBODY");
             expect(tbody).toBeDefined();
             if (tbody) {
-                const tr = tbody.children[0]
-                const variant = vm.inverse ? 'bg-success' : 'table-success'
-                expect(Boolean(tr) && Boolean(tr.classList) && tr.classList.contains(variant)).toBe(true)
+                expect(tbody.children.length).toBe(vm.perPage || app.items.length);
             }
-        })
-    })
+        });
+    });
 
-    it('table_basic should contain custom formatted columns', async() => {
-        const { app: { $refs, $el } } = window
-        const app = window.app
-        const vm = $refs.table_basic
+    it("all examples have sortable & unsortable headers", async () => {
+        const { app: { $refs, $el } } = window;
 
-        const tbody = [...vm.$el.children].find(el => el && el.tagName === 'TBODY')
-        expect(tbody).toBeDefined()
-        if (tbody) {
-            const tr = [...tbody.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                expect(tr.children[0].textContent).toContain(vm.items[0].name.first + ' ' + vm.items[0].name.last)
-                expect(tr.children[1].textContent).toContain(String(vm.items[0].age))
-                expect(tr.children[3].children[0].tagName).toBe('BUTTON')
+        const tables = ["table_basic", "table_paginated", "table_inverse"];
+        const sortables = [true, true, false, false];
+
+        tables.forEach(table => {
+            const vm = $refs[table];
+            const thead = [...vm.$el.children].find(el => el && el.tagName === "THEAD");
+            expect(thead).toBeDefined();
+            if (thead) {
+                const tr = [...thead.children].find(el => el && el.tagName === "TR");
+                expect(tr).toBeDefined();
+                if (tr) {
+                    const fieldKeys = Object.keys(vm.fields);
+                    const ths = [...tr.children];
+                    expect(ths.length).toBe(fieldKeys.length);
+                    ths.forEach((th, idx) => {
+                        expect(th.classList.contains("sorting")).toBe(vm.fields[fieldKeys[idx]].sortable || false);
+                    });
+                }
             }
-        }
-    })
+        });
+    });
 
-    it('table_paginated should contain custom formatted columns', async() => {
-        const { app: { $refs, $el } } = window
-        const app = window.app
-        const vm = $refs.table_basic
-
-        const tbody = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === 'TBODY')
-        expect(tbody).toBeDefined()
-        if (tbody) {
-            const tr = [...tbody.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                expect(tr.children[0].textContent).toContain(vm.items[0].name.first + ' ' + vm.items[0].name.last)
-                expect(tr.children[1].textContent).toContain(String(vm.items[0].age))
-                expect(tr.children[3].children[0].tagName).toBe('INPUT')
-            }
-        }
-    })
-
-    it('table_paginated should contain custom formatted headers', async() => {
-        const { app: { $refs, $el } } = window
-
-        const thead = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === 'THEAD')
-        expect(thead).toBeDefined()
-        if (thead) {
-            const tr = [...thead.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                expect(tr.children[0].textContent).toContain('Person Full name')
-                expect(tr.children[1].textContent).toContain('Person age')
-                expect(tr.children[2].textContent).toContain('is Active')
-                expect(tr.children[3].textContent).toContain('Select')
-            }
-        }
-    })
-
-    it('table_paginated should contain custom formatted footers', async() => {
-        const { app: { $refs, $el } } = window
-
-        const tfoot = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === 'TFOOT')
-        expect(tfoot).toBeDefined()
-        if (tfoot) {
-            const tr = [...tfoot.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                expect(tr.children[0].textContent).toContain('Showing 5 People')
-                expect(tr.children[1].textContent).toContain('Person age')
-                expect(tr.children[2].textContent).toContain('is Active')
-                expect(tr.children[3].textContent).toContain('Selected: 0')
-            }
-        }
-    })
-
-    it('each data row should emit a row-clicked event when clicked', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-
-        const tbody = [...vm.$el.children].find(el => el && el.tagName === 'TBODY');
-        expect(tbody).toBeDefined();
-        if (tbody) {
-            const trs = [...tbody.children]
-            expect(trs.length).toBe(vm.perPage)
-            trs.forEach((tr, idx) => {
-                const spy = jest.fn()
-                vm.$on('row-clicked', spy)
-                tr.click()
-                vm.$off('row-clicked', spy)
-                expect(spy).toHaveBeenCalled()
-            })
-        }
-    })
-
-    it('each header th should emit a head-clicked event when clicked', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const fieldKeys = Object.keys(vm.fields)
-
-        const thead = [...vm.$el.children].find(el => el && el.tagName === 'THEAD');
-        expect(thead).toBeDefined()
-        if (thead) {
-            const tr = [...thead.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                const ths = [...tr.children]
-                expect(ths.length).toBe(fieldKeys.length)
-                ths.forEach((th, idx) => {
-                    const spy = jest.fn()
-                    vm.$on('head-clicked', spy)
-                    th.click()
-                    vm.$off('head-clicked', spy)
-                    expect(spy).toHaveBeenCalled()
-                })
-            }
-        }
-    })
-
-    it('each footer th should emit a head-clicked event when clicked', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const fieldKeys = Object.keys(vm.fields)
-
-        const tfoot = [...vm.$el.children].find(el => el && el.tagName === 'TFOOT');
-        expect(tfoot).toBeDefined()
-        if (tfoot) {
-            const tr = [...tfoot.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
-            if (tr) {
-                const ths = [...tr.children]
-                expect(ths.length).toBe(fieldKeys.length)
-                ths.forEach((th, idx) => {
-                    const spy = jest.fn()
-                    vm.$on('head-clicked', spy)
-                    th.click()
-                    vm.$off('head-clicked', spy)
-                    expect(spy).toHaveBeenCalled()
-                })
-            }
-        }
-    })
-
-    it('sortable header th should emit a sort-changed event with context when clicked and sort changed', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const spy = jest.fn()
+    it("table_paginated has sortable & unsortable footers", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
         const fieldKeys = Object.keys(vm.fields);
 
-        vm.$on('sort-changed', spy)
-        const thead = [...vm.$el.children].find(el => el && el.tagName === 'THEAD');
+        const tfoot = [...vm.$el.children].find(el => el && el.tagName === "TFOOT");
+        expect(tfoot).toBeDefined();
+        if (tfoot) {
+            const tr = [...tfoot.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                const ths = [...tr.children];
+                expect(ths.length).toBe(fieldKeys.length);
+                ths.forEach((th, idx) => {
+                    expect(th.classList.contains("sorting")).toBe(vm.fields[fieldKeys[idx]].sortable || false);
+                });
+            }
+        }
+    });
+
+    it('all example tables should have attribute aria-busy="false" when busy is false', async () => {
+        const { app: { $refs, $el } } = window;
+
+        const tables = ["table_basic", "table_paginated", "table_inverse"];
+
+        await setData(app, "isBusy", false);
+        await nextTick();
+
+        tables.forEach(table => {
+            expect($refs[table].$el.getAttribute("aria-busy")).toBe("false");
+        });
+    });
+
+    it('table_paginated should have attribute aria-busy="true" when busy is true', async () => {
+        const { app: { $refs, $el } } = window;
+        const app = window.app;
+
+        await setData(app, "isBusy", true);
+        await nextTick();
+        expect($refs.table_paginated.$el.getAttribute("aria-busy")).toBe("true");
+
+        await setData(app, "isBusy", false);
+        await nextTick();
+        expect($refs.table_paginated.$el.getAttribute("aria-busy")).toBe("false");
+    });
+
+    it("sortable columns should have ARIA labels in thead", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+        const ariaLabel = vm.labelSortDesc;
+
+        const thead = [...vm.$el.children].find(el => el && el.tagName === "THEAD");
         expect(thead).toBeDefined();
         if (thead) {
-            const tr = [...thead.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
+            const tr = [...thead.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
             if (tr) {
-                let sortBy = null
-                const ths = [...tr.children]
-                expect(ths.length).toBe(fieldKeys.length)
-                ths.forEach((th, idx) => {
-                    th.click()
-                    if (vm.fields[fieldKeys[idx]].sortable) {
-                        expect(spy).toHaveBeenCalledWith(vm.context)
-                        expect(vm.context.sortBy).toBe(fieldKeys[idx])
-                        sortBy = vm.context.sortBy
-                    } else {
-                        if (sortBy) {
-                            expect(spy).toHaveBeenCalledWith(vm.context)
-                            expect(vm.context.sortBy).toBe(null)
-                            sortBy = null
-                        } else {
-                            expect(spy).not.toHaveBeenCalled()
-                            expect(vm.context.sortBy).toBe(null)
-                        }
-                    }
-                    spy.mockClear()
-                })
+                expect(tr.children[0].getAttribute("aria-label")).toBe(ariaLabel);
+                expect(tr.children[1].getAttribute("aria-label")).toBe(ariaLabel);
+                expect(tr.children[2].getAttribute("aria-label")).toBe(null);
+                expect(tr.children[3].getAttribute("aria-label")).toBe(null);
             }
         }
-    })
+    });
 
-    it('sortable footer th should emit a sort-changed event with context when clicked and sort changed', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const spy = jest.fn()
+    it("sortable columns should have ARIA labels in tfoot", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+        const ariaLabel = vm.labelSortDesc;
+
+        const tfoot = [...vm.$el.children].find(el => el && el.tagName === "THEAD");
+        expect(tfoot).toBeDefined();
+        if (tfoot) {
+            const tr = [...tfoot.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                expect(tr.children[0].getAttribute("aria-label")).toBe(ariaLabel);
+                expect(tr.children[1].getAttribute("aria-label")).toBe(ariaLabel);
+                expect(tr.children[2].getAttribute("aria-label")).toBe(null);
+                expect(tr.children[3].getAttribute("aria-label")).toBe(null);
+            }
+        }
+    });
+
+    it('all examples should have variant "success" on 1st row', async () => {
+        const { app: { $refs, $el } } = window;
+        const app = window.app;
+
+        const tables = ["table_basic", "table_paginated", "table_inverse"];
+
+        const items = app.items.slice();
+        items[0]._rowVariant = "success";
+        await setData(app, "items", items);
+        await nextTick();
+
+        tables.forEach((table, idx) => {
+            const vm = $refs[table];
+            const tbody = [...vm.$el.children].find(el => el && el.tagName == "TBODY");
+            expect(tbody).toBeDefined();
+            if (tbody) {
+                const tr = tbody.children[0];
+                const variant = vm.inverse ? "bg-success" : "table-success";
+                expect(Boolean(tr) && Boolean(tr.classList) && tr.classList.contains(variant)).toBe(true);
+            }
+        });
+    });
+
+    it("table_basic should contain custom formatted columns", async () => {
+        const { app: { $refs, $el } } = window;
+        const app = window.app;
+        const vm = $refs.table_basic;
+
+        const tbody = [...vm.$el.children].find(el => el && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
+        if (tbody) {
+            const tr = [...tbody.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                expect(tr.children[0].textContent).toContain(vm.items[0].name.first + " " + vm.items[0].name.last);
+                expect(tr.children[1].textContent).toContain(String(vm.items[0].age));
+                expect(tr.children[3].children[0].tagName).toBe("BUTTON");
+            }
+        }
+    });
+
+    it("table_paginated should contain custom formatted columns", async () => {
+        const { app: { $refs, $el } } = window;
+        const app = window.app;
+        const vm = $refs.table_basic;
+
+        const tbody = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
+        if (tbody) {
+            const tr = [...tbody.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                expect(tr.children[0].textContent).toContain(vm.items[0].name.first + " " + vm.items[0].name.last);
+                expect(tr.children[1].textContent).toContain(String(vm.items[0].age));
+                expect(tr.children[3].children[0].tagName).toBe("INPUT");
+            }
+        }
+    });
+
+    it("table_paginated should contain custom formatted headers", async () => {
+        const { app: { $refs, $el } } = window;
+
+        const thead = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === "THEAD");
+        expect(thead).toBeDefined();
+        if (thead) {
+            const tr = [...thead.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                expect(tr.children[0].textContent).toContain("Person Full name");
+                expect(tr.children[1].textContent).toContain("Person age");
+                expect(tr.children[2].textContent).toContain("is Active");
+                expect(tr.children[3].textContent).toContain("Select");
+            }
+        }
+    });
+
+    it("table_paginated should contain custom formatted footers", async () => {
+        const { app: { $refs, $el } } = window;
+
+        const tfoot = [...$refs.table_paginated.$el.children].find(el => el && el.tagName === "TFOOT");
+        expect(tfoot).toBeDefined();
+        if (tfoot) {
+            const tr = [...tfoot.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                expect(tr.children[0].textContent).toContain("Showing 5 People");
+                expect(tr.children[1].textContent).toContain("Person age");
+                expect(tr.children[2].textContent).toContain("is Active");
+                expect(tr.children[3].textContent).toContain("Selected: 0");
+            }
+        }
+    });
+
+    it("each data row should emit a row-clicked event when clicked", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+
+        const tbody = [...vm.$el.children].find(el => el && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
+        if (tbody) {
+            const trs = [...tbody.children];
+            expect(trs.length).toBe(vm.perPage);
+            trs.forEach((tr, idx) => {
+                const spy = jest.fn();
+                vm.$on("row-clicked", spy);
+                tr.click();
+                vm.$off("row-clicked", spy);
+                expect(spy).toHaveBeenCalled();
+            });
+        }
+    });
+
+    it("each header th should emit a head-clicked event when clicked", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
         const fieldKeys = Object.keys(vm.fields);
 
-        vm.$on('sort-changed', spy)
-        const tfoot = [...vm.$el.children].find(el => el && el.tagName === 'TFOOT')
-        expect(tfoot).toBeDefined()
-        if (tfoot) {
-            const tr = [...tfoot.children].find(el => el && el.tagName === 'TR')
-            expect(tr).toBeDefined()
+        const thead = [...vm.$el.children].find(el => el && el.tagName === "THEAD");
+        expect(thead).toBeDefined();
+        if (thead) {
+            const tr = [...thead.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
             if (tr) {
-                let sortBy = null
-                const ths = [...tr.children]
-                expect(ths.length).toBe(fieldKeys.length)
+                const ths = [...tr.children];
+                expect(ths.length).toBe(fieldKeys.length);
                 ths.forEach((th, idx) => {
-                    th.click()
-                    if (vm.fields[fieldKeys[idx]].sortable) {
-                        expect(spy).toHaveBeenCalledWith(vm.context)
-                        expect(vm.context.sortBy).toBe(fieldKeys[idx])
-                        sortBy = vm.context.sortBy
-                    } else {
-                        if (sortBy) {
-                            expect(spy).toHaveBeenCalledWith(vm.context)
-                            expect(vm.context.sortBy).toBe(null)
-                            sortBy = null
-                        } else {
-                            expect(spy).not.toHaveBeenCalled()
-                            expect(vm.context.sortBy).toBe(null)
-                        }
-                    }
-                    spy.mockClear()
-                })
+                    const spy = jest.fn();
+                    vm.$on("head-clicked", spy);
+                    th.click();
+                    vm.$off("head-clicked", spy);
+                    expect(spy).toHaveBeenCalled();
+                });
             }
         }
-    })
+    });
 
-    it('table_paginated pagination works', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const app = window.app
-        const spy = jest.fn()
+    it("each footer th should emit a head-clicked event when clicked", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+        const fieldKeys = Object.keys(vm.fields);
 
-        const tbody = [...vm.$el.children].find(el => el && el.tagName === 'TBODY')
-        expect(tbody).toBeDefined()
+        const tfoot = [...vm.$el.children].find(el => el && el.tagName === "TFOOT");
+        expect(tfoot).toBeDefined();
+        if (tfoot) {
+            const tr = [...tfoot.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                const ths = [...tr.children];
+                expect(ths.length).toBe(fieldKeys.length);
+                ths.forEach((th, idx) => {
+                    const spy = jest.fn();
+                    vm.$on("head-clicked", spy);
+                    th.click();
+                    vm.$off("head-clicked", spy);
+                    expect(spy).toHaveBeenCalled();
+                });
+            }
+        }
+    });
+
+    it("sortable header th should emit a sort-changed event with context when clicked and sort changed", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+        const spy = jest.fn();
+        const fieldKeys = Object.keys(vm.fields);
+
+        vm.$on("sort-changed", spy);
+        const thead = [...vm.$el.children].find(el => el && el.tagName === "THEAD");
+        expect(thead).toBeDefined();
+        if (thead) {
+            const tr = [...thead.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                let sortBy = null;
+                const ths = [...tr.children];
+                expect(ths.length).toBe(fieldKeys.length);
+                ths.forEach((th, idx) => {
+                    th.click();
+                    if (vm.fields[fieldKeys[idx]].sortable) {
+                        expect(spy).toHaveBeenCalledWith(vm.context);
+                        expect(vm.context.sortBy).toBe(fieldKeys[idx]);
+                        sortBy = vm.context.sortBy;
+                    } else {
+                        if (sortBy) {
+                            expect(spy).toHaveBeenCalledWith(vm.context);
+                            expect(vm.context.sortBy).toBe(null);
+                            sortBy = null;
+                        } else {
+                            expect(spy).not.toHaveBeenCalled();
+                            expect(vm.context.sortBy).toBe(null);
+                        }
+                    }
+                    spy.mockClear();
+                });
+            }
+        }
+    });
+
+    it("sortable footer th should emit a sort-changed event with context when clicked and sort changed", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+        const spy = jest.fn();
+        const fieldKeys = Object.keys(vm.fields);
+
+        vm.$on("sort-changed", spy);
+        const tfoot = [...vm.$el.children].find(el => el && el.tagName === "TFOOT");
+        expect(tfoot).toBeDefined();
+        if (tfoot) {
+            const tr = [...tfoot.children].find(el => el && el.tagName === "TR");
+            expect(tr).toBeDefined();
+            if (tr) {
+                let sortBy = null;
+                const ths = [...tr.children];
+                expect(ths.length).toBe(fieldKeys.length);
+                ths.forEach((th, idx) => {
+                    th.click();
+                    if (vm.fields[fieldKeys[idx]].sortable) {
+                        expect(spy).toHaveBeenCalledWith(vm.context);
+                        expect(vm.context.sortBy).toBe(fieldKeys[idx]);
+                        sortBy = vm.context.sortBy;
+                    } else {
+                        if (sortBy) {
+                            expect(spy).toHaveBeenCalledWith(vm.context);
+                            expect(vm.context.sortBy).toBe(null);
+                            sortBy = null;
+                        } else {
+                            expect(spy).not.toHaveBeenCalled();
+                            expect(vm.context.sortBy).toBe(null);
+                        }
+                    }
+                    spy.mockClear();
+                });
+            }
+        }
+    });
+
+    it("table_paginated pagination works", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+        const app = window.app;
+        const spy = jest.fn();
+
+        const tbody = [...vm.$el.children].find(el => el && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
         if (tbody) {
             // We need between 11 and 14 ites for this test
-            expect(app.items.length > 10).toBe(true)
-            expect(app.items.length < 15).toBe(true)
+            expect(app.items.length > 10).toBe(true);
+            expect(app.items.length < 15).toBe(true);
 
-            vm.$on('input', spy)
+            vm.$on("input", spy);
 
             // Page size to be less then number of items
-            await setData(app, 'currentPage', 1)
-            await setData(app, 'perPage', 10)
-            await nextTick()
-            expect(vm.perPage).toBe(10)
-            expect(vm.value.length).toBe(10)
-            expect(tbody.children.length).toBe(10)
+            await setData(app, "currentPage", 1);
+            await setData(app, "perPage", 10);
+            await nextTick();
+            expect(vm.perPage).toBe(10);
+            expect(vm.value.length).toBe(10);
+            expect(tbody.children.length).toBe(10);
 
             // Goto page 2, should have length 1
-            await setData(app, 'currentPage', 2)
-            await nextTick()
-            expect(vm.value.length).toBe(app.items.length - 10)
-            expect(tbody.children.length).toBe(app.items.length - 10)
+            await setData(app, "currentPage", 2);
+            await nextTick();
+            expect(vm.value.length).toBe(app.items.length - 10);
+            expect(tbody.children.length).toBe(app.items.length - 10);
 
-            expect(spy).toHaveBeenCalled()
+            expect(spy).toHaveBeenCalled();
         }
-    })
+    });
 
-    it('table_paginated filtering works', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const app = window.app
-        const spy = jest.fn()
+    it("table_paginated filtering works", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+        const app = window.app;
+        const spy = jest.fn();
 
-        expect(vm.showEmpty).toBe(true)
-        expect(app.items.length > 10).toBe(true)
-        expect(app.items.length < 15).toBe(true)
-        
-        const tbody = [...vm.$el.children].find(el => el && el.tagName === 'TBODY')
-        expect(tbody).toBeDefined()
+        expect(vm.showEmpty).toBe(true);
+        expect(app.items.length > 10).toBe(true);
+        expect(app.items.length < 15).toBe(true);
+
+        const tbody = [...vm.$el.children].find(el => el && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
         if (tbody) {
-            expect(app.items.length > 1).toBe(true)
-            
-            vm.$on('input', spy)
+            expect(app.items.length > 1).toBe(true);
+
+            vm.$on("input", spy);
 
             // Set page size to max number of items
-            await setData(app, 'currentPage', 1)
-            await setData(app, 'perPage', 15)
-            await nextTick()
-            expect(vm.value.length).toBe(app.items.length)
-            expect(tbody.children.length).toBe(app.items.length)
+            await setData(app, "currentPage", 1);
+            await setData(app, "perPage", 15);
+            await nextTick();
+            expect(vm.value.length).toBe(app.items.length);
+            expect(tbody.children.length).toBe(app.items.length);
 
             // Apply Fiter
-            await setData(app, 'filter', String(app.items[0].name.last))
-            await nextTick()
-            expect(vm.value.length < app.items.length).toBe(true)
-            expect(tbody.children.length < app.items.length).toBe(true)
-            
+            await setData(app, "filter", String(app.items[0].name.last));
+            await nextTick();
+            expect(vm.value.length < app.items.length).toBe(true);
+            expect(tbody.children.length < app.items.length).toBe(true);
+
             // Empty filter alert
-            await setData(app, 'filter', 'ZZZZZZZZZZZZZZZZZzzzzzzzzzzzzzzzzz........')
-            await nextTick()
-            expect(vm.value.length).toBe(0)
-            expect(tbody.children.length).toBe(1)
-            expect(tbody.children[0].children[0].textContent).toContain(vm.emptyFilteredText)
+            await setData(app, "filter", "ZZZZZZZZZZZZZZZZZzzzzzzzzzzzzzzzzz........");
+            await nextTick();
+            expect(vm.value.length).toBe(0);
+            expect(tbody.children.length).toBe(1);
+            expect(tbody.children[0].children[0].textContent).toContain(vm.emptyFilteredText);
 
             expect(spy).toHaveBeenCalled();
         }
-    })
+    });
 
-    it('table_paginated shows empty message when no items', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_paginated
-        const app = window.app
-        const spy = jest.fn()
+    it("table_paginated shows empty message when no items", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_paginated;
+        const app = window.app;
+        const spy = jest.fn();
 
-        expect(vm.showEmpty).toBe(true)
+        expect(vm.showEmpty).toBe(true);
 
-        const tbody = [...vm.$el.children].find(el => el && el.tagName === 'TBODY')
-        expect(tbody).toBeDefined()
+        const tbody = [...vm.$el.children].find(el => el && el.tagName === "TBODY");
+        expect(tbody).toBeDefined();
         if (tbody) {
-            expect(app.items.length > 10).toBe(true)
-            expect(app.items.length < 15).toBe(true)
+            expect(app.items.length > 10).toBe(true);
+            expect(app.items.length < 15).toBe(true);
 
-            vm.$on('input', spy)
+            vm.$on("input", spy);
 
             // Set page size to show all items
-            await setData(app, 'currentPage', 1)
-            await setData(app, 'perPage', 15)
-            await nextTick()
-            expect(vm.value.length).toBe(app.items.length)
-            expect(tbody.children.length).toBe(app.items.length)
+            await setData(app, "currentPage", 1);
+            await setData(app, "perPage", 15);
+            await nextTick();
+            expect(vm.value.length).toBe(app.items.length);
+            expect(tbody.children.length).toBe(app.items.length);
 
             // Set items to empty list
-            await setData(app, 'items', [])
-            await nextTick()
-            expect(app.items.length).toBe(0)
-            expect(vm.value.length).toBe(0)
-            expect(tbody.children.length).toBe(1)
-            expect(tbody.textContent).toContain(vm.emptyText)
+            await setData(app, "items", []);
+            await nextTick();
+            expect(app.items.length).toBe(0);
+            expect(vm.value.length).toBe(0);
+            expect(tbody.children.length).toBe(1);
+            expect(tbody.textContent).toContain(vm.emptyText);
 
             expect(spy).toHaveBeenCalled();
         }
-    })
+    });
 
-    it('table_provider should emit a refreshed event for providerArray', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_provider
-        const spy = jest.fn()
+    it("table_provider should emit a refreshed event for providerArray", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_provider;
+        const spy = jest.fn();
 
-        await setData(app, 'providerType', 'array')
-        await nextTick()
-        await sleep(100)
+        await setData(app, "providerType", "array");
+        await nextTick();
+        await sleep(100);
 
-        vm.$on('refreshed', spy)
+        vm.$on("refreshed", spy);
         vm.refresh();
-        await nextTick()
-        await sleep(100)
+        await nextTick();
+        await sleep(100);
 
-        expect(spy).toHaveBeenCalled()
+        expect(spy).toHaveBeenCalled();
         // expect(vm.value.length).toBe(app.items.length)
-    })
+    });
 
-    it('table_provider should emit a refreshed event for providerCallback', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_provider
-        const spy = jest.fn()
+    it("table_provider should emit a refreshed event for providerCallback", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_provider;
+        const spy = jest.fn();
 
-        await setData(app, 'providerType', 'callback')
-        await nextTick()
-        await sleep(100)
+        await setData(app, "providerType", "callback");
+        await nextTick();
+        await sleep(100);
 
-        vm.$on('refreshed', spy)
+        vm.$on("refreshed", spy);
         vm.refresh();
-        await nextTick()
-        await sleep(100)
+        await nextTick();
+        await sleep(100);
 
-        expect(spy).toHaveBeenCalled()
-    })
+        expect(spy).toHaveBeenCalled();
+    });
 
-    it('table_provider should emit a refreshed event for providerPromise', async() => {
-        const { app: { $refs, $el } } = window
-        const vm = $refs.table_provider
-        const spy = jest.fn()
+    it("table_provider should emit a refreshed event for providerPromise", async () => {
+        const { app: { $refs, $el } } = window;
+        const vm = $refs.table_provider;
+        const spy = jest.fn();
 
-        await setData(app, 'providerType', 'promise')
-        await nextTick()
-        await sleep(100)
+        await setData(app, "providerType", "promise");
+        await nextTick();
+        await sleep(100);
 
-        vm.$on('refreshed', spy)
+        vm.$on("refreshed", spy);
         vm.refresh();
-        await nextTick()
-        await sleep(100)
+        await nextTick();
+        await sleep(100);
 
-        expect(spy).toHaveBeenCalled()
-    })
-
+        expect(spy).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
Formatter now doesn't alter item records, allowing a revert back to basic array.slice() shallow copy of items (for speed).

Slight change in how field custom format slots work.  Formatted value is passed to slot as `value`, and unformatted  value as `unformatted`. `item` is the raw row data (no formatted/overwritten values). If no formatter is provided `value` will be the same as `unformatted`.

Basic HTML is supported as output of formatter (no components).

`sort-compare` function will now fall back to built-in defaultSortCompare routine if `sort-compare` returns `null`, allowing users to handle only special case fields in their custom `sort-compare` routine.
