### PR TITLE
fix(tooltip): Emit correct $root event name

### DIFF
--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -4,7 +4,7 @@ import { from as arrayFrom } from '../utils/array';
 import { closest, select, isVisible, isDisabled, getCS, addClass, removeClass, hasClass, setAttr, removeAttr, getAttr, eventOn, eventOff } from '../utils/dom';
 import BvEvent from './BvEvent';
 
-const NAME = 'tooltp';
+const NAME = 'tooltip';
 const CLASS_PREFIX = 'bs-tooltip';
 const BSCLS_PREFIX_REGEX = new RegExp(`\\b${CLASS_PREFIX}\\S+`, 'g');
 


### PR DESCRIPTION
I was wondering why `this.$root.$emit('bv::hide::tooltip')` wasn't working and found this typo.