### PR TITLE
feat(tooltip popover): Don't close if focus moves between trigger element and tip/popover

### DIFF
--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -521,6 +521,8 @@ class ToolTip {
             // Try and compile user supplied template, or fallback to default template
             this.$tip = this.compileTemplate(this.$config.template) || this.compileTemplate(this.constructor.Default.template);
         }
+        // Add tab index so tip can be focused, and to allow it to be set as relatedTargt in focusin/out events
+        this.$tip.tabIndex = -1;
         return this.$tip;
     }
 

--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -328,6 +328,12 @@ class ToolTip {
         this.setRootListener(on);
         // Ontouch start listeners
         this.setOnTouchStartListener(on);
+        if (on && /(focus|blur)/.test(this.$config.trigger)) {
+            // If focus moves between trigger element and tip container, dont close
+            eventOn(this.$tip, 'focusout', this);
+        } else {
+            eventOff(this.$tip, 'focusout', this);
+        }
     }
 
     // force hide of tip (internal method)
@@ -623,11 +629,29 @@ class ToolTip {
             return;
         }
         const type = e.type;
+        const target = e.target;
+        const relatedTarget = e.relatedTarget;
+        const $element = this.$element;
+        const $tip = this.$tip;
         if (type === 'click') {
             this.toggle(e);
         } else if (type === 'focusin' || type === 'mouseenter') {
             this.enter(e);
-        } else if (type === 'focusout' || type === 'mouseleave') {
+        } else if (type === 'focusout') {
+            // target is the element which is loosing focus
+            // And relatdTarget is the element gaining focus
+            if (target === $element && $tip && $tip.contains(relatedTarget)) {
+                // If focus moves from $element to $tip, don't trigger a leave
+                return;
+            }
+            if ($tip && target === $tip && $element.contains(relatedTarget)) {
+                // If focus moves from $tip to $element, don't trigger a leave
+                // This will only happen during the whileOpen listeners
+                return;
+            }
+            // OPtherwise trigger a leave
+            this.leave(e);
+        } else if (type === 'mouseleave') {
             this.leave(e);
         }
     }


### PR DESCRIPTION
Only applies when the trigger is set to `focus` and/or `blur`

Handy when using interactive popover content