### PR TITLE
feat(docs): New reference section wrt project relative urls and image based Bootstrap-Vue components

### DIFF
--- a/docs/reference/images/README.md
+++ b/docs/reference/images/README.md
@@ -4,6 +4,7 @@
 on `<img>` tags, but doesn't automatically for Bootrap-Vue custom
 components that accept image src url tags.
 
+## `transformToRequire` option
 To hve your project convert these custom component image URLs for you, you will need to
 customize the [`transformToRequire`](https://vue-loader.vuejs.org/en/options.html#transformtorequire)
 `option` for `vue-loader` in your webpack config.
@@ -33,3 +34,20 @@ transformToRequire: {
 }
 ```
 
+This will allow you to use the following format:
+
+```html
+<b-img src="~/static/picture.jpg" />
+
+<b-card-img img-src="~/static/picture.jpg" />
+```
+
+## Using `require`
+If you cannot set the `transforToRequire` in your view-loader config, you
+can alternatively use the `require` method:
+
+```html
+<b-img :src="require('.../static/picture.jpg')" />
+
+<b-card-img :img-src="require('.../static/picture.jpg')" />
+```

--- a/docs/reference/images/README.md
+++ b/docs/reference/images/README.md
@@ -1,0 +1,35 @@
+# Project Image relative URLs
+
+> vue-loader automatically converts project relative `src` attributes
+on `<img>` tags, but doesn't automatically for Bootrap-Vue custom
+components that accept image src url tags.
+
+To hve your project convert these custom component image URLs for you, you will need to
+customize the [`transformToRequire`](https://vue-loader.vuejs.org/en/options.html#transformtorequire)
+`option` for `vue-loader` in your webpack config.
+
+The default value for `transformToRequire` is:
+
+```js
+transformToRequire: {
+  img: 'src',
+  image: 'xlink:href'
+}
+```
+
+To allow Bootstrap-Vue components to use project relative URLs,
+use the following configuration:
+
+```js
+transformToRequire: {
+  img: 'src',
+  image: 'xlink:href',
+  'b-img': 'src',
+  'b-img-lazy': ['src', 'blank-src'],
+  'b-card': 'img-src',
+  'b-card-img': 'img-src',
+  'b-carousel-slide': 'img-src',
+  'b-embed': 'src'
+}
+```
+

--- a/docs/reference/images/README.md
+++ b/docs/reference/images/README.md
@@ -5,7 +5,7 @@ on `<img>` tags, but doesn't automatically for Bootrap-Vue custom
 components that accept image src url tags.
 
 ## `transformToRequire` option
-To hve your project convert these custom component image URLs for you, you will need to
+To have your project convert these custom component image URLs for you, you will need to
 customize the [`transformToRequire`](https://vue-loader.vuejs.org/en/options.html#transformtorequire)
 `option` for `vue-loader` in your webpack config.
 
@@ -34,7 +34,7 @@ transformToRequire: {
 }
 ```
 
-This will allow you to use the following format:
+This will allow you to use the following format in your `.vue` files:
 
 ```html
 <b-img src="~/static/picture.jpg" />
@@ -47,7 +47,7 @@ If you cannot set the `transforToRequire` in your view-loader config, you
 can alternatively use the `require` method:
 
 ```html
-<b-img :src="require('.../static/picture.jpg')" />
+<b-img :src="require('../static/picture.jpg')" />
 
-<b-card-img :img-src="require('.../static/picture.jpg')" />
+<b-card-img :img-src="require('../static/picture.jpg')" />
 ```

--- a/docs/reference/images/README.md
+++ b/docs/reference/images/README.md
@@ -1,4 +1,4 @@
-# Project Image relative URLs
+# Project relative image URLs for Bootstrap Vue custom components
 
 > vue-loader automatically converts project relative `src` attributes
 on `<img>` tags, but doesn't automatically for Bootrap-Vue custom

--- a/docs/reference/images/index.js
+++ b/docs/reference/images/index.js
@@ -1,0 +1,8 @@
+import readme from './README.md';
+
+export default {
+    readme,
+    meta: {
+        title: 'Component img src resolving'
+    }
+};

--- a/docs/reference/index.js
+++ b/docs/reference/index.js
@@ -4,6 +4,7 @@ export default {
     'variants': require('./variants').default,
     'sizes': require('./sizes').default,
     'spacing': require('./spacing').default,
+    'imgages': require('./images').default,
     'router-links': require('./router-links').default,
     'examples': require('./examples').default
 };


### PR DESCRIPTION
Currently vue-loader/webpack only translate project relative asset URLs for `<img>` tags.

This brief document explains how to configure the `transformToRequire` vue-loader option to transform image SRC tags for Bootsrtap-Vue's components that accept image URLs via props.

Feel free to edit the docs.