### PR TITLE
feat(modal): Improve modal transitions, padding adjustments, and aditional features

### DIFF
--- a/docs/components/button/meta.json
+++ b/docs/components/button/meta.json
@@ -1,9 +1,7 @@
 {
   "title": "Button",
   "component": "bButton",
-  "components": [
-    "bLink"
-  ],
+  "components": ["bLink", "bButtonClose"],
   "events": [
     {
       "event": "click",

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -223,7 +223,8 @@ methods: {
 **Note**: events `ok` and `cancel` are emitted by modal's built in **OK** and **Cancel**
 buttons respectively. These events will not be emitted, by default, if you have provided your own
 buttons in the `modal-footer` slot or have hidden the footer. In this case use the `hide` event
-to control cancelling of the modal close.
+to control cancelling of the modal close. Event `hide` is always emitted, even if `ok` and `cancel`
+are emitted.
 
 The `ok`, `cancel`, and `hide` event object containsseveral properties and methods:
 
@@ -269,21 +270,25 @@ anywhere else.
 
 ## Tooltips and popovers
 Tooltips and popovers can be placed within modals as needed. When modals are closed, any tooltips
-and popovers within are also automatically dismissed.  Just remember to specify the modal's ID as the
-tooltip or popover's `container` to ensure they are not hidden behind the modal.
+and popovers within are also automatically dismissed. Tooltips and popovers are automatically
+appended to the modal element (to ensure correct z-indexing), although you can override where
+they are appended by specifying a container ID (refer to tooltip and popover docs for details).
 
 ```html
 <div>
   <b-btn v-b-modal.modalPopover>Show Modal</b-btn>
   <b-modal id="modalPopover" title="Modal with Popover" ok-only>
-    This 
-    <b-btn v-b-popover:modalPopover="'Popover inside a modal!'" title="Popover">
-      Button
-    </b-btn>
-    triggers a popover on click.
-    <br><br>
-    This <a href="#" v-b-tooltip:modalPopover title="Tooltip in a modal!">Link</a>
-    will show a tooltip on hover.
+    <p>
+      This 
+      <b-btn v-b-popover="'Popover inside a modal!'" title="Popover">
+        Button
+      </b-btn>
+      triggers a popover on click.
+    </p>
+    <p>
+      This <a href="#" v-b-tooltip: title="Tooltip in a modal!">Link</a>
+      will show a tooltip on hover.
+    </p>
   </b-modal>
 </div>
 
@@ -291,10 +296,13 @@ tooltip or popover's `container` to ensure they are not hidden behind the modal.
 ```
 
 ## Variants
-Control the header, foorter, and body background and text variants by setting the `header-bg-variant`,
-`header-text-variant`, `body-bg-variant`, `body-text-variant`, `footer-bg-variant`, and `footer-text-variant`
-props. Use any of the standard Bootstrap variants shuch as `danger`, `warning`, `info`, `success`, `dark`,
-`light`, etc.
+Control the header, foorter, and body background and text variants by setting the
+`header-bg-variant`, `header-text-variant`, `body-bg-variant`, `body-text-variant`,
+`footer-bg-variant`, and `footer-text-variant` props. Use any of the standard Bootstrap
+variants shuch as `danger`, `warning`, `info`, `success`, `dark`, `light`, etc.
+
+The variants for the bottom border of the header and top border of the footer can be
+controlled by the `header-border-variant` and `footer-border-variant` props respectively.
 
 ## Accessibility
 
@@ -307,14 +315,7 @@ not be present if you have the header hidden.
 
 ### Auto Focus
 
-`<b-modal>` will autofocus the first visible, non-disabled, focusable element found
-in the modal, searching in the following order:
-
-- Modal body
-- Modal footer
-- Modal header
-
-If a focusable element is not found, then the entire modal will be focused.
+`<b-modal>` will autofocus the modal container when opened.
 
 You can pre-focus an element within the `<b-modal>` by listening to the `<b-modal>` `shown` event, and
 call the element's `focus()` method. `<b-modal>` will not attempt to autofocus if
@@ -341,15 +342,6 @@ methods: {
     }
 }
 ```
-
-To disable the auto-focus feature, add the prop `no-auto-focus` on
-`<b-modal>`. This will disable searching for a focusable element within
-body, footer, and header. With `no-auto-focus` set, the modal-content
-will be focused instead, unless you have pre-focused an element within.
-
-`no-auto-focus`may be required when you have modal with long body content (without
-focusable items in th modal body) that causes the modal to overflow the
-height of the viewport, and in-turn automatically scrolls down to the footer buttons.
 
 ### Returning focus to the triggering element on modal close
 

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -286,7 +286,7 @@ they are appended by specifying a container ID (refer to tooltip and popover doc
       triggers a popover on click.
     </p>
     <p>
-      This <a href="#" v-b-tooltip: title="Tooltip in a modal!">Link</a>
+      This <a href="#" v-b-tooltip title="Tooltip in a modal!">Link</a>
       will show a tooltip on hover.
     </p>
   </b-modal>

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -1,7 +1,8 @@
 # Modals
 
-> Modals are streamlined, but flexible dialog prompts powered by JavaScript.
-They support a number of use cases from user notification to completely custom content and feature a handful of helpful sub-components, sizes, accessibility, and more.
+> Modals are streamlined, but flexible dialog prompts powered by JavaScript and CSS. They
+support a number of use cases from user notification to completely custom content and
+feature a handful of helpful sub-components, sizes, variants, accessibility, and more.
 
 ```html
 <template>
@@ -40,7 +41,7 @@ They support a number of use cases from user notification to completely custom c
                 this.name = '';
             },
             handleOk(e) {
-                e.cancel();
+                e.preventDefault();
                 if (!this.name) {
                     alert('Please enter your name');
                 } else {
@@ -50,7 +51,7 @@ They support a number of use cases from user notification to completely custom c
             handleSubmit() {
                 this.names.push(this.name);
                 this.clearName();
-                this.$refs.modal1.hide()
+                this.$refs.modal1.hide();
             }
         }
     }
@@ -59,7 +60,7 @@ They support a number of use cases from user notification to completely custom c
 <!-- modal.vue -->
 ```
 
-`<b-modal>`, by default, has an **OK** and a **Close** button in the footer. These buttons can
+`<b-modal>`, by default, has an **OK** and **Cancel** buttons in the footer. These buttons can
 be customized by setting various props on the component. You can customize the size of the buttons,
 disable the **OK** button, hide the **Close** button (i.e. OK Only), choose a variant (e.g. `danger`
 for a red OK button) using the `ok-variant` and `close-variant` props, and provide custom
@@ -74,9 +75,9 @@ You can override the modal title via the named slot `modal-title`, override the
 header completely via the `modal-header` slot, and override the footer completely
 via the `modal-footer` slot. 
 
-**Note**: when using the `modal-footer` slot, the default **OK** and **Close** buttons will not be present. 
-Also, if you use the `modal-header` slot, the default header `X` close button will not be present, nor can you use
-the `modal-title` slot.
+**Note**: when using the `modal-footer` slot, the default **OK** and **Close** buttons will not
+be present. Also, if you use the `modal-header` slot, the default header `X` close button will
+not be present, nor can you use the `modal-title` slot.
 
 ## Toggle Modal Visibility
 
@@ -84,7 +85,7 @@ There are several methods that you can employ to toggle the visibility of `<b-mo
 
 ### Using `v-b-modal` directive (recommended)
 
-Other elements can easily show modals using `v-b-modal` directive.
+Other elements can easily show modals using the `v-b-modal` directive.
 
 ```html
 <!-- Using modifiers -->
@@ -153,16 +154,18 @@ data: {
 When using the `v-model` property, do not use the `visible` property at the same time.
 
 
-### Directly Emitting Events
+### Emitting Events on $root
 
-You can emit `show::modal` and `hide::modal` event on `$root` with first
-argument which is the modal's id:
+You can emit `bv::show::modal` and `bv::hide::modal` event on `$root` with the first
+argument set to the modal's id. An optional second argument can specify the element
+to return focus to once the modal is closed. The second argument can be a CSS selector,
+and element reference, or a component reference.
 
 ```html
 <b-button @click="showModal" ref="btnShow">
     Open Modal
 </b-button>
-<b-modal id="modal1">
+<b-modal id="modal1" @hidden="onHidden">
     Hello From My Modal!
     <b-btn @click="hideModal">Close Me</b-btn>
 </b-modal>
@@ -171,10 +174,12 @@ argument which is the modal's id:
 ```js
 methods: {
     showModal() {
-        this.$root.$emit('show::modal','modal1');
+        this.$root.$emit('bv::show::modal','modal1');
     },
     hideModal() {
-        this.$root.$emit('hide::modal','modal1');
+        this.$root.$emit('bv::hide::modal','modal1');
+    },
+    onHidden(evt) {
         // Return focus to our Open Modal button
         // See accessibility below for additional return-focus methods
         this.$refs.btnShow.$el.focus();
@@ -185,12 +190,12 @@ methods: {
 
 ## Prevent Closing
 
-To prevent `<b-modal>` from closing (for example when validation fails)
-you can call the `cancel()` method of the event object passed to your `ok` (**OK** button),
-`cancel` (**Close** button) and `hide` event handlers.
+To prevent `<b-modal>` from closing (for example when validation fails). you can call
+the `preventDefault()` method of the event object passed to your `ok` (**OK** button),
+`cancel` (**Cancel** button) and `hide` event handlers.
 
 ```html
-<b-modal @hide="save">
+<b-modal id="modalPrevent" @hide="save">
     Hello From Modal!
     <b-alert variant="danger" :show="message ? true : false">
         {{ message }}
@@ -207,7 +212,7 @@ methods: {
     save(e) {
         if(!this.saved) {
             this.message = 'Please save your work';
-            return e.cancel();
+            e.preventDefault();
         } else {
             this.message = null;
         }
@@ -215,29 +220,81 @@ methods: {
 }
 ```
 
-**Note**: events `ok` and `cancel` are emitted by modal's built in **OK** and **Close**
+**Note**: events `ok` and `cancel` are emitted by modal's built in **OK** and **Cancel**
 buttons respectively. These events will not be emitted, by default, if you have provided your own
 buttons in the `modal-footer` slot or have hidden the footer. In this case use the `hide` event
 to control cancelling of the modal close.
 
-The `close` event object contains a single property and a single method:
+The `ok`, `cancel`, and `hide` event object containsseveral properties and methods:
 
 | Property or Method | Type | Description
 | ------------ | ------ | --------------------------------------------
-| `e.cancel()` | Method | When called prevents the modal from closing
-| `isOK` | Property | Will be one of: `true` (Default **OK** Clicked), `false` (Default **Close** clicked), the argument provided to the `hide()` method, or `undefined` otherwise (i.e. close on Esc, or close on backdrop click)
+| `e.preventDefault()` | Method | When called prevents the modal from closing
+| `trigger` | Property | Will be one of: `ok` (Default **OK** Clicked), `cancel` (Default **Cancel** clicked), `esc` (if the <kbd>ESC</kbd> key was pressed), `backdrop` (if the backdrop was clicked), `headerclose` (if the header X button was clicked), the argument provided to the `hide()` method, or `undefined` otherwise.
+| `target` | Property | A refernece to the modal element
+| `vueTarget` | property | A refernce to the modal's Vue VM instance
 
-You can set the value of `isOK` by passing an argument to the component's
+You can set the value of `trigger` by passing an argument to the component's
 `hide()` method for advanced control. 
 
-**Note:** `ok` and `cancel` events will be only emitted when the argument to `hide()` is strictly `true`
-or `fase` respectively. The argument passed to `hide()` will be placed into the
-`isOK` property of the close event object.
+**Note:** `ok` and `cancel` events will be only emitted when the argument to `hide()` is strictly `ok`
+or `cancel` respectively. The argument passed to `hide()` will be placed into the
+`trigger` property of the event object.
 
 
 ## Modal sizing
+Modals have two optional sizes, available via the prop `size`. These sizes kick in at certain
+breakpoints to avoid horizontal scrollbars on narrower viewports. Valid optional sizez are
+`lg`, or `sm`.
 
-The width of `<b-modal>` can be set via the `size` prop to `lg`, `sm` or `md` (default).
+```html
+<div>
+  <b-btn v-b-modal.modallg variant="primary">Large modal</b-btn>
+  <b-btn v-b-modal.modalsm variant="primary">Small modal</b-btn>
+
+  <b-modal id="modallg" size="lg" title="Large Modal">
+    Hello Modal!
+  </b-modal>
+  <b-modal id="modalsm" size="sm" title="Small Modal">
+    Hello Modal!
+  </b-modal>
+</div>
+
+<!-- modal-sizes.vue -->
+```
+## Using the grid
+Utilize the Bootstrap grid system within a modal by nesting `<b-container fluid>` within
+the modal-body. Then, use the normal grid system `<b-row>` and `<b-col>` as you would
+anywhere else.
+
+## Tooltips and popovers
+Tooltips and popovers can be placed within modals as needed. When modals are closed, any tooltips
+and popovers within are also automatically dismissed.  Just remember to specify the modal's ID as the
+tooltip or popover's `container` to ensure they are not hidden behind the modal.
+
+```html
+<div>
+  <b-btn v-b-modal.modalPopover>Show Modal</b-btn>
+  <b-modal id="modalPopover" title="Modal with Popover" ok-only>
+    This 
+    <b-btn v-b-popover:modalPopover="'Popover inside a modal!'" title="Popover">
+      Button
+    </b-btn>
+    triggers a popover on click.
+    <br><br>
+    This <a href="#" v-b-tooltip:modalPopover title="Tooltip in a modal!">Link</a>
+    will show a tooltip on hover.
+  </b-modal>
+</div>
+
+<!-- modal-popover.vue -->
+```
+
+## Variants
+Control the header, foorter, and body background and text variants by setting the `header-bg-variant`,
+`header-text-variant`, `body-bg-variant`, `body-text-variant`, `footer-bg-variant`, and `footer-text-variant`
+props. Use any of the standard Bootstrap variants shuch as `danger`, `warning`, `info`, `success`, `dark`,
+`light`, etc.
 
 ## Accessibility
 

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -57,7 +57,7 @@ feature a handful of helpful sub-components, sizes, variants, accessibility, and
     }
 </script>
 
-<!-- modal.vue -->
+<!-- modal-1.vue -->
 ```
 
 `<b-modal>`, by default, has an **OK** and **Cancel** buttons in the footer. These buttons can
@@ -101,54 +101,68 @@ Other elements can easily show modals using the `v-b-modal` directive.
 ```
 
 Focus will automatically be returned to the trigger element once the modal closes.
-See the  **Accessibility** section below for details.
+See the **Accessibility** section below for details.
 
 ### Using `show()` and `hide()` component methods
 
 You can access modal using `ref` attribute and then call the `show()` or `hide()` methods.
 
 ```html
-<b-button @click="showModal">
-    Open Modal
-</b-button>
-<b-modal ref="my_modal">
-    Hello From My Modal!
-    <b-btn @click="hideModal">Close Me</b-btn>
-</b-modal>
-```
+<template>
+    <b-button @click="showModal">
+        Open Modal
+    </b-button>
+    <b-modal ref="myModalRef" title="Using Component Methods">
+        <div class="d-block text-center">
+            <h3>Hello From My Modal!</h3>
+        </div>
+        <b-btn class="mt-3" variant="outline-danger" block @click="hideModal">Close Me</b-btn>
+    </b-modal>
+</template>
 
-```js
-methods: {
-    showModal() {
-        this.$refs.my_modal.show();
-    },
-    hideModal() {
-        this.$refs.my_modal.hide();
+<script>
+export default {
+    methods: {
+        showModal() {
+            this.$refs.myModalRef.show();
+        },
+        hideModal() {
+            this.$refs.myModalRef.hide();
+        }
     }
 }
+</script>
+
+<!-- modal-2.vue -->
 ```
 
 The `hide()` method accepts an optional argument. See section **Prevent Closing**
 below for details.
 
-### Using `v-model` property.
+### Using `v-model` property
 
 `v-model` property is always automatically synced with `<b-modal>` visible state
 and you can show/hide using `v-model`.
 
 ```html
-<b-button @click="modalShow = !modalShow">
-    Open Modal
-</b-button>
-<b-modal v-model="modalshow">
-    Hello From Modal!
-</b-modal>
-```
+<template>
+    <b-button @click="modalShow = !modalShow">
+        Open Modal
+    </b-button>
+    <b-modal v-model="modalShow">
+        Hello From Modal!
+    </b-modal>
+</template>
 
-```js
-data: {
-    modalShow: false
+<script>
+export default {
+    data: {
+        modalShow: false
+    }
 }
+</script>
+
+<!-- modal-3.vue -->
 ```
 
 When using the `v-model` property, do not use the `visible` property at the same time.
@@ -166,7 +180,7 @@ and element reference, or a component reference.
     Open Modal
 </b-button>
 <b-modal id="modal1" @hidden="onHidden">
-    Hello From My Modal!
+    <div class="d-block">Hello From My Modal!</div>
     <b-btn @click="hideModal">Close Me</b-btn>
 </b-modal>
 ```

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -73,7 +73,7 @@ props `no-close-on-esc`, `no-close-on-backdrop`, and `hide-header-close` respect
 
 You can override the modal title via the named slot `modal-title`, override the
 header completely via the `modal-header` slot, and override the footer completely
-via the `modal-footer` slot. 
+via the `modal-footer` slot.
 
 **Note**: when using the `modal-footer` slot, the default **OK** and **Close** buttons will not
 be present. Also, if you use the `modal-header` slot, the default header `X` close button will
@@ -226,17 +226,17 @@ buttons in the `modal-footer` slot or have hidden the footer. In this case use t
 to control cancelling of the modal close. Event `hide` is always emitted, even if `ok` and `cancel`
 are emitted.
 
-The `ok`, `cancel`, and `hide` event object containsseveral properties and methods:
+The `ok`, `cancel`, and `hide` event object contains several properties and methods:
 
 | Property or Method | Type | Description
 | ------------ | ------ | --------------------------------------------
 | `e.preventDefault()` | Method | When called prevents the modal from closing
 | `trigger` | Property | Will be one of: `ok` (Default **OK** Clicked), `cancel` (Default **Cancel** clicked), `esc` (if the <kbd>ESC</kbd> key was pressed), `backdrop` (if the backdrop was clicked), `headerclose` (if the header X button was clicked), the argument provided to the `hide()` method, or `undefined` otherwise.
-| `target` | Property | A refernece to the modal element
-| `vueTarget` | property | A refernce to the modal's Vue VM instance
+| `target` | Property | A reference to the modal element
+| `vueTarget` | property | A reference to the modal's Vue VM instance
 
 You can set the value of `trigger` by passing an argument to the component's
-`hide()` method for advanced control. 
+`hide()` method for advanced control.
 
 **Note:** `ok` and `cancel` events will be only emitted when the argument to `hide()` is strictly `ok`
 or `cancel` respectively. The argument passed to `hide()` will be placed into the
@@ -245,7 +245,7 @@ or `cancel` respectively. The argument passed to `hide()` will be placed into th
 
 ## Modal sizing
 Modals have two optional sizes, available via the prop `size`. These sizes kick in at certain
-breakpoints to avoid horizontal scrollbars on narrower viewports. Valid optional sizez are
+breakpoints to avoid horizontal scrollbars on narrower viewports. Valid optional sizes are
 `lg`, or `sm`.
 
 ```html
@@ -279,7 +279,7 @@ they are appended by specifying a container ID (refer to tooltip and popover doc
   <b-btn v-b-modal.modalPopover>Show Modal</b-btn>
   <b-modal id="modalPopover" title="Modal with Popover" ok-only>
     <p>
-      This 
+      This
       <b-btn v-b-popover="'Popover inside a modal!'" title="Popover">
         Button
       </b-btn>
@@ -296,10 +296,10 @@ they are appended by specifying a container ID (refer to tooltip and popover doc
 ```
 
 ## Variants
-Control the header, foorter, and body background and text variants by setting the
+Control the header, footer, and body background and text variants by setting the
 `header-bg-variant`, `header-text-variant`, `body-bg-variant`, `body-text-variant`,
 `footer-bg-variant`, and `footer-text-variant` props. Use any of the standard Bootstrap
-variants shuch as `danger`, `warning`, `info`, `success`, `dark`, `light`, etc.
+variants such as `danger`, `warning`, `info`, `success`, `dark`, `light`, etc.
 
 The variants for the bottom border of the header and top border of the footer can be
 controlled by the `header-border-variant` and `footer-border-variant` props respectively.
@@ -310,7 +310,7 @@ controlled by the `header-border-variant` and `footer-border-variant` props resp
 focus, and keyboard (tab) _focus containment_.
 
 For `aria-labelledby` and `aria-described` by attributes to appear on the
-modal, you **must** supply an `id` attribute on `<b-modal>`. `aria-labeledby` will
+modal, you **must** supply an `id` attribute on `<b-modal>`. `aria-labelledby` will
 not be present if you have the header hidden.
 
 ### Auto Focus

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -62,9 +62,9 @@ feature a handful of helpful sub-components, sizes, variants, accessibility, and
 
 `<b-modal>`, by default, has an **OK** and **Cancel** buttons in the footer. These buttons can
 be customized by setting various props on the component. You can customize the size of the buttons,
-disable the **OK** button, hide the **Close** button (i.e. OK Only), choose a variant (e.g. `danger`
-for a red OK button) using the `ok-variant` and `close-variant` props, and provide custom
-button content using the `ok-title` and `close-title` props, or using the named
+disable the **OK** button, hide the **Cancel** button (i.e. OK Only), choose a variant (e.g. `danger`
+for a red OK button) using the `ok-variant` and `cancel-variant` props, and provide custom
+button content using the `ok-title` and `cancel-title` props, or using the named
 slots `modal-ok` and `modal-cancel`.
 
 `<b-modal>` supports close on ESC (enabled by default), close on backdrop click (enabled by default), and
@@ -75,7 +75,7 @@ You can override the modal title via the named slot `modal-title`, override the
 header completely via the `modal-header` slot, and override the footer completely
 via the `modal-footer` slot.
 
-**Note**: when using the `modal-footer` slot, the default **OK** and **Close** buttons will not
+**Note**: when using the `modal-footer` slot, the default **OK** and **Cancel** buttons will not
 be present. Also, if you use the `modal-header` slot, the default header `X` close button will
 not be present, nor can you use the `modal-title` slot.
 
@@ -89,14 +89,14 @@ Other elements can easily show modals using the `v-b-modal` directive.
 
 ```html
 <!-- Using modifiers -->
-<b-btn v-b-modal.modal1>Show Modal</b-btn>
+<b-btn v-b-modal.myModal>Show Modal</b-btn>
 
 <!-- Using value -->
-<b-btn v-b-modal="'modal1'">Show Modal</b-btn>
+<b-btn v-b-modal="'myMmodal'">Show Modal</b-btn>
 
 <!-- the modal -->
-<b-modal id="modal1">
-    Hello From Modal 1!
+<b-modal id="myMmodal">
+    Hello From My Modal!
 </b-modal>
 ```
 
@@ -179,7 +179,7 @@ and element reference, or a component reference.
 <b-button @click="showModal" ref="btnShow">
     Open Modal
 </b-button>
-<b-modal id="modal1" @hidden="onHidden">
+<b-modal @hidden="onHidden">
     <div class="d-block">Hello From My Modal!</div>
     <b-btn @click="hideModal">Close Me</b-btn>
 </b-modal>

--- a/docs/components/modal/meta.json
+++ b/docs/components/modal/meta.json
@@ -13,15 +13,22 @@
       ]
     },
     {
-      "event": "shown",
-      "description": "always emits when modal is shown"
+      "event": "show",
+      "description": "always emits just before modal is shown. cancelable",
+       "args": [
+        {
+          "arg": "bvEvt",
+          "description": "BvEvent object. Call bvEvt.preventDefault() to cancel show"
+        }
+      ]
     },
     {
-      "event": "hidden",
-      "description": "always emits after modal is hidden",
+      "event": "shown",
+      "description": "always emits when modal is shown",
       "args": [
         {
-          "e": "Close event object. Non Cancellable: See docs"
+          "arg": "bvEvt",
+          "description": "BvEvent object"
         }
       ]
     },
@@ -30,25 +37,38 @@
       "description": "always emits just before modal has hidden",
       "args": [
         {
-         "e": "Close event object. Cancellable: See docs"
+          "arg": "bvEvt",
+          "description": "BvEvent object. Call bvEvt.preventDefault() to cancel hide"
+        }
+      ]
+    },
+    {
+      "event": "hidden",
+      "description": "always emits after modal is hidden",
+      "args": [
+        {
+          "arg": "bvEvt",
+          "description": "BvEvent object"
         }
       ]
     },
     {
       "event": "ok",
-      "description": "when default OK button pressed, just before modal has hidden",
+      "description": "when default OK button pressed, just before modal has hidden. Cancelable",
       "args": [
         {
-          "e": "Close event object. Cancellable: See docs"
+          "arg": "bvEvt",
+          "description": "BvEvent object. Call bvEvt.preventDefault() to cancel hide"
         }
       ]
     },
     {
       "event": "cancel",
-      "description": "when default CANCEL (close) button pressed, just before modal has hidden",
+      "description": "when default CANCEL button pressed, just before modal has hidden. Cancelable",
       "args": [
         {
-          "e": "Close event object. Cancelable: See docs"
+          "arg": "bvEvt",
+          "description": "BvEvent object. Call bvEvt.preventDefault() to cancel hide"
         }
       ]
     }
@@ -56,7 +76,7 @@
   "slots": [
     {
       "name": "modal-header",
-      "description": "Entire modal header container. Also removes the top right X close button."
+      "description": "Entire modal header container contents. Also removes the top right X close button."
     },
     {
       "name": "modal-title",
@@ -72,7 +92,7 @@
     },
     {
       "name": "modal-cancel",
-      "description": "Modal Close (cancel) button content."
+      "description": "Modal CANCEL button content."
     }
   ]
 }

--- a/docs/components/modal/meta.json
+++ b/docs/components/modal/meta.json
@@ -83,6 +83,10 @@
       "description": "Modal title. If modal-header slot is used, this slot will not be shown."
     },
     {
+      "name": "modal-header-close",
+      "description": "Content of Modal heaqder close button. If modal-header slot is used, this slot will not be shown."
+    },
+    {
       "name": "modal-footer",
       "description": "Modal footer content. Also removes default OK and CANCEL buttons."
     },

--- a/lib/classes/popover.js
+++ b/lib/classes/popover.js
@@ -1,5 +1,6 @@
 import ToolTip from './tooltip';
 import { assign } from '../utils/object';
+import { select } from '../utils/dom';
 
 const NAME = 'popover';
 const CLASS_PREFIX = 'bs-popover';
@@ -44,8 +45,8 @@ class PopOver extends ToolTip {
         if (!tip) {
             return false;
         }
-        const hasTitle = Boolean((tip.querySelector(Selector.TITLE) || {}).innerHTML);
-        const hasContent = Boolean((tip.querySelector(Selector.CONTENT) || {}).innerHTML);
+        const hasTitle = Boolean((select(Selector.TITLE, tip) || {}).innerHTML);
+        const hasContent = Boolean((select(Selector.CONTENT, tip) || {}).innerHTML);
         return hasTitle || hasContent;
     }
 
@@ -54,9 +55,9 @@ class PopOver extends ToolTip {
     }
 
     setContent(tip) {
-        // we use append for html objects to maintain js events
-        this.setElementContent(tip.querySelector(Selector.TITLE), this.getTitle());
-        this.setElementContent(tip.querySelector(Selector.CONTENT), this.getContent());
+        // we use append for html objects to maintain js events/components
+        this.setElementContent(select(Selector.TITLE, tip), this.getTitle());
+        this.setElementContent(select(Selector.CONTENT, tip), this.getContent());
 
         tip.classList.remove(ClassName.FADE);
         tip.classList.remove(ClassName.SHOW);

--- a/lib/classes/popover.js
+++ b/lib/classes/popover.js
@@ -1,6 +1,6 @@
 import ToolTip from './tooltip';
 import { assign } from '../utils/object';
-import { select } from '../utils/dom';
+import { select, addClass, removeClass, getAttr } from '../utils/dom';
 
 const NAME = 'popover';
 const CLASS_PREFIX = 'bs-popover';
@@ -51,7 +51,7 @@ class PopOver extends ToolTip {
     }
 
     addAttachmentClass(attachment) {
-        this.getTipElement().classList.add(`${CLASS_PREFIX}-${attachment}`);
+        addClass(this.getTipElement(), `${CLASS_PREFIX}-${attachment}`);
     }
 
     setContent(tip) {
@@ -59,8 +59,8 @@ class PopOver extends ToolTip {
         this.setElementContent(select(Selector.TITLE, tip), this.getTitle());
         this.setElementContent(select(Selector.CONTENT, tip), this.getContent());
 
-        tip.classList.remove(ClassName.FADE);
-        tip.classList.remove(ClassName.SHOW);
+        removeClass(tip, ClassName.FADE);
+        removeClass(tip, ClassName.SHOW);
     }
 
     // This method may look identical to ToolTip version, but it uses a different RegEx defined above
@@ -69,7 +69,7 @@ class PopOver extends ToolTip {
         const tabClass = tip.className.match(BSCLS_PREFIX_REGEX);
         if (tabClass !== null && tabClass.length > 0) {
             tabClass.forEach(cls => {
-                tip.classList.remove(cls);
+                removeClass(tip, cls);
             });
         }
     }
@@ -87,8 +87,8 @@ class PopOver extends ToolTip {
             title = title.trim();
         }
         if (!title) {
-            // Try and grab elements title attribute
-            title = this.$element.getAttribute('title') || this.$element.getAttribute('data-original-title') || '';
+            // Try and grab element's title attribute
+            title = getAttr(this.$element, 'title') || getAttr(this, 'data-original-title') || '';
             title = title.trim();
         }
         return title;

--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -1,7 +1,7 @@
 import Popper from 'popper.js';
 import { assign, keys } from '../utils/object';
 import { from as arrayFrom } from '../utils/array';
-import { closest, isVisible, isDisabled } from '../utils/dom';
+import { closest, select, isVisible, isDisabled } from '../utils/dom';
 import BvEvent from './BvEvent';
 
 const NAME = 'tooltp';
@@ -386,7 +386,8 @@ class ToolTip {
     getContainer () {
         const container = this.$config.container;
         const body = document.body;
-        return container === false ? body : (body.querySelector(container) || body);
+        // If we are in a modal, we append to the modal instead of body, unless a container is specified
+        return container === false ? (closest(MODAL_CLASS, this.$element) || body) : (select(container, body) || body);
     }
 
     addAriaDescribedby() {
@@ -463,7 +464,7 @@ class ToolTip {
         if (!tip) {
             return false;
         }
-        return Boolean((tip.querySelector(Selector.TOOLTIP_INNER) || {}).innerHTML);
+        return Boolean((select(Selector.TOOLTIP_INNER, tip) || {}).innerHTML);
     }
 
     // NOTE: Overridden by PopOver class
@@ -492,7 +493,7 @@ class ToolTip {
 
     // NOTE: Overridden by PopOver class
     setContent(tip) {
-        this.setElementContent(tip.querySelector(Selector.TOOLTIP_INNER), this.getTitle());
+        this.setElementContent(select(Selector.TOOLTIP_INNER, tip), this.getTitle());
         tip.classList.remove(ClassName.FADE);
         tip.classList.remove(ClassName.SHOW);
     }

--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -1,7 +1,7 @@
 import Popper from 'popper.js';
 import { assign, keys } from '../utils/object';
 import { from as arrayFrom } from '../utils/array';
-import { closest, select, isVisible, isDisabled } from '../utils/dom';
+import { closest, select, isVisible, isDisabled, addClass, removeClass, hasClass, addAttr, removeAttr, getAttr } from '../utils/dom';
 import BvEvent from './BvEvent';
 
 const NAME = 'tooltp';
@@ -184,7 +184,7 @@ class ToolTip {
                 this.leave(null);
             }
         } else {
-            if (this.getTipElement().classList.contains(ClassName.SHOW)) {
+            if (hasClass(this.getTipElement(), ClassName.SHOW)) {
                 this.leave(null);
             } else {
                 this.enter(null);
@@ -210,11 +210,15 @@ class ToolTip {
         }
         
         // Set ID on tip and aria-describedby on element
-        tip.setAttribute('id', this.$id);
+        setAttr(tip, 'id', this.$id);
         this.addAriaDescribedby();
 
         // Set animation on or off
-        tip.classList[this.$config.animation ? 'add' : 'remove'](ClassName.FADE);
+        if (this.$config.animation) {
+            addClass(tip, ClassName.FADE);
+        } else {
+            removeClass(tip, ClassName.FADE);
+        }
 
         const placement = this.getPlacement();
         const attachment = this.constructor.getAttachment(placement);
@@ -265,7 +269,7 @@ class ToolTip {
         this.setWhileOpenListeners(true);
 
         // Show tip
-        tip.classList.add(ClassName.SHOW);
+        addClass(tip, ClassName.SHOW);
 
         // Start the transition/animation
         this.transitionOnce(tip, complete);
@@ -278,7 +282,7 @@ class ToolTip {
         if (on) {
             this.$visibleInterval = setInterval(() => {
                 const tip = this.getTipElement();
-                if (tip && !isVisible(this.$element) && tip.classList.contains(ClassName.SHOW)) {
+                if (tip && !isVisible(this.$element) && hasClass(tip, ClassName.SHOW)) {
                     // Element is no longer visible, so force-hide the tooltip
                     this.forceHide();
                 }
@@ -310,7 +314,7 @@ class ToolTip {
         // Remove animation for quicker hide
         const initAnimation = this.$config.animation;
         this.$config.animation = false;
-        tip.classList.remove(ClassName.FADE);
+        removeClass(tip, ClassName.FADE);
         // Hide the tip
         this.hide(null, true);
         this.$config.animation = initAnimation;
@@ -359,7 +363,7 @@ class ToolTip {
         this.setWhileOpenListeners(false);
 
         // Hide tip
-        tip.classList.remove(ClassName.SHOW);
+        removeClass(tip, ClassName.SHOW);
 
         this.$activeTrigger.click = false;
         this.$activeTrigger.focus = false;
@@ -392,18 +396,18 @@ class ToolTip {
 
     addAriaDescribedby() {
         // Add aria-describedby on trigger element, without removing any other IDs
-        let desc = this.$element.getAttribute('aria-describedby') || '';
+        let desc = getAttr(this.$element, 'aria-describedby') || '';
         desc = desc.split(/\s+/).concat(this.$id).join(' ').trim();
-        this.$element.setAttribute('aria-describedby', desc);
+        setAttr(this.$element, 'aria-describedby', desc);
     }
 
     removeAriaDescribedby() {
-        let desc = this.$element.getAttribute('aria-describedby') || '';
+        let desc = getAttr(this.$element, 'aria-describedby') || '';
         desc = desc.replace(this.$id, '').replace(/\s+/g,' ').trim();
         if (desc) {
-            this.$element.setAttribute('aria-describedby', desc);
+            setAttr(this.$element, 'aria-describedby', desc);
         } else {
-            this.$element.removeAttribute('aria-describedby');
+            removeAttr(this.$element,'aria-describedby');
         }
     }
 
@@ -430,7 +434,7 @@ class ToolTip {
             // Call complete callback
             complete();
         };
-        if (tip.classList.contains(ClassName.FADE)) {
+        if (hasClass(tip, ClassName.FADE)) {
             transEvents.forEach(evtName => {
                 this.$tip.addEventListener(evtName, fnOnce);
             });
@@ -469,7 +473,7 @@ class ToolTip {
 
     // NOTE: Overridden by PopOver class
     addAttachmentClass(attachment) {
-        this.getTipElement().classList.add(`${CLASS_PREFIX}-${attachment}`);
+        addClass(this.getTipElement(), `${CLASS_PREFIX}-${attachment}`);
     }
 
     getTipElement() {
@@ -494,8 +498,8 @@ class ToolTip {
     // NOTE: Overridden by PopOver class
     setContent(tip) {
         this.setElementContent(select(Selector.TOOLTIP_INNER, tip), this.getTitle());
-        tip.classList.remove(ClassName.FADE);
-        tip.classList.remove(ClassName.SHOW);
+        removeClass(tip, ClassName.FADE);
+        removeClass(tip, ClassName.SHOW);
     }
 
     setElementContent(container, content) {
@@ -536,7 +540,7 @@ class ToolTip {
         }
         if (!title) {
             // If an explicit title is not given, try element's title atributes
-            title = this.$element.getAttribute('title') || this.$element.getAttribute('data-original-title') || '';
+            title = getAttr(this.$element, 'title') || getAttr(this.$element, 'data-original-title') || '';
             title = title.trim();
         }
 
@@ -650,10 +654,10 @@ class ToolTip {
 
     fixTitle() {
         const el = this.$element;
-        const titleType = typeof el.getAttribute('data-original-title');
-        if (el.getAttribute('title') || titleType !== 'string') {
-            el.setAttribute('data-original-title', el.getAttribute('title') || '');
-            el.setAttribute('title', '');
+        const titleType = typeof getAttr(el, 'data-original-title');
+        if (getAttr(el, 'title') || titleType !== 'string') {
+            setAttr(el, 'data-original-title', getAttr(el, 'title') || '');
+            setAttr(el, 'title', '');
         }
     }
 
@@ -662,7 +666,7 @@ class ToolTip {
         if (e) {
             this.$activeTrigger[e.type === 'focusin' ? 'focus' : 'hover'] = true;
         }
-        if (this.getTipElement().classList.contains(ClassName.SHOW) || this.$hoverState === HoverState.SHOW) {
+        if (hasClass(this.getTipElement(), ClassName.SHOW) || this.$hoverState === HoverState.SHOW) {
             this.$hoverState = HoverState.SHOW;
             return;
         }
@@ -750,7 +754,7 @@ class ToolTip {
         const tabClass = tip.className.match(BSCLS_PREFIX_REGEX);
         if (tabClass !== null && tabClass.length > 0) {
             tabClass.forEach(cls => {
-                tip.classList.remove(cls);
+                removeClass(tip, cls);
             });
         }
     }
@@ -762,10 +766,10 @@ class ToolTip {
 
     fixTransition(tip) {
         const initConfigAnimation = this.$config.animation || false;
-        if (tip.getAttribute('x-placement') !== null) {
+        if (getAttr(tip, 'x-placement') !== null) {
             return;
         }
-        tip.classList.remove(ClassName.FADE);
+        removeClass(tip, ClassName.FADE);
         this.$config.animation = false;
         this.hide();
         this.show();

--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -11,7 +11,7 @@ const BSCLS_PREFIX_REGEX = new RegExp(`\\b${CLASS_PREFIX}\\S+`, 'g');
 const TRANSITION_DURATION = 150;
 
 // Modal $root event (prepare for future evnt name change)
-const MODAL_CLOSE_EVENT = ['bv::modal::hidden', 'hidden::modal'];
+const MODAL_CLOSE_EVENT = 'bv::modal::hidden';
 const MODAL_CLASS = '.modal';
 
 const AttachmentMap = {
@@ -620,9 +620,7 @@ class ToolTip {
         }
         // We can listen for modal hidden events on $root
         if (this.$root) {
-            MODAL_CLOSE_EVENT.forEach(evtName => {
-                this.$root[on ? '$on' : '$off'](evtName, this.forceHide.bind(this));
-            });
+            this.$root[on ? '$on' : '$off'](MODAL_CLOSE_EVENT, this.forceHide.bind(this));
         }
     }
 

--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -1,7 +1,7 @@
 import Popper from 'popper.js';
-import { assign, keys } from '../utils/object';
+import { assign } from '../utils/object';
 import { from as arrayFrom } from '../utils/array';
-import { closest, select, isVisible, isDisabled, addClass, removeClass, hasClass, addAttr, removeAttr, getAttr } from '../utils/dom';
+import { closest, select, isVisible, isDisabled, addClass, removeClass, hasClass, setAttr, removeAttr, getAttr } from '../utils/dom';
 import BvEvent from './BvEvent';
 
 const NAME = 'tooltp';
@@ -133,7 +133,7 @@ class ToolTip {
         if (config.content && typeof config.content === 'number') {
             updatedConfig.content = config.content.toString();
         }
-        
+
         // Hide element original title if needed
         this.fixTitle();
         // Update the config
@@ -208,7 +208,7 @@ class ToolTip {
             this.$tip = null;
             return;
         }
-        
+
         // Set ID on tip and aria-describedby on element
         setAttr(tip, 'id', this.$id);
         this.addAriaDescribedby();

--- a/lib/components/alert.vue
+++ b/lib/components/alert.vue
@@ -5,23 +5,19 @@
          aria-live="polite"
          aria-atomic="true"
     >
-        <button type="button"
-                class="close"
-                v-if="dismissible"
-                data-dismiss="alert"
-                :aria-label="dismissLabel"
-                @click.stop.prevent="dismiss"
-        >
-            <span class="d-inline-block" aria-hidden="true"><slot name="dismiss">&times;</slot></span>
-        </button>
+        <b-btn-close v-if="dismissible" :aria-label="dismissLabel" @click="dismiss">
+          <slot name="dismiss"></slot>
+        </b-btn-close>
         <slot></slot>
     </div>
 </template>
 
 <script>
     import {warn} from '../utils';
+    import bBtnClose from "./button-close";
 
     export default {
+        components: {bBtnClose},
         model: {
             prop: 'show',
             event: 'input'

--- a/lib/components/button-close.js
+++ b/lib/components/button-close.js
@@ -7,7 +7,7 @@ const props = {
     },
     ariaLabel: {
         type: String,
-        default: 'Close'
+        default: "Close"
     },
     textVariant: {
         type: String,
@@ -18,16 +18,16 @@ const props = {
 export default {
     functional: true,
     props,
-    render(h, { props, data, listeners, slots }) {
+    render(h, { props, data, listeners, children }) {
         const componentData = {
             staticClass: "close",
-            class: [
-                Boolean(props.textVariant) ? `text-${props.textVariant}` : ""
-            ],
+            class: {
+                [`text-${props.textVariant}`]: props.textVariant
+            },
             attrs: {
-                "type": "button",
-                "disabled": props.disabled,
-                "aria-label": Boolean(props.ariaLabel) ? String(props.ariaLabel) : null
+                type: "button",
+                disabled: props.disabled,
+                "aria-label": props.ariaLabel ? String(props.ariaLabel) : null
             },
             on: {
                 click(e) {
@@ -39,7 +39,10 @@ export default {
                 }
             }
         };
-        const children = Boolean(slots().default) ? slots().default : ["&times;"];
+        // Careful not to override the slot with innerHTML
+        if (!children.length) {
+            componentData.domProps = { innerHTML: "&times;" };
+        }
         return h("button", mergeData(data, componentData), children);
     }
 };

--- a/lib/components/button-close.js
+++ b/lib/components/button-close.js
@@ -28,6 +28,15 @@ export default {
                 "type": "button",
                 "disabled": props.disabled,
                 "aria-label": Boolean(props.ariaLabel) ? String(props.ariaLabel) : null
+            },
+            on: {
+                click(e) {
+                    // Ensure click on button HTML content is also disabled
+                    if (props.disabled && e instanceof Event) {
+                        e.stopPropagation();
+                        e.preventDefault();
+                    }
+                }
             }
         };
         const children = Boolean(slots().default) ? slots().default : ["&times;"];

--- a/lib/components/button-close.js
+++ b/lib/components/button-close.js
@@ -32,5 +32,5 @@ export default {
         };
         const children = Boolean(slots().default) ? slots().default : ["&times;"];
         return h("button", mergeData(data, componentData), children);
-    })
+    }
 };

--- a/lib/components/button-close.js
+++ b/lib/components/button-close.js
@@ -1,0 +1,36 @@
+import { mergeData } from "../utils";
+
+const props = {
+    disabled: {
+        type: Boolean,
+        default: false
+    },
+    ariaLabel: {
+        type: String,
+        default: 'Close'
+    },
+    textVariant: {
+        type: String,
+        default: null
+    }
+};
+
+export default {
+    functional: true,
+    props,
+    render(h, { props, data, listeners, slots }) {
+        const componentData = {
+            staticClass: "close",
+            class: [
+                Boolean(props.textVariant) ? `text-${props.textVariant}` : ""
+            ],
+            attrs: {
+                "type": "button",
+                "disabled": props.disabled,
+                "aria-label": Boolean(props.ariaLabel) ? String(props.ariaLabel) : null
+            }
+        };
+        const children = Boolean(slots().default) ? slots().default : ["&times;"];
+        return h("button", mergeData(data, componentData), children);
+    })
+};

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -4,6 +4,7 @@ import bBreadcrumb from "./breadcrumb";
 import bBreadcrumbItem from "./breadcrumb-item";
 import bBreadcrumbLink from "./breadcrumb-link";
 import bButton from "./button";
+import bButtonClose from "./button-close";
 import bButtonToolbar from "./button-toolbar.vue";
 import bButtonGroup from "./button-group";
 import bInputGroup from "./input-group.vue";
@@ -73,6 +74,8 @@ export {
     bBreadcrumbLink,
     bButton,
     bButton as bBtn,
+    bButtonClose,
+    bButtonClose as bBtnClose,
     bButtonToolbar,
     bButtonToolbar as bBtnToolbar,
     bButtonGroup,

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -300,7 +300,7 @@
                 if (new_val === old_val) {
                     return;
                 }
-                this[newVal ? 'show' : 'hide']();
+                this[new_val ? 'show' : 'hide']();
             }
         },
         methods: {

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -383,7 +383,7 @@
             setResizeEvent(on) {
                 ['resize', 'orientationchange'].forEach(evtName => {
                     window[on ? 'addEventListener' : 'removeEventListener'](evtName, this.adjustDialog);
-                }
+                });
             },
             // Root Listener handlers
             showHandler(id, triggerEl) {
@@ -513,7 +513,7 @@
                     const margin = el.getAttribute('data-margin-right') || '';
                     el.style.margingRight = margin;
                     el.removeAttribute('data-margin-right');
-                })
+                });
 
                 // Restore body padding
                 const body = document.body;

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -44,10 +44,10 @@
                                     <slot name="modal-title">{{title}}</slot>
                                 </h5>
                                 <b-btn-close v-if="!hideHeaderClose"
-                                                :disabled="is_transitioning"
-                                                :aria-label="headerCloseLabel"
-                                                :text-variant="headerTextVariant"
-                                                @click="hide('headerclose')"
+                                             :disabled="is_transitioning"
+                                             :aria-label="headerCloseLabel"
+                                             :text-variant="headerTextVariant"
+                                             @click="hide('headerclose')"
                                 ><slot name="modal-header-close"></slot></b-btn-close>
                             </slot>
                         </header>

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -85,7 +85,7 @@
     import bBtnClose from './button-close';
     import { idMixin, listenOnRootMixin } from '../mixins';
     import { from as arrayFrom, arrayFind } from '../utils/array';
-    import { isElement, isVisible, selectAll, select } from '../utils/dom';
+    import { isElement, isVisible, selectAll, select, addClass, removeClass, setAttr, removeAttr, getAttr } from '../utils/dom';
     import { observeDom, warn } from '../utils';
     import { BvEvent } from '../classes';
 
@@ -358,7 +358,7 @@
                 this.is_transitioning = true;
                 this.checkScrollbar();
                 this.setScrollbar();
-                document.body.classList.add('modal-open');
+                addClass(document.body, 'modal-open');
                 this.setResizeEvent(true);
             },
             onEnter() {
@@ -387,7 +387,7 @@
                 this.is_show = false;
             },
             onAfterLeave() {
-                document.body.classList.remove('modal-open');
+                removeClass(document.body, 'modal-open');
                 this.is_block = false;
                 this.resetAdjustments();
                 this.resetScrollbar();
@@ -526,7 +526,7 @@
                     selectAll('.fixed-top, .fixed-bottom, .is-fixed, .sticky-top').forEach(el => {
                       const actualPadding = el.style.paddingRight;
                       const calculatedPadding = computedStyle(el).paddingRight;
-                      el.setAttribute('data-padding-right', actualPadding);
+                      setAttr(el,'data-padding-right', actualPadding);
                       el.style.paddingRight = `${parseFloat(calculatedPadding) + this.scrollbarWidth}px`;
                     });
 
@@ -534,7 +534,7 @@
                     selectAll('.sticky-top').forEach(el => {
                       const actualMargin = el.style.marginRight;
                       const calculatedMargin = computedStyle(el).marginRight;
-                      el.setAttribute('data-margin-right', actualMargin);
+                      setAttr(el, 'data-margin-right', actualMargin);
                       el.style.marginRight = `${parseFloat(calculatedMargin) - this.scrollbarWidth}px`;
                     });
 
@@ -542,37 +542,37 @@
                     selectAll('.navbar-toggler').forEach(element => {
                       const actualMargin = el.style.marginRight;
                       const calculatedMargin = computedStyle(el).marginRight;
-                      el.setAttribute('data-margin-right', actualMargin);
+                      setAttr(el, 'data-margin-right', actualMargin);
                       el.style.marginRight = `${parseFloat(calculatedMargin) + this.scrollbarWidth}px`;
                     });
 
                     // Adjust body padding
                     const actualPadding = body.style.paddingRight;
                     const calculatedPadding = computedStyle(body).paddingRight;
-                    body.setAttribute('data-padding-right', actualPadding);
+                    setAtttr(body, 'data-padding-right', actualPadding);
                     body.style.paddingRight = `${parseFloat(calculatedPadding) + this.scrollbarWidth}px`;
                 }
             },
             resetScrollbar() {
                 // Restore fixed content padding
                 selectAll('.fixed-top, .fixed-bottom, .is-fixed, .sticky-top').forEach(el => {
-                    const padding = el.getAttribute('data-padding-right') || '';
+                    const padding = getAttr(el, 'data-padding-right') || '';
                     el.style.paddingRight = padding;
-                    el.removeAttribute('data-padding-right');
+                    removeAttr(el,'data-padding-right');
                 });
 
                 // Restore sticky content and navbar-toggler margin
                 selectAll('.sticky-top, .navbar-toggler').forEach(el => {
-                    const margin = el.getAttribute('data-margin-right') || '';
+                    const margin = getAttr(el, 'data-margin-right') || '';
                     el.style.margingRight = margin;
-                    el.removeAttribute('data-margin-right');
+                    removeAttr(el, 'data-margin-right');
                 });
 
                 // Restore body padding
                 const body = document.body;
-                const padding = body.getAttribute('data-padding-right') || '';
+                const padding = getAttr(body, 'data-padding-right') || '';
                 body.style.paddingRight = padding;
-                body.removeAttribute('data-padding-right');
+                removeAttr(body, 'data-padding-right');
             }
 
         },

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -249,49 +249,61 @@
             modalClasses() {
                 return [
                     'modal',
-                    this.noFade ? '' : 'fade',
-                    this.is_show ? 'show' : '',
-                    this.is_block ? 'd-block' : ''
+                    {
+                        fade: !this.noFade,
+                        show: this.is_show,
+                        'd-block': this.is_block
+                    }
                 ];
             },
             dialogClasses() {
                 return [
                     'modal-dialog',
-                    Boolean(this.size) ? `modal-${this.size}` : ''
+                    {
+                        [`modal-${this.size}`]: this.size
+                    }
                 ];
             },
             backdropClasses() {
                 return [
                     'modal-backdrop',
-                    this.noFade ? '' : 'fade',
-                    this.is_show ? 'show' : ''
+                    {
+                        fade: !this.noFade,
+                        show: this.is_show,
+                    }
                 ];
             },
             headerClasses() {
                 return [
                     'modal-header',
                     // Rounding is needed to fix a bug in bootstrap V4.beta.1 CSS
-                    Boolean(this.headerBgVariant) ? 'rounded-top' : '',
-                    Boolean(this.headerBgVariant) ? `bg-${this.headerBgVariant}` : '',
-                    Boolean(this.headerTextVariant) ? `text-${this.headerTextVariant}` : '',
-                    Boolean(this.headerBorderVariant) ? `border-${this.headerBorderVariant}` : ''
+                    {
+                        'rounded-top': this.headerBgVariant,
+                        [`bg-${this.headerBgVariant}`]: this.headerBgVariant,
+                        [`text-${this.headerTextVariant}`]: this.headerTextVariant,
+                        [`border-${this.headerBorderVariant}`]: this.headerBorderVariant,
+                    }
                 ];
             },
             bodyClasses() {
                 return [
                     'modal-body',
-                    Boolean(this.bodyBgVariant) ? `bg-${this.bodyBgVariant}` : '',
-                    Boolean(this.bodyTextVariant) ? `text-${this.bodyTextVariant}` : ''
+                    {
+                        [`bg-${this.bodyBgVariant}`]: this.bodyBgVariant,
+                        [`text-${this.bodyTextVariant}`]: this.bodyTextVariant,
+                    }
                 ];
             },
             footerClasses() {
                 return [
                     'modal-footer',
                     // Rounding is needed to fix a bug in bootstrap V4.beta.1 CSS
-                    Boolean(this.footerBgVariant) ? 'rounded-bottom' : '',
-                    Boolean(this.footerBgVariant) ? `bg-${this.footerBgVariant}` : '',
-                    Boolean(this.footerTextVariant) ? `text-${this.footerTextVariant}` : '',
-                    Boolean(this.footerBorderVariant) ? `border-${this.footerBorderVariant}` : ''
+                    {
+                        'rounded-bottom': this.footerBgVariant,
+                        [`bg-${this.footerBgVariant}`]: this.footerBgVariant,
+                        [`text-${this.footerTextVariant}`]: this.footerTextVariant,
+                        [`border-${this.footerBorderVariant}`]: this.footerBorderVariant,
+                    }
                 ];
             }
         },

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -8,7 +8,7 @@
                     leave-to-class=""
                     @before-enter="onBeforeEnter"
                     @enter="onEnter"
-                    @after-enter="focusFirst"
+                    @after-enter="onAfterEnter"
                     @before-leave="onBeforeLeave"
                     @leave="onLeave"
                     @after-leave="onAfterLeave"

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -232,7 +232,7 @@
                 if (new_val === old_val) {
                     return;
                 }
-                this[newVal ? 'show', 'hide']();
+                this[newVal ? 'show' : 'hide']();
             }
         },
         methods: {
@@ -343,16 +343,14 @@
                 // Preffer returnFocus prop over event specified return_focus value
                 let el = this.returnFocus || this.return_focus || null;
 
+                if (typeof el === 'string') {
+                    // CSS Selector
+                    el = select(el);
+                }
                 if (el) {
-                    if (typeof el === 'string') {
-                        // CSS Selector
-                        el = select(el);
-                    }
-                    if (el) {
-                        el = el.$el || el;
-                        if (isVisible(el)) {
-                            el.focus();
-                        }
+                    el = el.$el || el;
+                    if (isVisible(el)) {
+                        el.focus();
                     }
                 }
             },

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -375,7 +375,7 @@
                 if (id === this.id) {
                     this.hide();
                 }
-            }
+            },
             // Focus control handlers
             focusFirst() {
                 // Don't try and focus if we are SSR
@@ -402,7 +402,7 @@
                         el.focus();
                     }
                 }
-            },
+            }
         },
         mounted() {
             // TODO: Measure scrollbar

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -29,12 +29,12 @@
                          role="document"
                          ref="content"
                          :aria-labelledby="hideHeader ? null : safeId('__BV_modal_header_')"
-                         :aria-describedby="safeid('__BV_modal_body_')"
+                         :aria-describedby="safeId('__BV_modal_body_')"
                          @focusout="onFocusout"
                          @click.stop
                     >
 
-                        <header :class="headerClases"
+                        <header :class="headerClasses"
                                 ref="header"
                                 :id="safeId('__BV_modal_header_')"
                                 v-if="!hideHeader"
@@ -59,7 +59,7 @@
                         <footer :class="footerClasses" ref="footer" v-if="!hideFooter" :id="safeId('__BV_modal_footer_')">
                             <slot name="modal-footer">
                                 <b-btn v-if="!okOnly"
-                                       :variant="cacelVariant"
+                                       :variant="cancelVariant"
                                        :size="buttonSize"
                                         :disabled="is_transitioning"
                                        @click="hide('cancel')"
@@ -105,7 +105,7 @@
         }
         return arrayFind(selectAll(selector, root), isVisible) || null;
     }
-    
+
     function reflow(el) {
         return el.offsetHeight;
     }
@@ -270,7 +270,7 @@
             headerClasses() {
                 return [
                     'modal-header',
-                    // Rounding is needed to fix a bug in bootstrap V4.beata.1 CSS
+                    // Rounding is needed to fix a bug in bootstrap V4.beta.1 CSS
                     Boolean(this.headerBgVariant) ? 'rounded-top' : '',
                     Boolean(this.headerBgVariant) ? `bg-${this.headerBgVariant}` : '',
                     Boolean(this.headerTextVariant) ? `text-${this.headerTextVariant}` : '',
@@ -287,7 +287,7 @@
             footerClasses() {
                 return [
                     'modal-footer',
-                    // Rounding is needed to fix a bug in bootstrap V4.beata.1 CSS
+                    // Rounding is needed to fix a bug in bootstrap V4.beta.1 CSS
                     Boolean(this.footerBgVariant) ? 'rounded-bottom' : '',
                     Boolean(this.footerBgVariant) ? `bg-${this.footerBgVariant}` : '',
                     Boolean(this.footerTextVariant) ? `text-${this.footerTextVariant}` : '',
@@ -335,7 +335,7 @@
                     isOK: trigger || null,
                     trigger: trigger || null,
                     cancel() {
-                        // Bacwards compatability
+                        // Backwards compatibility
                         warn('b-modal: evt.cancel() is deprecated. Please use evt.preventDefault().');
                         this.preventDefault();
                     }
@@ -518,7 +518,7 @@
                 if (this.isBodyOverflowing) {
                     // Note: DOMNode.style.paddingRight returns the actual value or '' if not set
                     //   while $(DOMNode).css('padding-right') returns the calculated value or 0 if not set
-                    
+
                     const ComputedStyle = document.getComputedStyle;
                     const body = document.body;
 
@@ -564,7 +564,7 @@
                 // Restore sticky content and navbar-toggler margin
                 selectAll('.sticky-top, .navbar-toggler').forEach(el => {
                     const margin = getAttr(el, 'data-margin-right') || '';
-                    el.style.margingRight = margin;
+                    el.style.marginRight = margin;
                     removeAttr(el, 'data-margin-right');
                 });
 
@@ -584,7 +584,7 @@
             this.listenOnRoot('bv::hide::modal', this.hideHandler);
             // Listen for bv:modal::show events, and close ourselves if the opening modal not us
             this.listenOnRoot('bv::modal::show', this.modalListener);
-            // Observe chagnes in modal content and adjust if necessary
+            // Observe changes in modal content and adjust if necessary
             observeDom(this.$refs.modal, this.adjustDialog.bind(this), {
                 subtree: true,
                 childList: true,

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -43,19 +43,12 @@
                                 <h5 :is="titleTag" class="modal-title">
                                     <slot name="modal-title">{{title}}</slot>
                                 </h5>
-                                <button type="button"
-                                        v-if="!hideHeaderClose"
-                                        class="close"
-                                        :disabled="is_transitioning"
-                                        :aria-label="headerCloseLabel"
-                                        @click="hide('headerclose')"
-                                >
-                                    <slot name="modal-header-close">
-                                        <span aria-hidden="true"
-                                              :class="Boolean(headerTextVariant) ? `text-${headerTextVariant}` : ''"
-                                              v-html="headerCloseTitle"></span>
-                                    </slot>
-                                </button>
+                                <b-btn-close v-if="!hideHeaderClose"
+                                                :disabled="is_transitioning"
+                                                :aria-label="headerCloseLabel"
+                                                :text-variant="headerTextVariant"
+                                                @click="hide('headerclose')"
+                                ><slot name="modal-header-close"></slot></b-btn-close>
                             </slot>
                         </header>
 
@@ -89,6 +82,7 @@
 
 <script>
     import bBtn from './button';
+    import bBtnClose from './button-close';
     import { idMixin, listenOnRootMixin } from '../mixins';
     import { from as arrayFrom, arrayFind } from '../utils/array';
     import { isElement, isVisible, selectAll, select } from '../utils/dom';
@@ -118,7 +112,7 @@
 
     export default {
         mixins: [idMixin, listenOnRootMixin],
-        components: {bBtn},
+        components: {bBtn, bBtnClose},
         data() {
             return {
                 is_visible: false,
@@ -229,10 +223,6 @@
             },
             returnFocus: {
                 default: null
-            },
-            headerCloseTitle: {
-                type: String,
-                default: '&times;'
             },
             headerCloseLabel: {
                 type: String,

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -88,7 +88,7 @@
     import { idMixin, listenOnRootMixin } from '../mixins';
     import { from as arrayFrom, arrayFind } from '../utils/array';
     import { isElement, isVisible, selectAll, select } from '../utils/dom';
-    import ( observeDom } from '../utils';
+    import { observeDom } from '../utils';
     import { BvEvent } from '../classes';
 
     const FOCUS_SELECTOR = [

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -309,7 +309,7 @@
                 if (this.is_visible) {
                     return;
                 }
-                showEvt = new BvEvent('show', {
+                const showEvt = new BvEvent('show', {
                     cancelable: true,
                     vueTarget: this,
                     target: this.$refs.modal,
@@ -327,7 +327,7 @@
                 if (!this.is_visible) {
                     return;
                 }
-                hideEvt = new BvEvent('hide', {
+                const hideEvt = new BvEvent('hide', {
                     cancelable: true,
                     vueTarget: this,
                     target: this.$refs.modal,
@@ -370,7 +370,7 @@
                 this.is_transitioning = false;
                 this.$nextTick(() => {
                     this.focusFirst();
-                    shownEvt = new BvEvent('shown', {
+                    const shownEvt = new BvEvent('shown', {
                         cancelable: false,
                         vueTarget: this,
                         target: this.$refs.modal,
@@ -394,7 +394,7 @@
                 this.is_transitioning = false;
                 this.$nextTick(() => {
                     this.returnFocusTo();
-                    hiddenEvt = new BvEvent('hidden', {
+                    const hiddenEvt = new BvEvent('hidden', {
                         cancelable: false,
                         vueTarget: this,
                         target: this.$refs.modal,
@@ -406,8 +406,8 @@
             // Event emitter
             emitEvent(bvEvt) {
                 const type = bvEvt.type;
-                this.$emit(type, bvevt);
-                this.$root.$emit(`bv::modal::${type}`, bvevt);
+                this.$emit(type, bvEvt);
+                this.$root.$emit(`bv::modal::${type}`, bvEvt);
             },
             // UI Event Handlers
             onClickOut() {

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -50,9 +50,11 @@
                                         :aria-label="headerCloseLabel"
                                         @click="hide('headerclose')"
                                 >
-                                    <span aria-hidden="true"
-                                          :class="Boolean(headerTextVariant) ? `text-${headerTextVariant}` : ''"
-                                          v-html="headerCloseTitle"></span>
+                                    <slot name="modal-header-close">
+                                        <span aria-hidden="true"
+                                              :class="Boolean(headerTextVariant) ? `text-${headerTextVariant}` : ''"
+                                              v-html="headerCloseTitle"></span>
+                                    </slot>
                                 </button>
                             </slot>
                         </header>

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -260,7 +260,7 @@
                 return [
                     'modal-dialog',
                     {
-                        [`modal-${this.size}`]: this.size
+                        [`modal-${this.size}`]: Boolean(this.size)
                     }
                 ];
             },
@@ -278,10 +278,10 @@
                     'modal-header',
                     // Rounding is needed to fix a bug in bootstrap V4.beta.1 CSS
                     {
-                        'rounded-top': this.headerBgVariant,
-                        [`bg-${this.headerBgVariant}`]: this.headerBgVariant,
-                        [`text-${this.headerTextVariant}`]: this.headerTextVariant,
-                        [`border-${this.headerBorderVariant}`]: this.headerBorderVariant,
+                        'rounded-top': Boolean(this.headerBgVariant),
+                        [`bg-${this.headerBgVariant}`]: Boolean(this.headerBgVariant),
+                        [`text-${this.headerTextVariant}`]: Boolean(this.headerTextVariant),
+                        [`border-${this.headerBorderVariant}`]: Boolean(this.headerBorderVariant)
                     }
                 ];
             },
@@ -289,8 +289,8 @@
                 return [
                     'modal-body',
                     {
-                        [`bg-${this.bodyBgVariant}`]: this.bodyBgVariant,
-                        [`text-${this.bodyTextVariant}`]: this.bodyTextVariant,
+                        [`bg-${this.bodyBgVariant}`]: Boolean(this.bodyBgVariant),
+                        [`text-${this.bodyTextVariant}`]: Boolean(this.bodyTextVariant)
                     }
                 ];
             },
@@ -299,10 +299,10 @@
                     'modal-footer',
                     // Rounding is needed to fix a bug in bootstrap V4.beta.1 CSS
                     {
-                        'rounded-bottom': this.footerBgVariant,
-                        [`bg-${this.footerBgVariant}`]: this.footerBgVariant,
-                        [`text-${this.footerTextVariant}`]: this.footerTextVariant,
-                        [`border-${this.footerBorderVariant}`]: this.footerBorderVariant,
+                        'rounded-bottom': Boolean(this.footerBgVariant),
+                        [`bg-${this.footerBgVariant}`]: Boolean(this.footerBgVariant),
+                        [`text-${this.footerTextVariant}`]: Boolean(this.footerTextVariant),
+                        [`border-${this.footerBorderVariant}`]: Boolean(this.footerBorderVariant)
                     }
                 ];
             }

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -347,7 +347,7 @@
                 }
                 this.emitEvent(hideEvt);
                 // Hide if not canceled
-                if (hideEvt.defaultPrevented || !this._is_visible) {
+                if (hideEvt.defaultPrevented || !this.is_visible) {
                     return;
                 }
                 this.is_visible = false;

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -34,7 +34,7 @@
                          @click.stop
                     >
 
-                        <header class="modal-header"
+                        <header :class="headerClases"
                                 ref="header"
                                 :id="safeId('__BV_modal_header_')"
                                 v-if="!hideHeader"
@@ -50,16 +50,18 @@
                                         :aria-label="headerCloseLabel"
                                         @click="hide('headerclose')"
                                 >
-                                    <span aria-hidden="true" v-html="headerCloseTitle"></span>
+                                    <span aria-hidden="true"
+                                          :class="Boolean(headerTextVariant) ? `text-${headerTextVariant}` : ''"
+                                          v-html="headerCloseTitle"></span>
                                 </button>
                             </slot>
                         </header>
 
-                        <div class="modal-body" ref="body" :id="safeId('__BV_modal_body_')">
+                        <div :class="bodyClasses" ref="body" :id="safeId('__BV_modal_body_')">
                             <slot></slot>
                         </div>
 
-                        <footer class="modal-footer" ref="footer" v-if="!hideFooter" :id="safeId('__BV_modal_footer_')">
+                        <footer :class="footerClasses" ref="footer" v-if="!hideFooter" :id="safeId('__BV_modal_footer_')">
                             <slot name="modal-footer">
                                 <b-btn v-if="!okOnly"
                                        :variant="cacelVariant"
@@ -163,6 +165,38 @@
                 type: Boolean,
                 default: false
             },
+            headerBgVariant: {
+                type: String,
+                default: null
+            },
+            headerBorderVariant: {
+                type: String,
+                default: null
+            },
+            headerTextVariant: {
+                type: String,
+                default: null
+            },
+            bodyBgVariant: {
+                type: String,
+                default: null
+            },
+            bodyTextVariant: {
+                type: String,
+                default: null
+            },
+            footerBgVariant: {
+                type: String,
+                default: null
+            },
+            footerBorderVariant: {
+                type: String,
+                default: null
+            },
+            footerTextVariant: {
+                type: String,
+                default: null
+            },
             hideHeader: {
                 type: Boolean,
                 default: false
@@ -171,11 +205,11 @@
                 type: Boolean,
                 default: false
             },
-            hideBackdrop: {
+            hideHeaderClose: {
                 type: Boolean,
                 default: false
             },
-            hideHeaderClose: {
+            hideBackdrop: {
                 type: Boolean,
                 default: false
             },
@@ -239,6 +273,33 @@
                     'modal-backdrop',
                     this.noFade ? '' : 'fade',
                     this.is_show ? 'show' : ''
+                ];
+            },
+            headerClasses() {
+                return [
+                    'modal-header',
+                    // Rounding is needed to fix a bug in bootstrap V4.beata.1 CSS
+                    Boolean(this.headerBgVariant) ? 'rounded-top' : '',
+                    Boolean(this.headerBgVariant) ? `bg-${this.headerBgVariant}` : '',
+                    Boolean(this.headerTextVariant) ? `text-${this.headerTextVariant}` : '',
+                    Boolean(this.headerBorderVariant) ? `border-${this.headerBorderVariant}` : ''
+                ];
+            },
+            bodyClasses() {
+                return [
+                    'modal-body',
+                    Boolean(this.bodyBgVariant) ? `bg-${this.bodyBgVariant}` : '',
+                    Boolean(this.bodyTextVariant) ? `text-${this.bodyTextVariant}` : ''
+                ];
+            },
+            footerClasses() {
+                return [
+                    'modal-footer',
+                    // Rounding is needed to fix a bug in bootstrap V4.beata.1 CSS
+                    Boolean(this.footerBgVariant) ? 'rounded-bottom' : '',
+                    Boolean(this.footerBgVariant) ? `bg-${this.footerBgVariant}` : '',
+                    Boolean(this.footerTextVariant) ? `text-${this.footerTextVariant}` : '',
+                    Boolean(this.footerBorderVariant) ? `border-${this.footerBorderVariant}` : ''
                 ];
             }
         },

--- a/lib/directives/modal.js
+++ b/lib/directives/modal.js
@@ -7,7 +7,7 @@ export default {
     bind(undefined, binding, vnode) {
         target(vnode, binding, listen_types, ({targets, vnode}) => {
             targets.forEach(target => {
-                vnode.context.$root.$emit('bv::modal::show', target, vnode.elm);
+                vnode.context.$root.$emit('bv::show::modal', target, vnode.elm);
             });
         });
     }

--- a/lib/directives/modal.js
+++ b/lib/directives/modal.js
@@ -7,7 +7,7 @@ export default {
     bind(undefined, binding, vnode) {
         target(vnode, binding, listen_types, ({targets, vnode}) => {
             targets.forEach(target => {
-                vnode.context.$root.$emit('show::modal', target, vnode.elm);
+                vnode.context.$root.$emit('bv::modal::show', target, vnode.elm);
             });
         });
     }

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -110,7 +110,7 @@ dom.removeAttr = function(el, attr) {
 // Get an attribute value from an element (returns null if not found)
 dom.getAttr = function(el, attr) {
     if (attr && dom.isElement(el)) {
-        retrun el.getAttribute(attr);
+        return el.getAttribute(attr);
     }
     return null;
 };

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -100,7 +100,7 @@ dom.setAttr = function(el, attr, value) {
     }
 };
 
-// Remove an attribut from an element
+// Remove an attribute from an element
 dom.removeAttr = function(el, attr) {
     if (attr && dom.isElement(el)) {
         el.removeAttribute(attr);

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -71,38 +71,38 @@ dom.getById = function(id) {
 };
 
 dom.addClass = fuinction(el, className) {
-    if (className && isElement(el)) {
+    if (className && dom.isElement(el)) {
         el.classList.add(className);
     }
 };
 
 dom.removeClass = fuinction(el, className) {
-    if (className && isElement(el)) {
+    if (className && dom.isElement(el)) {
         el.classList.remove(className);
     }
 };
 
-dom.hasClass = fuinction(el, className) {
-    if (className && isElement(el)) {
+dom.hasClass = fuinction(dom.el, className) {
+    if (className && dom.isElement(el)) {
         return el.classList.contains(className);
     }
     return false;
 };
 
 dom.setAttr = fuinction(el, attr, value) {
-    if (attr && isElement(el)) {
+    if (attr && dom.isElement(el)) {
         el.setAttribute(attr, value);
     }
 };
 
 dom.removeAttr = fuinction(el, attr) {
-    if (attr && isElement(el)) {
+    if (attr && dom.isElement(el)) {
         el.removeAttribute(attr);
     }
 };
 
 dom.getAttr = fuinction(el, attr) {
-    if (attr && isElement(el)) {
+    if (attr && dom.isElement(el)) {
         retrun el.getAttribute(attr);
     }
     return null;

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -66,42 +66,49 @@ dom.closest = function(selector, root) {
     return el === root ? null : el;
 };
 
+// Get an element given an ID
 dom.getById = function(id) {
     return document.getElementById(/^#/.test(id) ? id.slice(1) : id) || null;
 };
 
-dom.addClass = fuinction(el, className) {
+// Add a class to an element
+dom.addClass = function(el, className) {
     if (className && dom.isElement(el)) {
         el.classList.add(className);
     }
 };
 
-dom.removeClass = fuinction(el, className) {
+// Remove a class from an element
+dom.removeClass = function(el, className) {
     if (className && dom.isElement(el)) {
         el.classList.remove(className);
     }
 };
 
-dom.hasClass = fuinction(dom.el, className) {
+// Test if an element has a class
+dom.hasClass = function(dom.el, className) {
     if (className && dom.isElement(el)) {
         return el.classList.contains(className);
     }
     return false;
 };
 
-dom.setAttr = fuinction(el, attr, value) {
+// Set an attribute on an element
+dom.setAttr = function(el, attr, value) {
     if (attr && dom.isElement(el)) {
         el.setAttribute(attr, value);
     }
 };
 
-dom.removeAttr = fuinction(el, attr) {
+// Remove an attribut from an element
+dom.removeAttr = function(el, attr) {
     if (attr && dom.isElement(el)) {
         el.removeAttribute(attr);
     }
 };
 
-dom.getAttr = fuinction(el, attr) {
+// Get an attribute value from an element (returns null if not found)
+dom.getAttr = function(el, attr) {
     if (attr && dom.isElement(el)) {
         retrun el.getAttribute(attr);
     }

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -70,6 +70,45 @@ dom.getById = function(id) {
     return document.getElementById(/^#/.test(id) ? id.slice(1) : id) || null;
 };
 
+dom.addClass = fuinction(el, className) {
+    if (className && isElement(el)) {
+        el.classList.add(className);
+    }
+};
+
+dom.removeClass = fuinction(el, className) {
+    if (className && isElement(el)) {
+        el.classList.remove(className);
+    }
+};
+
+dom.hasClass = fuinction(el, className) {
+    if (className && isElement(el)) {
+        return el.classList.contains(className);
+    }
+    return false;
+};
+
+dom.setAttr = fuinction(el, attr, value) {
+    if (attr && isElement(el)) {
+        el.setAttribute(attr, value);
+    }
+};
+
+dom.removeAttr = fuinction(el, attr) {
+    if (attr && isElement(el)) {
+        el.removeAttribute(attr);
+    }
+};
+
+dom.getAttr = fuinction(el, attr) {
+    if (attr && isElement(el)) {
+        retrun el.getAttribute(attr);
+    }
+    return null;
+};
+
+
 export const isElement = dom.isElement;
 export const isVisible = dom.isVisible;
 export const isDisabled = dom.isDisabled;
@@ -77,3 +116,9 @@ export const closest = dom.closest;
 export const getById = dom.getById;
 export const selectAll = dom.selectAll;
 export const select = dom.select;
+export const addClass = dom.addClass;
+export const removeClass = dom.removeClass;
+export const hasClass = dom.hasClass;
+export const setAttr = dom.setAttr;
+export const removeAttr = dom.removeAttr;
+export const getAttr = dom.getAttr;

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -86,7 +86,7 @@ dom.removeClass = function(el, className) {
 };
 
 // Test if an element has a class
-dom.hasClass = function(dom.el, className) {
+dom.hasClass = function(el, className) {
     if (className && dom.isElement(el)) {
         return el.classList.contains(className);
     }

--- a/tests/fixtures/modal/demo.html
+++ b/tests/fixtures/modal/demo.html
@@ -12,6 +12,9 @@
     <!-- Modal Component -->
     <b-modal id="modal1"
              title="Submit your name"
+             header-bg-variant="info"
+             header-text-variant="light"
+             header-border-variant="info"
              @ok="submit"
              @shown="clearName">
 

--- a/tests/fixtures/modal/demo.js
+++ b/tests/fixtures/modal/demo.js
@@ -10,7 +10,7 @@ window.app = new Vue({
         },
         submit(e) {
             if (!this.name) {
-                return e.cancel();
+                return e.preventDefault();
             }
 
             this.names.push(this.name);


### PR DESCRIPTION
Various modal improvements:

- [x] Improve modal transitions.
- [x] Remove need for scoped CSS.
- [x] Incorporate `BvEvent` object in modal events (`hide`, `hidden`, `show`, `shown`).
- [x] Incorporate scrollbar adjustments.
- [x] Add listeners for resize/orientationchange to adjust modal padding if necessary
- [x] Use observeDom util to adjust modal when content size changes.
- [x] Option to not show backdrop (although still supports close on backdrop click, when backdrop not shown).
- [x] Emit on `$root` new namespaced events.
- [x] Listen on `$root` new namedspaced events (**Minor breaking change**).
- [x] Update `v-b-modal` directive to use new namespaced `$root` event.
- [x] Add optional bg, border, and text variants (header, footer, body).
_Note: current Bootstrap V4.beta.1 CSS causes header and footer to loose rounded corners when a background variant is applied. This PR includes a fix for that using the `rounded-*` classes_
- [x] New functional component `<b-button-close>` for header close button (also added to `<b-alert>`).
- [x] New slot for header-close button content
- [x] Change footer close button text to `Cancel` to better reflect slot name and event name
- [x] More dom utils for better minification (used by modal and tooltips/popovers).
- [x] Auto append tooltip/popovers to `.modal` `<div>` (instead of `<body>`) for proper z-indexing, if container not specified on tooltip/popover (check is done within tooltip.js class)
- [x] Update docs & examples.
