### PR TITLE
fix: Add lodash.startcase to dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "bootstrap": "^4.0.0-beta",
     "jquery": "^3.0.0",
+    "lodash.startcase": "^4.4.0",
     "popper.js": "^1.12.5",
     "vue": "^2.4.2",
     "vue-functional-data-merge": "^1.0.6"


### PR DESCRIPTION
`b-table` requires `lodash.startcase`

Re: issue #1028 
