### PR TITLE
fix(tooltip popover): illegal invocation errors when tooltip inside v-if elements

### DIFF
--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -306,11 +306,11 @@ class ToolTip {
 
     // force hide of tip (internal method)
     forceHide() {
+        // Disable while open listeners/watchers
+        this.setWhileOpenListeners(false);
         if (!this.$tip) {
             return;
         }
-        // Disable while open listeners/watchers
-        this.setWhileOpenListeners(false);
         // Clear any hover enter/leave event
         clearTimeout(this.$hoverTimeout);
         this.$hoverTimeout = null;
@@ -364,6 +364,10 @@ class ToolTip {
         // Disable while open listeners/watchers
         this.setWhileOpenListeners(false);
 
+        // If forced close, disable animation
+        if (force) {
+            removeClass(tip, ClassName.FADE);
+        }
         // Hide tip
         removeClass(tip, ClassName.SHOW);
 

--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -291,38 +291,40 @@ class ToolTip {
     }
 
     setWhileOpenListeners(on) {
-        // Ontouch start listeners
-        this.setOnTouchStartListener(on);
-        // Global hide events
-        this.setRootListener(on);
         // Modal close events
         this.setModalListener(on);
-        // Route change events
-        this.setRouteWatcher(on);
         // Periodic $element visibility check
         // For handling when tip is in <keepalive>, tabs, carousel, etc
         this.visibleCheck(on);
+        // Route change events
+        this.setRouteWatcher(on);
+        // Global hide events
+        this.setRootListener(on);
+        // Ontouch start listeners
+        this.setOnTouchStartListener(on);
     }
 
     // force hide of tip (internal method)
     forceHide() {
-        const tip = this.getTipElement();
+        if (!this.$tip) {
+            return;
+        }
+        // Disable while open listeners/watchers
+        this.setWhileOpenListeners(false);
         // Clear any hover enter/leave event
         clearTimeout(this.$hoverTimeout);
         this.$hoverTimeout = null;
         this.$hoverState = '';
-        // Remove animation for quicker hide
-        const initAnimation = this.$config.animation;
-        this.$config.animation = false;
-        removeClass(tip, ClassName.FADE);
         // Hide the tip
         this.hide(null, true);
-        this.$config.animation = initAnimation;
     }
 
     // Hide tooltip
     hide(callback, force) {
-        const tip = this.getTipElement();
+        const tip = this.$tip;
+        if (!tip) {
+            return;
+        }
 
         // Create a canelable BvEvent
         const hideEvt = new BvEvent('hide', {


### PR DESCRIPTION
Prevents illegal invocation errors when tooltip or popover inside `v-if`'ed elements.

Fixes issue  #1032