### PR TITLE
feat(docs): Add TOC section in right hand column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 <a name="1.0.0-beta.7"></a>
-## 1.0.0-beta.7 (2017-09-01)
-[1.0.0-beta.7](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.6...v1.0.0-beta.7)
+## [1.0.0-beta.7](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.6...v1.0.0-beta.7) (2017-09-01)
 
 ### Bug Fixes
 
@@ -21,7 +20,6 @@ All notable changes to this project will be documented in this file. See [standa
 * this is not defined in props ([fe4ff06](https://github.com/bootstrap-vue/bootstrap-vue/commit/fe4ff06))
 * **tooltip+popover components:** Delay instantiation on mounted() ([#969](https://github.com/bootstrap-vue/bootstrap-vue/issues/969)) ([4fc18ec](https://github.com/bootstrap-vue/bootstrap-vue/commit/4fc18ec))
 * **tooltip+popover components:** Emit events and minor adjustments ([#972](https://github.com/bootstrap-vue/bootstrap-vue/issues/972)) ([cf7c538](https://github.com/bootstrap-vue/bootstrap-vue/commit/cf7c538))
-
 
 ### Features
 
@@ -43,8 +41,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="1.0.0-beta.6"></a>
-## 1.0.0-beta.6 (2017-08-30)
-[1.0.0-beta.6](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.5...v1.0.0-beta.6)
+## [1.0.0-beta.6](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.5...v1.0.0-beta.6) (2017-08-30)
 
 ### Bug Fixes
 
@@ -64,7 +61,6 @@ All notable changes to this project will be documented in this file. See [standa
 * **scrollspy:** Make work with new nav-link functional component ([#909](https://github.com/bootstrap-vue/bootstrap-vue/issues/909)) ([2ebba5d](https://github.com/bootstrap-vue/bootstrap-vue/commit/2ebba5d))
 * **tabs:** minor logic update ([add0fb6](https://github.com/bootstrap-vue/bootstrap-vue/commit/add0fb6))
 * **tabs:** Show first tab when set to active ([#912](https://github.com/bootstrap-vue/bootstrap-vue/issues/912)) ([d920b1c](https://github.com/bootstrap-vue/bootstrap-vue/commit/d920b1c))
-
 
 ### Features
 
@@ -86,8 +82,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="1.0.0-beta.5"></a>
-## 1.0.0-beta.5 (2017-08-21)
-[1.0.0-beta.5](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.2...v1.0.0-beta.5)
+## [1.0.0-beta.5](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.2...v1.0.0-beta.5) (2017-08-21)
 
 ### Bug Fixes
 
@@ -140,7 +135,6 @@ All notable changes to this project will be documented in this file. See [standa
 * **tabs:** Better handling of active tab and transitions ([#903](https://github.com/bootstrap-vue/bootstrap-vue/issues/903)) ([d5b81dd](https://github.com/bootstrap-vue/bootstrap-vue/commit/d5b81dd))
 * **tabs:** update to use card-block ([d881c37](https://github.com/bootstrap-vue/bootstrap-vue/commit/d881c37))
 
-
 ### Features
 
 * **addEventListenerOnce:** add to utils ([0869ffd](https://github.com/bootstrap-vue/bootstrap-vue/commit/0869ffd))
@@ -175,10 +169,8 @@ All notable changes to this project will be documented in this file. See [standa
 * link, breadcrumb, & button functional components ([#830](https://github.com/bootstrap-vue/bootstrap-vue/issues/830)) ([cdbef2d](https://github.com/bootstrap-vue/bootstrap-vue/commit/cdbef2d))
 
 
-
 <a name="0.20.2"></a>
-## 0.20.2 (2017-08-11)
-[0.20.2](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.1...v0.20.2) 
+## [0.20.2](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.1...v0.20.2) (2017-08-11)
 
 ### Bug Fixes
 
@@ -192,15 +184,12 @@ All notable changes to this project will be documented in this file. See [standa
 * **v-play:** disable vue global errorHandler ([9a7bdaf](https://github.com/bootstrap-vue/bootstrap-vue/commit/9a7bdaf))
 
 
-
 <a name="0.20.1"></a>
-## 0.20.1 (2017-08-10)
-[0.20.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.0...v0.20.1)
+## [0.20.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.0...v0.20.1) (2017-08-10)
 
 
 <a name="0.20.0"></a>
-## 0.20.0 (2017-08-10)
-[0.20.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.19.0...v0.20.0)
+## [0.20.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.19.0...v0.20.0) (2017-08-10)
 
 ### Bug Fixes
 
@@ -224,8 +213,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="0.19.0"></a>
-# [0.19.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.18.0...v0.19.0) (2017-08-09)
-
+## [0.19.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.18.0...v0.19.0) (2017-08-09)
 
 ### Bug Fixes
 
@@ -294,8 +282,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="0.18.0"></a>
-## 0.18.0 (2017-07-04)
-[0.18.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.17.1...v0.18.0)
+## [0.18.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.17.1...v0.18.0) (2017-07-04)
 
 ### Bug Fixes
 
@@ -337,8 +324,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="0.17.1"></a>
-## 0.17.1 (2017-06-30)
-[0.17.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/0.17.0...0.17.1)
+## [0.17.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/0.17.0...0.17.1) (2017-06-30)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-<a name="1.0.0-beta.7"></a>
-## [1.0.0-beta.7](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.6...v1.0.0-beta.7) (2017-09-01)
+## [v1.0.0-beta.7](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.6...v1.0.0-beta.7)
+Released: 2017-09-01
 
 ### Bug Fixes
 
@@ -39,9 +39,8 @@ All notable changes to this project will be documented in this file. See [standa
 * **tooltips+popovers:** Automatically hide when trigger element is no longer visible ([#978](https://github.com/bootstrap-vue/bootstrap-vue/issues/978)) ([09eaaa2](https://github.com/bootstrap-vue/bootstrap-vue/commit/09eaaa2))
 
 
-
-<a name="1.0.0-beta.6"></a>
-## [1.0.0-beta.6](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.5...v1.0.0-beta.6) (2017-08-30)
+## [v1.0.0-beta.6](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.5...v1.0.0-beta.6)
+Released: 2017-08-30
 
 ### Bug Fixes
 
@@ -80,9 +79,8 @@ All notable changes to this project will be documented in this file. See [standa
 * **table:** use computedFields for easier usage ([b9980f0](https://github.com/bootstrap-vue/bootstrap-vue/commit/b9980f0))
 
 
-
-<a name="1.0.0-beta.5"></a>
-## [1.0.0-beta.5](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.2...v1.0.0-beta.5) (2017-08-21)
+## [v1.0.0-beta.5](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.2...v1.0.0-beta.5)
+Released: 2017-08-21
 
 ### Bug Fixes
 
@@ -169,8 +167,8 @@ All notable changes to this project will be documented in this file. See [standa
 * link, breadcrumb, & button functional components ([#830](https://github.com/bootstrap-vue/bootstrap-vue/issues/830)) ([cdbef2d](https://github.com/bootstrap-vue/bootstrap-vue/commit/cdbef2d))
 
 
-<a name="0.20.2"></a>
-## [0.20.2](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.1...v0.20.2) (2017-08-11)
+## [v0.20.2](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.1...v0.20.2)
+Released: 2017-08-11
 
 ### Bug Fixes
 
@@ -184,12 +182,12 @@ All notable changes to this project will be documented in this file. See [standa
 * **v-play:** disable vue global errorHandler ([9a7bdaf](https://github.com/bootstrap-vue/bootstrap-vue/commit/9a7bdaf))
 
 
-<a name="0.20.1"></a>
-## [0.20.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.0...v0.20.1) (2017-08-10)
+## [v0.20.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.0...v0.20.1)
+Released: 2017-08-10
 
 
-<a name="0.20.0"></a>
-## [0.20.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.19.0...v0.20.0) (2017-08-10)
+## [v0.20.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.19.0...v0.20.0)
+Released: 2017-08-10
 
 ### Bug Fixes
 
@@ -211,9 +209,8 @@ All notable changes to this project will be documented in this file. See [standa
 * **table:** Add row-dblclicked event ([#780](https://github.com/bootstrap-vue/bootstrap-vue/issues/780)) ([1aaf915](https://github.com/bootstrap-vue/bootstrap-vue/commit/1aaf915))
 
 
-
-<a name="0.19.0"></a>
-## [0.19.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.18.0...v0.19.0) (2017-08-09)
+## [v0.19.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.18.0...v0.19.0)
+Released: 2017-08-09
 
 ### Bug Fixes
 
@@ -280,9 +277,8 @@ All notable changes to this project will be documented in this file. See [standa
 * **utils:** wrap-up as ES6 module ([#656](https://github.com/bootstrap-vue/bootstrap-vue/issues/656)) ([b5f7cfc](https://github.com/bootstrap-vue/bootstrap-vue/commit/b5f7cfc))
 
 
-
-<a name="0.18.0"></a>
-## [0.18.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.17.1...v0.18.0) (2017-07-04)
+## [v0.18.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.17.1...v0.18.0)
+Released: 2017-07-04
 
 ### Bug Fixes
 
@@ -322,9 +318,8 @@ All notable changes to this project will be documented in this file. See [standa
 * **mixin:** Automate event registration & removal on root vm ([#581](https://github.com/bootstrap-vue/bootstrap-vue/issues/581)) ([be5f834](https://github.com/bootstrap-vue/bootstrap-vue/commit/be5f834))
 
 
-
-<a name="0.17.1"></a>
-## [0.17.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/0.17.0...0.17.1) (2017-06-30)
+## [v0.17.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/0.17.0...0.17.1)
+Released: 2017-06-30
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 <a name="1.0.0-beta.7"></a>
-# [1.0.0-beta.7](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.6...v1.0.0-beta.7) (2017-09-01)
-
+## 1.0.0-beta.7 (2017-09-01)
+[1.0.0-beta.7](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.6...v1.0.0-beta.7)
 
 ### Bug Fixes
 
@@ -43,8 +43,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="1.0.0-beta.6"></a>
-# [1.0.0-beta.6](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.5...v1.0.0-beta.6) (2017-08-30)
-
+## 1.0.0-beta.6 (2017-08-30)
+[1.0.0-beta.6](https://github.com/bootstrap-vue/bootstrap-vue/compare/v1.0.0-beta.5...v1.0.0-beta.6)
 
 ### Bug Fixes
 
@@ -86,8 +86,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="1.0.0-beta.5"></a>
-# [1.0.0-beta.5](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.2...v1.0.0-beta.5) (2017-08-21)
-
+## 1.0.0-beta.5 (2017-08-21)
+[1.0.0-beta.5](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.2...v1.0.0-beta.5)
 
 ### Bug Fixes
 
@@ -177,8 +177,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="0.20.2"></a>
-## [0.20.2](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.1...v0.20.2) (2017-08-11)
-
+## 0.20.2 (2017-08-11)
+[0.20.2](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.1...v0.20.2) 
 
 ### Bug Fixes
 
@@ -194,13 +194,13 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="0.20.1"></a>
-## [0.20.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.0...v0.20.1) (2017-08-10)
-
+## 0.20.1 (2017-08-10)
+[0.20.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.20.0...v0.20.1)
 
 
 <a name="0.20.0"></a>
-# [0.20.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.19.0...v0.20.0) (2017-08-10)
-
+## 0.20.0 (2017-08-10)
+[0.20.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.19.0...v0.20.0)
 
 ### Bug Fixes
 
@@ -294,8 +294,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="0.18.0"></a>
-# [0.18.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.17.1...v0.18.0) (2017-07-04)
-
+## 0.18.0 (2017-07-04)
+[0.18.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v0.17.1...v0.18.0)
 
 ### Bug Fixes
 
@@ -337,8 +337,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 <a name="0.17.1"></a>
-## [0.17.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/0.17.0...0.17.1) (2017-06-30)
-
+## 0.17.1 (2017-06-30)
+[0.17.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/0.17.0...0.17.1)
 
 ### Bug Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,18 @@
 
 👍🎉 First off, thanks for taking the time to contribute! 🎉👍
 
-### Playground & Issue Reports
+## Playground & Issue Reports
 If you want to play with BootstrapVue components without any local setup just head to
-[OnlinePlayground](https://bootstrap-vue.github.io/play) and you can interactively play and test components with a fresh Vue instance.
+[OnlinePlayground](https://bootstrap-vue.js.org/play) and you can interactively play and test components with a fresh Vue instance.
 If you want to keep your changes or make PRs reporting a component's misbehaviour you can save them in JSFiddle and provide that link in issues.
 
-### Setup
-- Clone this repo.
+## Setup
+- Clone this repo (`git clone https://github.com/bootstrap-vue/bootstrap-vue --branch=dev`)
 - Make sure you have node & yarn installed locally.
+- `cd bootstrap-vue`
 - Run `yarn install` to get all dependencies installed.
 
-### Work on components
+## Work on components
 If you want to hack and improve components locally, you can follow these steps:
 
 - Run `yarn docs-dev` to run a local development server.
@@ -21,7 +22,7 @@ If you want to hack and improve components locally, you can follow these steps:
   Changes will be applied with webpack hot-reloading without needing to reload the page.
 - Finally feel free to share your awesome hacks with others and opening a PR.
 
-### Test inside your project
+## Test inside your project
 If you want to see your changes in your project instead of the playground:
 
 - Execute `yarn link` inside *bootstrap-vue* directory.
@@ -29,5 +30,5 @@ If you want to see your changes in your project instead of the playground:
 - Run `yarn watch` inside *bootstrap-vue*
 - Now every time you change a component, a new production version will be built and ready on your project. 
 
-### Pull requests
-Please ensure all pull requests are made aganst the `dev` branch on GitHub.
+## Pull requests
+Please ensure all pull requests related to `v1.x` are made aganst the `dev` branch on GitHub.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-### Webpack
+## Webpack
 If you are using module bundlers such as Webpack, Rollup, Laravel elixir/mix, etc you may prefer directly include package
 into your project. To get started use yarn or npm to get latest version first:
 
@@ -29,7 +29,7 @@ manually include both [Bootstrap](https://v4-alpha.getbootstrap.com/getting-star
 and [BootstrapVue](https://unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.css) CSS files
 in your bundle or reference them from `static/` via `index.html`.
 
-### Nuxt.js
+## Nuxt.js
 You can use official [Nuxt.js](https://nuxtjs.org) module to add BootstrapVue support. ([module docs](https://github.com/nuxt-community/modules/tree/master/modules/bootstrap-vue))
 
 - Add `@nuxtjs/bootstrap-vue` dependency using yarn or npm to your project:
@@ -46,7 +46,7 @@ You can use official [Nuxt.js](https://nuxtjs.org) module to add BootstrapVue su
 }
 ```
 
-### vue-cli
+## vue-cli
 
 Download the dependencies:
 
@@ -66,7 +66,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 Vue.use(BootstrapVue)
 ```
 
-### Individual components and directives
+## Individual components and directives
 If for any reason just want to use a specific component, you can do this by directly importing that component.
 This is not recommended as entire package gzipped size is ~40Kb (including Popper.js)!
 
@@ -88,7 +88,7 @@ new Vue({
   // ...
 })
 ```
-### Browser
+## Browser
 
 ```html
 <!-- Add this to <head> -->
@@ -119,19 +119,19 @@ If you've already been using Bootstrap 4, there are a couple adjustments you may
 
 ## Browsers Support
 
-**CSS**
+### CSS
 
 BootstrapVue is to be used with Bootstrap 4 CSS.
 Please see [Browsers and devices](https://v4-alpha.getbootstrap.com/getting-started/browsers-devices)
 for more information about browsers currently supported by Bootstrap 4. 
 
-**JS**
+### JS
 
 BootstrapVue is written in Vue! So this is up to your project and bundler that which browsers are supported.
 If you want to support older IE, Android and IOS devices, you may want to use
 [Babel Polyfill](https://babeljs.io/docs/usage/polyfill)
 
-**IE 11**
+### IE 11
 
 You'll need babel-polyfill for BootstrapVue to work properly. In order to support this browser: 
 - `npm install babel-polyfill`

--- a/docs/components/alert/README.md
+++ b/docs/components/alert/README.md
@@ -205,3 +205,5 @@ export default {
 
 <!-- alert-auto-dismiss-1.vue -->
 ```
+
+## Component Reference

--- a/docs/components/badge/README.md
+++ b/docs/components/badge/README.md
@@ -12,19 +12,19 @@
 <!-- badges.vue -->
 ```
 
-### Contextual variations
+## Contextual variations
 Add any of the following variants via the `variant` prop to change the
 appearance of a `<b-badge>`: `default`, `primary`, `success`, `warning`, `info`,
 and `danger`. If no variant is specified `default` will be used.
 
-#### Conveying meaning to assistive technologies:
+### Conveying meaning to assistive technologies:
 Using color to add meaning only provides a visual indication, which will not
 be conveyed to users of assistive technologies – such as screen readers. Ensure
 that information denoted by the color is either obvious from the content itself
 (e.g. the visible text), or is included through alternative means, such as
 additional text hidden with the `.sr-only` class.
 
-### Pill badges
+## Pill badges
 Use the `pill` prop to make badges more rounded (with a larger border-radius
 and additional horizontal padding). Useful if you miss the badges from Bootstrap v3.
 

--- a/docs/components/badge/README.md
+++ b/docs/components/badge/README.md
@@ -27,3 +27,5 @@ additional text hidden with the `.sr-only` class.
 ### Pill badges
 Use the `pill` prop to make badges more rounded (with a larger border-radius
 and additional horizontal padding). Useful if you miss the badges from Bootstrap v3.
+
+## Component Reference

--- a/docs/components/breadcrumb/README.md
+++ b/docs/components/breadcrumb/README.md
@@ -28,6 +28,7 @@ export default {
 <!-- breadcrumb.vue -->
 ```
 
+## Breadcrumb items
 Items are rendered using `:items` prop.
 It can be an array of objects to provide link and active state.
 Links can be `href`'s for anchor tags, or `to`'s for router-links.
@@ -47,3 +48,5 @@ items = [
   }
 ]
 ```
+
+## Component Reference

--- a/docs/components/button-group/README.md
+++ b/docs/components/button-group/README.md
@@ -26,7 +26,7 @@
 <!-- button-group-1.vue -->
 ```
 
-### Sizing
+## Sizing
 Set the size prop to `lg` or `sm` to render larger or smaller, respectively, buttons.
 There is no need to specify the size on the individual buttons.
 
@@ -55,7 +55,7 @@ There is no need to specify the size on the individual buttons.
 <!-- button-group-2.vue -->
 ```
 
-### Vertical variation
+## Vertical variation
 Make a set of buttons appear vertically stacked rather than horizontally by setting
 the `vertical` prop. Split button dropdowns are not supported here.
 
@@ -72,7 +72,7 @@ the `vertical` prop. Split button dropdowns are not supported here.
 <!-- button-group-3.vue -->
 ```
 
-### Dropdown menu support
+## Dropdown menu support
 Add [`<b-dropdown>`](./dropdown) menus directly inside your `<b-button-group>`. Note
 that split dropdown menus are not supported when prop `vertical` is set.
 
@@ -101,13 +101,12 @@ that split dropdown menus are not supported when prop `vertical` is set.
 <!-- button-group-4.vue -->
 ```
 
-### Alias
+## Alias
 `<b-button-group>` can also be used by its shorter alias `<b-btn-group>`.
 
-### See also
+## See also
 Also check out the [`<b-button-toolabr>`](./button-toolbar) component for generating
 toolbars containing button groups and input groups.
 
-### Tooltips and popovers
-Due to the specific implementation (and some other components), tooltips and popovers
-on elements within a button-group will have adverse effect on styling.
+
+## Component Reference

--- a/docs/components/button-toolbar/README.md
+++ b/docs/components/button-toolbar/README.md
@@ -76,20 +76,20 @@
 <!-- button-toolbar-3.vue -->
 ```
 
-### Usage
+## Usage
 Feel free to mix input groups and dropdowns with button groups in your toolbars.
 Similar to the example above, you’ll likely need some utility classes
 though to space things properly.
 
-### Sizing
+## Sizing
 Note, if you want smaller or larger buttons or controls, set the `size`
 prop directly on the `<b-button-group>`, `<b-input-group>`, and `<b-dropdown>` components.
 
-### Justify
+## Justify
 Make the toolbar span the maximum available width, by increasing spacing between the
 button groups, input groups and dropdowns, by setting the prop `justify`.
 
-### Keyboard Navigation
+## Keyboard Navigation
 Enable optional keyboard navigation by setting the prop `key-nav`.
 
 | Keypress | Action
@@ -104,9 +104,11 @@ Enable optional keyboard navigation by setting the prop `key-nav`.
 **Caution:** If you have text or text-like inputs in your toolbar, leave keyboard navigation off,
 as it is not possble to use key presses to jump out of a text (or test-like) inputs.
 
-### Alias
+## Alias
 `<b-button-toolbar>` can also be used via the shorthand alias `<b-btn-toolbar>`
 
-### See Also
+## See Also
 - [`<b-button-group>`](./button-group)
 - [`<b-dropdown>`](./dropdown)
+
+## Component Reference

--- a/docs/components/button/README.md
+++ b/docs/components/button/README.md
@@ -63,7 +63,7 @@ and `outline-danger`.
 Variant `link` will render a button with the appearance of a link while maintaining the
 default padding and size of a button.
 
-### Disabled state
+## Disabled state
 
 Set the `disabled` prop to disable button default functionality. `disabled` also
 works with buttons, rendered as `<a>` elements and `<router-link>`.
@@ -77,13 +77,13 @@ works with buttons, rendered as `<a>` elements and `<router-link>`.
 <!-- button-3.vue -->
 ```
 
-### Button type
+## Button type
 
 When neither `href` nor `to` props are provided, `<b-button>` renders an html `<button>`
 element.  You can specify the button's type by setting the prop `type` to `button`,
 `submit` or `reset`.  The default type is `button`.
 
-### Pressed state and toggling
+## Pressed state and toggling
 
 Buttons will appear pressed (with a darker background, darker border, and inset shadow)
 when the prop `presed` is set to `true`.
@@ -142,17 +142,23 @@ the `.sync` prop modifier (available in Vue 2.3+) on the `pressed` property
 <!-- button-4.vue -->
 ```
 
-### Router links
+If using toggle button style for a radio or checkbox style interface, it is best to use hhe
+built-in `button` style support of [`<b-form-radio-group>`](/docs/components/form-radios) and
+[`b-checkbox-group>`](/docs/components/form-checkboxes).
+
+## Router link support
 
 Refer to [`vue-router`](https://router.vuejs.org/) docs for the various `<router-link>` related props.
 
 Note the `tag` attribute for `<router-link>` is referred to as `router-tag` in `bootstrap-vue`.
 
-### Alias
+## Alias
 
 `<b-button>` can also be used by its shorter alias `<b-btn>`.
 
-### See also
+## See also
 
 - [`<b-button-group>`](./button-group)
 - [`<b-button-toolbar>`](./button-toolbar)
+
+## Component Reference

--- a/docs/components/card/README.md
+++ b/docs/components/card/README.md
@@ -591,3 +591,5 @@ isn’t a bulletproof solution yet.
 
 <!-- card-group-3.vue -->
 ```
+
+## Component Reference

--- a/docs/components/carousel/README.md
+++ b/docs/components/carousel/README.md
@@ -81,7 +81,7 @@ export default {
 ```
 
 
-### Sizing
+## Sizing
 Carousels don’t automatically normalize slide dimensions. As such, you may need to use
 additional utilities or custom styles to appropriately size content. When using images
 in each slide, ensure they all have the same dimensions (or aspect ratio).
@@ -98,7 +98,7 @@ component to render the images. The `img-*` props map to the corresponsing props
 available to `<b-img>`.
 
 
-### Interval
+## Interval
 Carousel defaults to an interval of `5000`ms (5 seconds). To pause the carousel from
 auto sliding, set the `interval` prop to `0`. To restart a paused carousel, set the
 `interval` back to the number of ms.
@@ -108,7 +108,7 @@ is supported, the carousel will avoid sliding when the webpage is not visible to
 the user (such as when the browser tab is inactive, the browser window is minimized, etc.).
 
 
-### Controls and Indicators
+## Controls and Indicators
 Set the prop `controls` to enable the previous and next control buttons.
 
 Set the prop `indicators` to show the slide indicator buttons.
@@ -116,12 +116,12 @@ Set the prop `indicators` to show the slide indicator buttons.
 Both indicators and controls can be set at the same time or independently.
 
 
-### V-model support
+## V-model support
 Programmaticaly control which slide is showing via `v-model` (which binds to the
 `value` prop). Note, that slides are indexed starting at `0`.
 
 
-### Accessibility
+## Accessibility
 Carousels are generally not fully compliant with accessibility standards, although
 we try to make them as accessible as possible.
 
@@ -130,3 +130,5 @@ accessibility features.  It is highly recommended to always add an ID to all com
 
 All carousel controls and indicators have aria labels.  These can be customized by
 setting the various `label-*` props.
+
+## Component Reference

--- a/docs/components/collapse/README.md
+++ b/docs/components/collapse/README.md
@@ -241,3 +241,5 @@ trigger elements may be inaccessible to keyboard or screen reader users. If you 
 something other than a button or link (or similar component), you should add the attributes
 `tabindex="0"` and `role="button"` to allow users of assistive technology to reach your
 trigger element.
+
+## Component Reference

--- a/docs/components/dropdown/README.md
+++ b/docs/components/dropdown/README.md
@@ -171,7 +171,7 @@ Dropdowns support keyboard navigation, emulating native `<select>` behaviour.
 ## Component Alias
 `<b-dropdown>` can be used via it's shorter alias of `<b-dd>`
 
-## Note
+## Implementation Note
 On touch-enabled devices, opening a `<b-dropdown>` adds empty (noop) `mouseover`
 handlers to the immediate children of the `<body>` element. This admittedly ugly
 hack is necessary to work around a
@@ -179,3 +179,7 @@ hack is necessary to work around a
 which would otherwise prevent a tap anywhere outside of the dropdown from
 triggering the code that closes the dropdown. Once the dropdown is closed, these
 additional empty `mouseover` handlers are removed.
+
+Dropdown menus use `Popper.js` for positioning. The `popper.js` library is included in the dist files.
+
+## Component Reference

--- a/docs/components/embed/README.md
+++ b/docs/components/embed/README.md
@@ -52,3 +52,5 @@ inside the inner embded element. Note that type `iframe` does not support any ch
           type='video/mp4;codecs="avc1.42E01E, mp4a.40.2"' />
 </b-embed>
 ```
+
+## Component Reference

--- a/docs/components/form-checkboxes/README.md
+++ b/docs/components/form-checkboxes/README.md
@@ -366,3 +366,5 @@ chechbox input by setting the `plain` prop.
 - `<b-form-checbox-group>` can be used by the shorter aliases `<b-checkbox-group>` and `<b-check-group>`.
 - `<b-form-checkbox>` can be used by thes shorter aliases `<b-checkbox>` and `<b-check>`.
 
+
+## Component Reference

--- a/docs/components/form-file/README.md
+++ b/docs/components/form-file/README.md
@@ -154,3 +154,4 @@ window.app = new Vue({
 });
 ```
 
+## Component Reference

--- a/docs/components/form-group/README.md
+++ b/docs/components/form-group/README.md
@@ -101,7 +101,7 @@ to `'invalid'`, `'valid'`, or `null`.
 You should always provide content via the `feedback` prop (or slot) to aid users
 using assistive technologies when setting a contextual `invalid` state.
 
-### Accessibility
+## Accessibility
 To enable auto-generation of `aria-*` attributes, **you must** supply a unique `id`
 prop to `<b-form-fieldset>`.
 
@@ -112,5 +112,7 @@ to the value of the `id` string associated with the input or contaner element.
 
 It is **highly recommended** that you provide a unique `id` prop on your input element.
 
-### Alias
+## Alias
 `<b-form-group>` can also be used via the legacy alias of `<b-form-fieldset>`.
+
+## Component Reference

--- a/docs/components/form-input/README.md
+++ b/docs/components/form-input/README.md
@@ -168,3 +168,6 @@ Supported `aria-invalid` values are:
 - `true` The value has failed validation.
 - `grammar` A grammatical error has been detected.
 - `spelling` A spelling error has been detected.
+
+
+## Component Reference

--- a/docs/components/form-radios/README.md
+++ b/docs/components/form-radios/README.md
@@ -305,3 +305,5 @@ You can have `b-form-radio` render a browser native radio input by setting the `
 ## Aliases
 - `<b-form-radio-group>` can be used by the shorter aliant `<b-radio-group>`.
 - `<b-form-radio>` can be used by the shorter alias of `<b-radio>`.
+
+## Component Reference

--- a/docs/components/form-select/README.md
+++ b/docs/components/form-select/README.md
@@ -321,3 +321,5 @@ that has the `select-size` prop set to a value greater than 1.
 ## Aliases
 - `<b-form-select>` can be used by the shorter alias `<b-select>`.
 
+## Component Reference
+

--- a/docs/components/form-textarea/README.md
+++ b/docs/components/form-textarea/README.md
@@ -70,3 +70,6 @@ field styling and preserve the correct margin and padding and height.
 
 <!-- b-form-textarea-3.vue -->
 ```
+
+## Component Reference
+

--- a/docs/components/form/README.md
+++ b/docs/components/form/README.md
@@ -100,3 +100,5 @@ to the form.
 ### Validation methods
 
 Coming soon.
+
+## Component Reference

--- a/docs/components/img/README.md
+++ b/docs/components/img/README.md
@@ -197,3 +197,5 @@ removed.
 
 <!-- b-img-lazy.vue -->
 ```
+
+## Component Reference

--- a/docs/components/input-group/README.md
+++ b/docs/components/input-group/README.md
@@ -42,10 +42,10 @@
 <!-- input-group-1.vue -->
 ```
 
-### Usage
+## Usage
 You can attach left or right Addons via props or named slots
 
-#### Via `left` and `right` props:
+### Via `left` and `right` props:
 
 ```html
 <div>
@@ -57,7 +57,7 @@ You can attach left or right Addons via props or named slots
 <!-- input-group-addons-1.vue -->
 ```
 
-#### Via named slots:
+### Via named slots:
 if you want better control over addons, you can use `right` and `left` slots instead:
 
 ```html
@@ -77,7 +77,7 @@ if you want better control over addons, you can use `right` and `left` slots ins
 <!-- input-group-addons-2.vue -->
 ```
 
-#### Direct placement of sub components:
+### Direct placement of sub components:
 Use the `<b-input-group-addon>` to add arbitrary addons wherever you like, and use
 the `<b-input-group-button>` component to group buttons in your input group.  Single
 buttons must always be wrapped in a `<b-input-group-button>` for proper styling
@@ -98,14 +98,16 @@ buttons must always be wrapped in a `<b-input-group-button>` for proper styling
 ```
 
 
-### Control sizing
+## Control sizing
 Set height using the `size` prop to `sm` or `lg` for small or large respectively. There 
 is no ned to set size on the individual inputs or buttons..
 
 To control width, place the input inside standard Bootstrap grid column.
 
-### Related components
+## Related components
 - `<b-input-group-addon>`
 - `<b-input-group-button>`
 
 `b-input-group-button` can also be used by the shorthand alias `b-input-group-btn`
+
+## Component Reference

--- a/docs/components/jumbotron/README.md
+++ b/docs/components/jumbotron/README.md
@@ -96,3 +96,5 @@ default styling.
 
 <!-- jumbotron-3.vue -->
 ```
+
+## Component Reference

--- a/docs/components/list-group/README.md
+++ b/docs/components/list-group/README.md
@@ -19,3 +19,9 @@ They can also be used as navigation with the right modifier class.
 
 <!-- list-group.vue -->
 ```
+
+## Actionalable list group items
+Turn a `<b-list-group-item>` into an actionalble link by specifying either an
+`href` prop or router link `to` prop.
+
+## Component Reference

--- a/docs/components/media/README.md
+++ b/docs/components/media/README.md
@@ -143,3 +143,5 @@ utilities wherever needed to fine tune.
 
 <!-- media-4.vue -->
 ```
+
+## Component Reference

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -17,6 +17,7 @@ feature a handful of helpful sub-components, sizes, variants, accessibility, and
 <!-- modal-1.vue -->
 ```
 
+## Overview
 `<b-modal>`, by default, has an **OK** and **Cancel** buttons in the footer. These buttons can
 be customized by setting various props on the component. You can customize the size of the buttons,
 disable the **OK** button, hide the **Cancel** button (i.e. OK Only), choose a variant (e.g. `danger`
@@ -394,7 +395,7 @@ For `aria-labelledby` and `aria-described` by attributes to appear on the
 modal, you **must** supply an `id` attribute on `<b-modal>`. `aria-labelledby` will
 not be present if you have the header hidden.
 
-### Auto Focus
+## Auto Focus on open
 
 `<b-modal>` will autofocus the modal container when opened.
 
@@ -423,13 +424,13 @@ methods: {
 }
 ```
 
-### Returning focus to the triggering element on modal close
+## Returning focus to the triggering element
 
 For accessibility reasons, it is desireable to return focus to the element
 that triggered the opening of the modal, when the modal closes.  `<b-modal>`
 provides several methods and options for returning focus to the triggering element.
 
-#### Specify Return Focus Element via the `return-focus` Prop:
+### Specify Return Focus Element via the `return-focus` Prop
 
 You can also specify an element to return focus to, when modal closes, by setting
 the `return-focus` prop to one of the following:
@@ -445,13 +446,13 @@ This method for returning focus is handy when you use the `<b-modal>` methods `s
 and `hide()`, or the `v-model` prop. Note this property takes
 precedence over other methods of specifying the return focus element.
 
-#### Auto Return Focus
+### Auto Return Focus
 
 When `<b-modal>` is opened via the `v-b-modal` directive on an element, focus will be
 returned to this element automatically when `<b-modal>` closes, unless an element has
 been specified via the `return-focus` prop.
 
-#### Specify Return Focus via Event
+### Specify Return Focus via Event
 
 When using the `bv::show::modal` event (emitted on `$root`), you can specify a second argument
 which is the element to return focus to.  This argument accepts the same types
@@ -473,10 +474,12 @@ event's `target` property:
 **Note:** If the `<b-modal>` has the `return-focus` prop set, then the element specified
 via the event will be ignored.
 
-### Keyboard Navigation
+## Keyboard Navigation
 
 When tabbing through elements within a `<b-modal>`, if focus attempts to leave the modal into the document,
 it  will be brought back into the modal.
 
 In some circumstances, you may need to disable the enforce focus feature. You can do this
 by setting the prop `no-enforce-focus`.
+
+## Component Reference

--- a/docs/components/nav/README.md
+++ b/docs/components/nav/README.md
@@ -17,17 +17,19 @@ Swap modifier props to switch between each style.
 <!-- nav-1.vue -->
 ```
 
+## Overview
+
 The base `<b-nav>` component is built with flexbox and provides a strong
 foundation for building all types of navigation components. It includes
 some style overrides (for working with lists), some link padding for larger
 hit areas, and basic disabled styling. No active states are included in the base nav.
 
-### Link Appearance
+## Link Appearance
 
 Two style variations are supported: `tabs` and `pills`, which support `active` state styling.
 These variants are mutually exclusive - use only one style or the other.
 
-#### Tabs:
+### Tab style
 
 Make the nav look like tabs by setting the prop `tabs`.
 
@@ -42,7 +44,7 @@ Make the nav look like tabs by setting the prop `tabs`.
 <!-- nav-2.vue -->
 ```
 
-#### Pills:
+### Pill style
 
 Use the pill style by setting the prop `pills`.
 
@@ -57,11 +59,11 @@ Use the pill style by setting the prop `pills`.
 <!-- nav-3.vue -->
 ```
 
-### Fill and justify
+## Fill and justify
 
 Force your `b-nav` content to extend the full available width.
 
-#### fill:
+### fill
 
 To proportionately fill all available space with your `<b-nav-item>` components,
 set the `fill` prop. Notice that all horizontal space is occupied, but not
@@ -78,7 +80,7 @@ every nav item has the same width.
 <!-- nav-4.vue -->
 ```
 
-#### Justified:
+### Justified
 
 For equal-width elements, set prop `justified` instead. All horizontal space
 will be occupied by nav links, but unlike `fill` above, every `<b-nav-item>`
@@ -95,7 +97,7 @@ will be the same width.
 <!-- nav-5.vue -->
 ```
 
-### Vertical variation
+## Vertical variation
 
 By default navs appear on a horizontal line. Stack your navigation by setting
 the `vertical` prop.
@@ -111,7 +113,7 @@ the `vertical` prop.
 <!-- nav-6.vue -->
 ```
 
-### Dropdown support
+## Dropdown support
 
 Use `<b-nav-item-dropdown>` to place dropdown items within your nav.
 
@@ -133,16 +135,16 @@ Use `<b-nav-item-dropdown>` to place dropdown items within your nav.
 Refer to [`<b-dropdown>`](../dropdown) for a list of supported sub-components.
 
 
-### Using in Navbar
+## Using in Navbar
 
-When using `<b-nav>` within a `<b-navbar>`, set the `navbar-nav` prop.
+When using `<b-nav>` within a `<b-navbar>`, set the `navbar-nav` prop to ensure taht the proper
+classes and handlers can be applied
 
-### Tabbed content support
+## Tabbed content support
 
 See the [`<b-tabs>`](./tabs) component.
 
-### Regarding accessibility
-
+## Accessibility
 If you’re using `<b-nav>` to provide a navigation bar, be sure to add a
 `role="navigation"` to the most logical parent container of `<b-nav>`, or wrap
 a `<nav>` element around `<b-nav>`. Do **not** add the role to the `<b-nav>` itself,
@@ -152,8 +154,10 @@ When using a `<b-nav-item-dropdown>` in your `<b-nav>`, be sure to assign a uniq
 prop value to the `<b-nav-dropdown>` so that the apropriate `aria-*` attributes can
 be automatically generated.
 
-### See Also
+## See Also
 
 - [`<b-tabs>`](./tabs) to create tabbable panes of local content, even via dropdown menus.
 - [`<b-navbar>`](./navbar) a wrapper that positions branding, navigation, and other elements in a concise header.
 - [`<b-dropdown>`](./dropdown) for sub-components that you can place inside `<b-nav-item-dropdown>`
+
+## Component Reference

--- a/docs/components/navbar/README.md
+++ b/docs/components/navbar/README.md
@@ -48,7 +48,7 @@ It’s easily extensible and thanks to our Collapse plugin, it can easily integr
 <!-- navbar-1.vue -->
 ```
 
-### Color schemes
+## Color schemes
 
 `<b-navbar>` supports the standard Bootstrap V4 available background color variants.
 Set the `variant` prop to one of the following values to change the background color:
@@ -57,7 +57,7 @@ Set the `variant` prop to one of the following values to change the background c
 Control the text color by setting `type` prop to `light` for use with light background
 color variants, or `dark` for dark background color variants.
 
-### Placement
+## Placement
 
 Control the placement of the navbar by setting one of two props:
 
@@ -67,7 +67,7 @@ Control the placement of the navbar by setting one of two props:
 | `sticky` | Boolean | `false` | Set to `true` to make the navbar stickied to the top when scrolled. _Note that `position: sticky`, used for `sticky`, isn’t fully supported in every browser._
 
 
-### Supported Content
+## Supported Content
 
 Navbars come with built-in support for a handful of sub-components. Choose from the following as needed:
 
@@ -80,7 +80,7 @@ Navbars come with built-in support for a handful of sub-components. Choose from 
 - `<b-navbar-toggler>` for use with the `<b-collapse>` component.
 - `<b-collapse is-nav>` for grouping and hiding navbar contents by a parent breakpoint.
 
-#### `<b-navbar-brand>`
+### `<b-navbar-brand>`
 
 The `<b-navbar-brand>` generates a link if `href` is provided, or a `<router-link>` if `to`
 is provided.  If neither is given it renders as a `<div>` tag.  You can override the
@@ -138,7 +138,7 @@ to properly size.  Here are some examples to demonstrate:
 <!-- navbar-brand-4.vue -->
 ```
 
-#### `<b-nav is-nav-bar>`
+### `<b-nav is-nav-bar>`
 
 Navbar navigation links build on our `<b-nav>` parent component with their own modifier
 class and require the use of `<b-collapse>` toggler for proper responsive styling.
@@ -153,7 +153,7 @@ Be sure to set the prop `is-nav-bar` on `<b-nav>` for proper alignment!
 - `<b-nav-text>` for adding vertically centered strings of text.
 - `<b-nav-item-dropdown>` for navbar dropdown menus
 
-#### `<b-nav-item>`
+### `<b-nav-item>`
 
 `<b-nav-item>` is the primary link (and `<router-link>`) component. Providing
 a `to` prop value will generate a `<router-link>` while providing an `href` prop
@@ -164,7 +164,7 @@ Disable a `<b-nav-item>` by setting the prop `disabled` to true.
 
 Handle click events by specifying a handler for the `@click` event on `<b-nav-item>`.
 
-#### `<b-nav-text>`
+### `<b-nav-text>`
 
 Navbars may contain bits of text with the help of `<b-nav-text>`. This component
 adjusts vertical alignment and horizontal spacing for strings of text.
@@ -185,7 +185,7 @@ adjusts vertical alignment and horizontal spacing for strings of text.
 <!-- navbar-text-1.vue -->
 ```
 
-#### `<b-nav-item-dropdown>`
+### `<b-nav-item-dropdown>`
 
 For `<b-nav-item-dropdown>` usage, see the [`<b-dropdown>`](./dropdown) docs.
 Note split dropdowns are not supported in `<b-navbar>`.
@@ -217,7 +217,7 @@ Note split dropdowns are not supported in `<b-navbar>`.
 <!-- navbar-dropdown-1.vue -->
 ```
 
-#### `<b-nav-form>`
+### `<b-nav-form>`
 
 Use `<b-nav-form>` to place inline form controls into your navbar
 
@@ -250,7 +250,7 @@ Input groups work as well:
 <!-- navbar-form-2.vue -->
 ```
 
-### Responsive collapsing content
+## Responsive collapsing content
 
 Navbars are responsive by default, but you can easily modify them to change that. Responsive
 behavior depends on our `<b-collapse>` component.
@@ -265,3 +265,5 @@ breakpoint to `sm`.  setting to `false` will disable collapsing.
 
 See the first example on this page for reference, and also refer to [`<b-collapse>`](./collapse) for
 details on the collapse component.
+
+## Component Reference

--- a/docs/components/pagination-nav/README.md
+++ b/docs/components/pagination-nav/README.md
@@ -212,7 +212,7 @@ export default {
 <!-- pagination-align.vue -->
 ```
 
-## Small screen support (`xs`)
+## Small screen support
 
 On smaller screens (i.e. mobile), some of the `<b-pagination>` buttons will be hidden to
 minimize the potential of the pagination interface wrapping onto multiple lines:

--- a/docs/components/pagination-nav/README.md
+++ b/docs/components/pagination-nav/README.md
@@ -86,7 +86,7 @@ which is a page number (1-N). The `page-gen` function should return a string.
 
 Note HTML strings are currently not supported.
 
-### Example: Using an array of links to generate pagination:
+**Example: Using an array of links to generate pagination:**
 
 ```html
 <template>
@@ -255,3 +255,5 @@ list, respectively, and <kbd>ENTER</kbd> or <kbd>SPACE</kbd> keys will select (c
 
 For pagination control of a component (such as `<b-table>`), use the
 [`<b-pagination>`](./pagination) component instead.
+
+## Component Reference

--- a/docs/components/pagination/README.md
+++ b/docs/components/pagination/README.md
@@ -36,13 +36,14 @@ export default {
 <!-- pagination-1.vue -->
 ```
 
+## Overview
 `<b-pagination>` is a custom input component that provides a current page number
 input control. The value should be bound via `v-model` in your app. Page numbers
 are indexed from 1. The number of pages is computed from the provided prop
 values for `total-rows` and `per-page`.
 
 
-### Customizing
+## Customizing
 `<b-pagination>` supports several props that allow you to customize the appearance.
 
 | Prop | Description
@@ -62,7 +63,7 @@ Ellipsis inidcator(s) will only be ever shown at the front and/or end of
 the page number buttons. For `limit` values less than or equal to `3`, the ellipsis
 indicator(s) will never be shown for practical display reasons.
 
-### Alignment
+## Alignment
 By default the pagination component is left aligned. Change the alignment to
 `center` or `right` (`right` is an alias for `end`) by setting the prop
 `align` to the appropriate value.
@@ -101,7 +102,7 @@ export default {
 ```
 
 
-### Small screen support (`xs`)
+## Small screen support
 On smaller screens (i.e. mobile), some of the `<b-pagination>` buttons will be hidden to
 minimize the potential of the pagination interface wrapping onto multiple lines:
 
@@ -112,17 +113,17 @@ This ensures that no more than 3 page number buttons are visible,
 along with the goto _first_, _prev_, _next_, and _last_ buttons.
 
 
-### Accessibility
+## Accessibility
 The `<b-pagination>` component provides many features to support assistive technology users,
 such as `aria-` attributes and keyboard navigation.
 
-#### `aria-controls`:
+### `aria-controls`
 When pagination is controling another component on the page (such as `<b-table>`), set
 the `aria-controls` prop to the `id` of the element it is controling. This will help
 non-sighted users know what component is being updated/controlled.
 
 
-#### ARIA labels:
+### ARIA labels
 `<b-pagination>` provides various `*-label-*` props which are used to set the `aria-label`
 attributes on the various elements within the component, which will help users of
 assistive technology.
@@ -136,20 +137,22 @@ assistive technology.
 | `label-page` | "Goto page", appended with the page number
 | `aria-label` | "Pagination", applied to the outer pagination container
 
-#### Keyboard navigation support:
+### Keyboard navigation support
 `<b-pagination>` supports keyboard navigation out of the box.
 - Tabbing into the pagination component will autofocus the current page button
 - <kbd>LEFT</kbd> and <kbd>RIGHT</kbd> arrow keys will focus the previous and next buttons in the page
 list, respectively, and <kbd>ENTER</kbd> or <kbd>SPACE</kbd> keys will select (click) the focused page button
 
 
-### Events
+## Events
 `<b-pagination>` provides two events that are emitted on the component:
 - `input` is emitted anytime the current page changes (either programmatically or via user interaction)
 - `change` is emitted only when the current page changes based on user interaction
 
 Both events provide the single argument of the current page number (starting from 1)
 
-### See Also
+## See Also
 For navigation based pagination, please see the [`<b-pagination-nav>`](./pagination-nav)
 component.
+
+## Component Reference

--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -305,3 +305,5 @@ have done in the above example.
 You may also want to implement focus containment in the popover content while the
 user is interactiving with it (keeping focus inside the popover until it is closed
 by the user).
+
+## Component Reference

--- a/docs/components/progress/README.md
+++ b/docs/components/progress/README.md
@@ -331,3 +331,6 @@ but you can override any of the props by setting them on the `<b-progress-bar>`
 Notes:
 - `height`, if speified, should always set on the `<b-progress>` component.
 - `<b-progress-bar>` will not inherit `value` from `<b-progress>`.
+
+
+## Component Reference

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -3,20 +3,6 @@
 > For displaying tabular data. `<b-table>` supports pagination, filtering, sorting,
 custom rendering, events, and asynchronous data.
 
-#### **Contents** 
-- [**Items (record data)**](#items-record-data-)
-- [**Fields (column definitions)**](#fields-column-definitions-)
-- [**Table style options**](#table-style-options)
-- [**Custom Data Rendering**](#custom-data-rendering)
-- [**Header/Footer custom rendering via scoped slots**](#header-footer-custom-rendering-via-scoped-slots)
-- [**Sorting**](#sorting)
-- [**Filtering**](#filtering)
-- [**Pagination**](#pagination)
-- [**v-model binding**](#-v-model-binding)
-- [**Using Items Provider Functions**](#using-items-provider-functions)
-- [**Server Side Rendering**](#server-side-rendering)
-- [**Complete Example**](#complete-example)
-
 **Example: Basic usage**
 ```html
 <template>
@@ -1025,3 +1011,4 @@ export default {
 <!-- table-complete-1.vue -->
 ```
 
+## Component Reference

--- a/docs/components/tabs/README.md
+++ b/docs/components/tabs/README.md
@@ -3,7 +3,7 @@
 > Tabs is an extension of navs, to create tabbable panes of local content, even via dropdown menus.
 
 
-### Basic usage
+## Basic usage
 
 ```html
 <b-tabs pills>
@@ -21,7 +21,7 @@
 <!-- basic.vue -->
 ```
 
-### Cards Integration
+## Cards Integration
 
 Tabs support integrating with bootstrap cards. Just add the `card` property. Note
 that you should add `no-body` prop on `<b-card>` element in order to decorate header
@@ -42,15 +42,15 @@ and remove the extra padding.
 <!-- with-card.vue -->
 ```
 
-### Pills variant
+## Pills variant
 
 Just add `pills` property to tabs component.
 
-### Fade
+## Fade animation
 
 Fade is enabled by default when changing tabs. It can disabled with `no-fade` property.
 
-### Add Tabs without content
+## Add Tabs without content
 
 If you want to add extra tabs that do not have any content, you can put them in `tabs` slot:
 
@@ -63,9 +63,9 @@ If you want to add extra tabs that do not have any content, you can put them in 
 </b-tabs>
 ```
 
-### Advanced Examples
+## Advanced Examples
 
-#### Navigation
+### Navigation
 
 ```html
 <template>
@@ -112,7 +112,7 @@ If you want to add extra tabs that do not have any content, you can put them in 
 <!-- tabs-navigation.vue -->
 ```
 
-#### Dynamic Tabs
+### Dynamic Tabs
 
 ```html
 <template>
@@ -166,3 +166,5 @@ If you want to add extra tabs that do not have any content, you can put them in 
 
 <!-- dynamic-tabs.vue -->
 ```
+
+## Component Reference

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -116,3 +116,4 @@ You can close all open tooltips by emitting the `bv::hide::tooltip` event on $ro
 this.$root.$emit('bv::hide::tooltip');
 ```
 
+## Component Reference

--- a/docs/index.js
+++ b/docs/index.js
@@ -57,7 +57,7 @@ export default {
         },
         {
             title: 'Misc',
-            slug: '',
+            slug: 'misc/',
             pages: [
                 {title: 'Release Notes', slug: 'changelog'},
                 {title: 'Contributing', slug: 'contributing'},

--- a/docs/layout/README.md
+++ b/docs/layout/README.md
@@ -345,3 +345,5 @@ Use flexbox alignment utilities to vertically and horizontally align columns.
 
 <!-- b-col-10.vue -->
 ```
+
+## Component Reference

--- a/docs/nuxt/components/toc.vue
+++ b/docs/nuxt/components/toc.vue
@@ -4,18 +4,18 @@
            v-b-scrollspy.70
            class="m-toc section-nav text-small">
       <template v-for="h2 in toc">
-        <b-nav v-if="isArray(h2)" class="mb-1">
+        <b-nav v-if="isArray(h2)" vertical class="mb-1">
             <b-nav-item vertical pills v-for="h3 in h2"
                         :key="h3.href"
                         :href="h3.href"
                         class="toc-entry toc-h3"
-            ><span v-html="h3.label"></span></b-nav-item>
+            >{{ h3.label }}</b-nav-item>
         </b-nav>
         <b-nav-item v-else 
                     :key="h2.href"
                     :href="h2.href"
                     class="toc-entry toc-h2"
-        ><span v-html="h2.label"></span></b-nav-item>
+        >{{ h2.label }}</b-nav-item>
       </template>
     </b-nav>
 </template>
@@ -58,13 +58,15 @@ export default {
             }
             const toc = [];
             // Grab all the H2 and H3 tags with ID's from readme
-            const headings = readme.match(/<h[23].*? id="[^"]+"[^<]+<\/h\d>/g) || [];
+            const headings = readme.match(/<h[23].*? id="[^"]+".+?<\/h\d>/g) || [];
             let h2Idx = 0;
             headings.forEach(heading => {
-                const matches = heading.match(/<(h[23]).*? id="([^"]+)".*?>([^<]+)<\/h\d>/);
+                // Pase teh link, label and heading level
+                const matches = heading.match(/^<(h[23]).*? id="([^"]+)"[^>]*>(.+?)<\/h\d>/$);
                 const tag = matches[1];
                 const href = `#${matches[2]}`;
-                const label = matches[3];
+                // Remove any HTML markup in the label
+                const label = matches[3].replace(/<[^>]+>/g, '');
                 if (tag === 'h2') {
                     toc.push({ href, label });
                     h2Idx = toc.length;

--- a/docs/nuxt/components/toc.vue
+++ b/docs/nuxt/components/toc.vue
@@ -9,13 +9,13 @@
                         :key="h3.href"
                         :href="h3.href"
                         class="toc-entry toc-h3"
-            >{{ h3.label }}</b-nav-item>
+            ><span v-html="h3.label"></span></b-nav-item>
         </b-nav>
         <b-nav-item v-else 
                     :key="h2.href"
                     :href="h2.href"
                     class="toc-entry toc-h2"
-        >{{ h2.label }}</b-nav-item>
+        ><span v-html="h2.label"></span></b-nav-item>
       </template>
     </b-nav>
 </template>

--- a/docs/nuxt/components/toc.vue
+++ b/docs/nuxt/components/toc.vue
@@ -1,32 +1,33 @@
 <template>
-    <b-nav v-if="toc && toc.length"
-           vertical
-           v-b-scrollspy.70
-           class="m-toc section-nav text-small">
-      <template v-for="h2 in toc">
-        <b-nav v-if="isArray(h2)" vertical class="mb-1">
-            <b-nav-item vertical pills v-for="h3 in h2"
-                        :key="h3.href"
-                        :href="h3.href"
-                        class="toc-entry toc-h3"
-            ><span v-html="h3.label"></span></b-nav-item>
+    <nav v-if="toc && toc.length > 0" aria-label="Page table of contents">
+        <b-nav vertical
+               v-b-scrollspy.75
+               class="m-toc section-nav">
+          <template v-for="h2 in toc">
+            <b-nav v-if="isArray(h2) && h2.length > 0" vertical class="mb-1">
+                <b-nav-item vertical pills v-for="h3 in h2"
+                            :key="h3.href"
+                            :href="h3.href"
+                            class="toc-entry toc-h3 mb-1"
+                ><span v-html="h3.label"></span></b-nav-item>
+            </b-nav>
+            <b-nav-item v-else 
+                        :key="h2.href"
+                        :href="h2.href"
+                        class="toc-entry toc-h2 mb-1"
+            ><span v-html="h2.label"></span></b-nav-item>
+          </template>
         </b-nav>
-        <b-nav-item v-else 
-                    :key="h2.href"
-                    :href="h2.href"
-                    class="toc-entry toc-h2"
-        ><span v-html="h2.label"></span></b-nav-item>
-      </template>
-    </b-nav>
+    </nav>
 </template>
 
 <style scoped>
-.m-toc.section-nav .nav-item {
+.m-toc.section-nav .nav-link {
      line-height: 1.2;
 }
 
 .m-toc.section-nav .toc-entry a {
-    padding-left: 24px;
+    padding-left: 12px;
     padding-left: 0.75rem;
 }
 

--- a/docs/nuxt/components/toc.vue
+++ b/docs/nuxt/components/toc.vue
@@ -62,7 +62,7 @@ export default {
             let h2Idx = 0;
             headings.forEach(heading => {
                 // Pase teh link, label and heading level
-                const matches = heading.match(/^<(h[23]).*? id="([^"]+)"[^>]*>(.+?)<\/h\d>/$);
+                const matches = heading.match(/^<(h[23]).*? id="([^"]+)"[^>]*>(.+?)<\/h\d>$/);
                 const tag = matches[1];
                 const href = `#${matches[2]}`;
                 // Remove any HTML markup in the label

--- a/docs/nuxt/layouts/docs.vue
+++ b/docs/nuxt/layouts/docs.vue
@@ -10,6 +10,7 @@
                 </div>
                 
                 <div class="d-none d-xl-block col-xl-2 bd-toc">
+                    <m-toc />
                 </div>
 
                 <div class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5 bd-content">
@@ -31,9 +32,10 @@ import mSidebar from '~/components/sidebar.vue';
 import mNav from '~/components/nav.vue';
 import mFooter from '~/components/footer.vue';
 import mSearch from '~/components/search.vue';
+import mToc from '~/components/toc.vue';
 
 export default {
-    components: { mSidebar, mNav, mFooter, mSearch },
+    components: { mSidebar, mNav, mFooter, mSearch, mToc },
     computed: {
         editPageURL() {
             const base = 'https://github.com/bootstrap-vue/bootstrap-vue/tree/dev';

--- a/docs/nuxt/pages/docs/changelog.vue
+++ b/docs/nuxt/pages/docs/changelog.vue
@@ -13,6 +13,9 @@
             readme() {
                 return readme;
             }
+        },
+        created() {
+            this.$root.$emit('bv-docs::update::toc', this.readme || '');
         }
     };
 </script>

--- a/docs/nuxt/pages/docs/components/_component.vue
+++ b/docs/nuxt/pages/docs/components/_component.vue
@@ -48,6 +48,10 @@ export default {
 
     created() {
         this.$root.$emit('bv-docs::update::toc', this.readme || '');
+    },
+
+    beforeDestroy() {
+        this.$root.$emit('bv-docs::update::toc', '');
     }
 };
 </script>

--- a/docs/nuxt/pages/docs/contributing.vue
+++ b/docs/nuxt/pages/docs/contributing.vue
@@ -13,6 +13,9 @@
             readme() {
                 return readme;
             }
+        },
+        created() {
+            this.$root.$emit('bv-docs::update::toc', this.readme || '');
         }
     };
 </script>

--- a/docs/nuxt/pages/docs/directives/_directive.vue
+++ b/docs/nuxt/pages/docs/directives/_directive.vue
@@ -29,6 +29,10 @@ export default {
 
     created() {
         this.$root.$emit('bv-docs::update::toc', this.readme || '');
+    },
+
+    beforeDestroy() {
+        this.$root.$emit('bv-docs::update::toc', '');
     }
 };
 </script>

--- a/docs/nuxt/pages/docs/index.vue
+++ b/docs/nuxt/pages/docs/index.vue
@@ -11,6 +11,10 @@
             readme() {
                 return readme;
             }
+        },
+
+        created() {
+            this.$root.$emit('bv-docs::update::toc', this.readme || '');
         }
     };
 </script>

--- a/docs/nuxt/pages/docs/index.vue
+++ b/docs/nuxt/pages/docs/index.vue
@@ -15,6 +15,10 @@
 
         created() {
             this.$root.$emit('bv-docs::update::toc', this.readme || '');
+        },
+
+        beforeDestroy() {
+            this.$root.$emit('bv-docs::update::toc', '');
         }
     };
 </script>

--- a/docs/nuxt/pages/docs/misc/changelog.vue
+++ b/docs/nuxt/pages/docs/misc/changelog.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script>
-    import layout from '../../layouts/docs.vue';
-    import readme from '../../../../CHANGELOG.md';
+    import layout from '../../../layouts/docs.vue';
+    import readme from '../../../../../CHANGELOG.md';
 
     export default {
         components: {layout},

--- a/docs/nuxt/pages/docs/misc/changelog.vue
+++ b/docs/nuxt/pages/docs/misc/changelog.vue
@@ -16,7 +16,7 @@
         },
         created() {
             // We remove the h3 tags because the all have the same generated ID
-            this.$root.$emit('bv-docs::update::toc', this.readme.replace(/<h3.*?</h3>/g, '') || '');
+            this.$root.$emit('bv-docs::update::toc', this.readme.replace(/<h3.*?<\/h3>/g, '') || '');
         }
     };
 </script>

--- a/docs/nuxt/pages/docs/misc/changelog.vue
+++ b/docs/nuxt/pages/docs/misc/changelog.vue
@@ -17,6 +17,10 @@
         created() {
             // We remove the h3 tags because the all have the same generated ID
             this.$root.$emit('bv-docs::update::toc', this.readme.replace(/<h3.*?<\/h3>/g, '') || '');
+        },
+
+        beforeDestroy() {
+            this.$root.$emit('bv-docs::update::toc', '');
         }
     };
 </script>

--- a/docs/nuxt/pages/docs/misc/changelog.vue
+++ b/docs/nuxt/pages/docs/misc/changelog.vue
@@ -15,7 +15,8 @@
             }
         },
         created() {
-            this.$root.$emit('bv-docs::update::toc', this.readme || '');
+            // We remove the h3 tags because the all have the same generated ID
+            this.$root.$emit('bv-docs::update::toc', this.readme.replace(/<h3.*?</h3>/g, '') || '');
         }
     };
 </script>

--- a/docs/nuxt/pages/docs/misc/contributing.vue
+++ b/docs/nuxt/pages/docs/misc/contributing.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script>
-    import layout from '../../layouts/docs.vue';
-    import readme from '../../../../CONTRIBUTING.md';
+    import layout from '../../../layouts/docs.vue';
+    import readme from '../../../../../CONTRIBUTING.md';
 
     export default {
         components: {layout},

--- a/docs/nuxt/pages/docs/misc/contributing.vue
+++ b/docs/nuxt/pages/docs/misc/contributing.vue
@@ -16,6 +16,9 @@
         },
         created() {
             this.$root.$emit('bv-docs::update::toc', this.readme || '');
+        },
+        beforeDestroy() {
+            this.$root.$emit('bv-docs::update::toc', '');
         }
     };
 </script>

--- a/docs/nuxt/pages/docs/misc/index.vue
+++ b/docs/nuxt/pages/docs/misc/index.vue
@@ -1,3 +1,5 @@
+<template></template>
+
 <script>
     export default {
         fetch({ redirect }) {

--- a/docs/nuxt/pages/docs/misc/index.vue
+++ b/docs/nuxt/pages/docs/misc/index.vue
@@ -1,0 +1,7 @@
+<script>
+    export default {
+        fetch({ redirect }) {
+            redirect('/docs/misc/changelog')
+        }
+    };
+</script>

--- a/docs/nuxt/pages/docs/reference/_reference.vue
+++ b/docs/nuxt/pages/docs/reference/_reference.vue
@@ -29,6 +29,10 @@ export default {
 
     created() {
         this.$root.$emit('bv-docs::update::toc', this.readme || '');
+    },
+
+    beforeDestroy() {
+        this.$root.$emit('bv-docs::update::toc', '');
     }
 };
 </script>

--- a/docs/nuxt/pages/docs/reference/_reference.vue
+++ b/docs/nuxt/pages/docs/reference/_reference.vue
@@ -25,6 +25,10 @@ export default {
         return {
             title: `${this.meta.title} - BootstrapVue`
         };
+    },
+
+    created() {
+        this.$root.$emit('bv-docs::update::toc', this.readme || '');
     }
 };
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -55,6 +55,7 @@ module.exports = {
                 .concat(scan('components'))
                 .concat(scan('directives'))
                 .concat(scan('reference'))
+                .concat(scan('misc'))
         }
     },
 


### PR DESCRIPTION
Adds a new `<m-toc>` docs component for building the list of `h2` and `h3` links, and placing them on teh right hand side of screen.

When a doc page component loads, it sends an event to the `m-toc` componet with the document content for parsing.

Moved `Misc` items in to their own `misc` directory (clicking on 'Misc' link was not showing the first page the Misc section.

Updated all component docs to have correct heading levels