### PR TITLE
fix(carousel): Prevent reflow trigger from being optimised out

### DIFF
--- a/lib/components/carousel.vue
+++ b/lib/components/carousel.vue
@@ -114,6 +114,12 @@
         return null;
     }
 
+    // Function to trigger a reflow of an element layout
+    // To help prevent this line from being optimized out
+    function reflow(el) {
+      return el.offsetHeight;
+    }
+
     export default {
         mixins: [ idMixin ],
         data() {
@@ -331,8 +337,7 @@
 
                 nextSlide.classList.add(direction.overlayClass);
                 // Trigger a reflow of next slide
-                // eslint-disable-next-line no-unused-expressions
-                nextSlide.offsetHeight;
+                reflow(nextSlide);
 
                 currentSlide.classList.add(direction.dirClass);
                 nextSlide.classList.add(direction.dirClass);

--- a/lib/components/carousel.vue
+++ b/lib/components/carousel.vue
@@ -331,8 +331,8 @@
 
                 nextSlide.classList.add(direction.overlayClass);
                 // Trigger a reflow of next slide
-                // eslint-disable-next-line no-void
-                void(nextSlide.offsetHeight);
+                // eslint-disable-next-line no-unused-expressions
+                nextSlide.offsetHeight;
 
                 currentSlide.classList.add(direction.dirClass);
                 nextSlide.classList.add(direction.dirClass);


### PR DESCRIPTION
requesting `el.offsetHight` is needed to trigger a reflow of an element in some browsers. transpilation was optimizing this statement out of the dist compiled files.

This fix should hopefully prevent that from occurring.

Fix for issue #993 
