### PR TITLE
Update ToolTip content when config.title changes in updateConfig

### DIFF
--- a/lib/classes/tooltip.js
+++ b/lib/classes/tooltip.js
@@ -166,6 +166,21 @@ class ToolTip {
         // Stop/Restart listening
         this.unListen();
         this.listen();
+
+        if (typeof updatedConfig.title === 'undefined') {
+            // We've recieved a new config without a title, hide the tooltip
+            this.hide();
+        } else if (prevConfig.title !== updatedConfig.title) {
+            // We've recieved a new title that differs from the previous one,
+            // set the new element content and update positioning
+            this.setElementContent(select(Selector.TOOLTIP_INNER, this.$tip), this.getTitle());
+            this.update();
+
+            if (typeof prevConfig.title === 'undefined') {
+                // There was no previous title set, we also need to show the tooltip
+                this.show();
+            }
+        }
     }
 
     // Destroy this instance


### PR DESCRIPTION
I had to support a use case where the tooltip content needs to update when the `config.title` binding changes (and the tooltip is already instantiated). This seems to do the trick.