### PR TITLE
fix(tooltip+popover): Click not triggered for elements with inner HTML elements in Chrome/WebKit

### DIFF
--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -610,10 +610,6 @@ class ToolTip {
 
     handleEvent(e) {
         // This special method allows us to use "this" as the event handlers
-        if (!e.target || e.target !== this.$element) {
-            // If this event isn't for us, then just return
-            return;
-        }
         if (elDisabled(this.$element)) {
             // If disabled, don't do anything. Note: if tip is shown before element gets
             // disabled, then tip not close until no longer disabled or forcefully closed.


### PR DESCRIPTION
Addresses issue #1005 

This fix removed the check for `e.target === this.$element`