### PR TITLE
feat(form-file): Add focus styling for custom-file input

### DIFF
--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -31,8 +31,7 @@
                :aria-describedby="custom ? safeId('_BV_file_control_') : null"
                @focusin="focusHandler"
                @focusout="focusHandler"
-               @change="onFileChange"
-        >
+               @change="onFileChange">
 
         <!-- Overlay Labels -->
         <!-- this is normally a <span> but we use <label> here so we can associate it with the input -->
@@ -42,7 +41,7 @@
                :class="['custom-file-control',dragging?'dragging':null]"
                :data-choose="computedChooseLabel"
                :data-selected="selectedLabel"
-        ></label
+        ></label>
 
     </div>
 </template>

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -3,7 +3,7 @@
            type="file"
            :id="safeId()"
            ref="input"
-           :class="['form-control-file', stateClass]"
+           :class="['form-control-file', sizeFormClass, stateClass]"
            :name="name"
            :disabled="disabled"
            :required="required"

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -14,7 +14,7 @@
            :webkitdirectory="directory"
            @change="onFileChange">
     <div v-else
-         :class="['custom-file', stateClass]"
+         :class="['custom-file', 'w-100', stateClass]"
          :id="safeId('_BV_file_outer_')"
          @dragover.stop.prevent="dragover">
          <!-- Normally this div should be label, but IE borks out if label has a file input inside. Awaiting fix from MSFT -->
@@ -33,7 +33,7 @@
         <input type="file"
                :id="safeId()"
                ref="input"
-               :class="['custom-file-input', stateClass, hasFocus?'focus':'']"
+               :class="['custom-file-input', 'w-100', stateClass, hasFocus?'focus':'']"
                :name="name"
                :disabled="disabled"
                :required="required"

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -6,19 +6,20 @@
     >
 
         <!-- Drop Here Target -->
-        <span class="drop-here"
-              v-if="dragging && custom"
-              @dragover.stop.prevent="dragover"
-              @drop.stop.prevent="drop"
-              @dragleave.stop.prevent="dragging=false"
-              :data-drop="dropLabel"
-        ></span>
+        <label v-if="dragging && custom"
+               :for="safeId()"
+               :data-drop="dropLabel"
+               class="drop-here"
+               @dragover.stop.prevent="dragover"
+               @drop.stop.prevent="drop"
+               @dragleave.stop.prevent="dragging=false"
+        ></label>
 
         <!-- Real Form input -->
         <input type="file"
                :id="safeId()"
                ref="input"
-               :class="[custom?'custom-file-input':'form-control-file', stateClass]"
+               :class="[custom?'custom-file-input':'form-control-file', stateClass, hasFocus?'focus':'']"
                :name="name"
                :disabled="disabled"
                :required="required"
@@ -28,22 +29,56 @@
                :multiple="multiple"
                :webkitdirectory="directory"
                :aria-describedby="custom ? safeId('_BV_file_control_') : null"
+               @focusin="focusHandler"
+               @focusout="focusHandler"
                @change="onFileChange"
         >
 
         <!-- Overlay Labels -->
-        <span :class="['custom-file-control',dragging?'dragging':null]"
-              :id="safeId('_BV_file_control_')"
-              :data-choose="computedChooseLabel"
-              :data-selected="selectedLabel"
-              v-if="custom"
-        ></span>
+        <!-- this is normally a <span> but we use <label> here so we can associate it with the input -->
+        <label v-if="custom"
+               :id="safeId('_BV_file_control_')"
+               :for="safeId()"
+               :class="['custom-file-control',dragging?'dragging':null]"
+               :data-choose="computedChooseLabel"
+               :data-selected="selectedLabel"
+        ></label
 
     </div>
 </template>
 
 <style scoped>
-    /* Are these classes needed??? bootstrap.css contains similar ones */
+    /* Custom-file focus styling */
+    /* regular focus styling */
+    .custom-file-input.focus ~ .custom-file-control,
+    .custom-file-input:focus ~ .custom-file-control {
+        color: #495057;
+        background-color: #fff;
+        border-color: #80bdff;
+        outline: none;
+    }
+
+    /* Invalid focus styling */
+    .custom-file-input.is-invalid.focus ~ .custom-file-control,
+    .custom-file-input.is-invalid:focus ~ .custom-file-control,
+    .was-validated .custom-file-input:invalid.focus ~ .custom-file-control,
+    .was-validated .custom-file-input:invalid:focus ~ .custom-file-control {
+        -webkit-box-shadow: 0 0 0 .2rem rgba(220,53,69,.25);
+        box-shadow: 0 0 0 .2rem rgba(220,53,69,.25);
+        border-color: #dc3545;
+    }
+
+    /* valid focus styling */
+    .custom-file-input.is-valid.focus ~ .custom-file-control,
+    .custom-file-input.is-valid:focus ~ .custom-file-control,
+    .was-validated .custom-file-input:valid.focus ~ .custom-file-control,
+    .was-validated .custom-file-input:valid:focus ~ .custom-file-control {
+        -webkit-box-shadow: 0 0 0 .2rem rgba(40,167,69,.25);
+        box-shadow: 0 0 0 .2rem rgba(40,167,69,.25);
+        border-color: #28a745;
+    }
+
+    /* Drag/Drop handling */
     .custom-file-control {
         overflow: hidden;
     }
@@ -95,7 +130,8 @@
         data() {
             return {
                 selectedFile: null,
-                dragging: false
+                dragging: false,
+                hasFocus: false
             };
         },
         props: {
@@ -177,6 +213,17 @@
             }
         },
         methods: {
+            handleFocus(evt) {
+                // Boostrap v4.beta doesn't have focus styling for custom file input
+                // Firefox has a borked '[type=file]:focus ~ sibling' selector, so we add
+                // A 'focus' class to get around this bug
+                if (this.plain || evt.type === 'focusout') {
+                    this.hasFocus = false;
+                } else {
+                    // Add focus styling for custom file input
+                    this.hasFocus = true;
+                }
+            },
             reset() {
                 try {
                     // Wrapped in try in case IE < 11 craps out

--- a/lib/components/form-file.vue
+++ b/lib/components/form-file.vue
@@ -1,12 +1,26 @@
 <template>
-    <!-- Normally this should be a <label> but IE borks out on it. Awaiting fix from MSFT -->
-    <div :class="[custom?'custom-file':null, state?`is-${state}`:null]"
+    <input v-if="plain"
+           type="file"
+           :id="safeId()"
+           ref="input"
+           :class="['form-control-file', stateClass]"
+           :name="name"
+           :disabled="disabled"
+           :required="required"
+           :capture="capture || null"
+           :aria-required="required ? 'true' : null"
+           :accept="accept || null"
+           :multiple="multiple"
+           :webkitdirectory="directory"
+           @change="onFileChange">
+    <div v-else
+         :class="['custom-file', stateClass]"
          :id="safeId('_BV_file_outer_')"
-         @dragover.stop.prevent="dragover"
-    >
+         @dragover.stop.prevent="dragover">
+         <!-- Normally this div should be label, but IE borks out if label has a file input inside. Awaiting fix from MSFT -->
 
-        <!-- Drop Here Target -->
-        <label v-if="dragging && custom"
+        <!-- Drop Here Target, set as label so it can be associated with input -->
+        <label v-if="dragging"
                :for="safeId()"
                :data-drop="dropLabel"
                class="drop-here"
@@ -19,7 +33,7 @@
         <input type="file"
                :id="safeId()"
                ref="input"
-               :class="[custom?'custom-file-input':'form-control-file', stateClass, hasFocus?'focus':'']"
+               :class="['custom-file-input', stateClass, hasFocus?'focus':'']"
                :name="name"
                :disabled="disabled"
                :required="required"
@@ -28,17 +42,16 @@
                :accept="accept || null"
                :multiple="multiple"
                :webkitdirectory="directory"
-               :aria-describedby="custom ? safeId('_BV_file_control_') : null"
+               :aria-describedby="safeId('_BV_file_control_')"
                @focusin="focusHandler"
                @focusout="focusHandler"
                @change="onFileChange">
 
         <!-- Overlay Labels -->
         <!-- this is normally a <span> but we use <label> here so we can associate it with the input -->
-        <label v-if="custom"
-               :id="safeId('_BV_file_control_')"
+        <label :id="safeId('_BV_file_control_')"
                :for="safeId()"
-               :class="['custom-file-control',dragging?'dragging':null]"
+               :class="['custom-file-control', dragging?'dragging':null]"
                :data-choose="computedChooseLabel"
                :data-selected="selectedLabel"
         ></label>


### PR DESCRIPTION
`b-form-file` doesn't have any focus styling when in custom input mode, which makes it difficult for keyboard-only users to know that the file input has focus.

This fix handles this (using scoped CSS), and also adds better accessibility features in general to `b-form-file`

Addresses issue #333 

The scoped CSS use hard-coded color styles, which could be updated to use SASS variables/mixins to adjust the colors used.