### PR TITLE
feat(docs): Better ARIA when changing routes

### DIFF
--- a/docs/nuxt/components/search.vue
+++ b/docs/nuxt/components/search.vue
@@ -12,7 +12,7 @@
       <div v-for="(toc, section, idx) in toc" :key="section" :class="idx > 0 ? 'mt-2' : ''">
         <h6 v-html="section" class="bd-text-purple my-1"></h6>
         <div v-for="t in toc" :key="t.href" class="my-1">
-          <b-link :to"t.href" v-html="t.title"></b-link>
+          <b-link :to="t.href" v-html="t.title"></b-link>
         </div>
       </div>
     </b-popover>

--- a/docs/nuxt/components/search.vue
+++ b/docs/nuxt/components/search.vue
@@ -12,7 +12,7 @@
       <div v-for="(toc, section, idx) in toc" :key="section" :class="idx > 0 ? 'mt-2' : ''">
         <h6 v-html="section" class="bd-text-purple my-1"></h6>
         <div v-for="t in toc" :key="t.href" class="my-1">
-          <a :href="t.href" v-html="t.title"></a>
+          <b-link :to"t.href" v-html="t.title"></b-link>
         </div>
       </div>
     </b-popover>

--- a/docs/nuxt/components/sidebar.vue
+++ b/docs/nuxt/components/sidebar.vue
@@ -16,9 +16,10 @@
                             :key="page.title
                 ">
                     {{ page.title }}
-                    <small class="badge badge-success" v-if="page.new">NEW</small>
-                    <small class="badge badge-warning" v-if="page.experimental">BETA</small>
-                    <small class="badge badge-danger" v-if="page.breaking">CHANGE</small>
+                    <b-badge tag="small" variant="success" v-if="page.new">NEW</b-badge>
+                    <b-badge tag="small" variant="warning" v-if="page.experimental">BETA</b-badge>
+                    <b-badge tag="small" variant="danger" v-if="page.breaking">CHANGE</b-badge>
+                    <b-badge tag="small" variant="info" v-if="page.features">ENHANCED</b-badge>
                 </b-nav-item>
             </b-nav>
     

--- a/docs/nuxt/pages/docs/components/_component.vue
+++ b/docs/nuxt/pages/docs/components/_component.vue
@@ -25,9 +25,11 @@
 <script>
 import componentdoc from '~/components/componentdoc.vue';
 import docs from '~/../components';
+import docsMixin from '../docs-mixin';
 
 export default {
     components: { componentdoc },
+    mixins: [ docsMixin ],
     layout: 'docs',
 
     fetch({ params, redirect }) {

--- a/docs/nuxt/pages/docs/directives/_directive.vue
+++ b/docs/nuxt/pages/docs/directives/_directive.vue
@@ -7,8 +7,10 @@
 
 <script>
 import directives from '../../../../directives';
+import docsMixin from '../docs-mixin';
 
 export default {
+    mixins: [ docsMixin ],
     layout: 'docs',
 
     fetch({ params, redirect }) {

--- a/docs/nuxt/pages/docs/docs-mixin.js
+++ b/docs/nuxt/pages/docs/docs-mixin.js
@@ -40,10 +40,19 @@ function offsetTop(el) {
 
 
 export default {
+    data() {
+        return {
+            scrollTimout: null
+        };
+    },
     mounted() {
+        clearTimeout(this.scrollTimeout);
+        this.scrollTimeout = null;
         this.focusScroll();
     },
     updated() {
+        clearTimeout(this.scrollTimeout);
+        this.scrollTimeout = null;
         this.focusScroll();
     },
     methods: {
@@ -70,8 +79,12 @@ export default {
             if (el) {
                 // Get the document scrolling element
                 const scroller = document.scrollingElement || document.documentElement || document.body;
-                // scroll heading into view (minus offset to account for nav top height
-                scrollTo(scroller, offsetTop(el) - 70, 100);
+                // Allow time for v-play to finish rendering
+                this.scrollTimeout = setTimeout(() => {
+                    // scroll heading into view (minus offset to account for nav top height
+                    scrollTo(scroller, offsetTop(el) - 70, 100);
+                    this.scrollTimeout = null;
+                }, 100);
             }
         }
     }

--- a/docs/nuxt/pages/docs/docs-mixin.js
+++ b/docs/nuxt/pages/docs/docs-mixin.js
@@ -1,0 +1,78 @@
+/*
+ * docs-mixin: used by any page under /docs path
+ */
+
+// Smooth Scroll handler methods
+function easeInOutQuad(t, b, c, d) {
+    t /= d/2;
+    if (t < 1) return c/2*t*t + b;
+    t--;
+    return -c/2 * (t*(t-2) - 1) + b;
+}
+function scrollTo(scroller, to, duration, cb) {
+    const start = scroller.scrollTop
+    const change = to - start
+    const increment = 20;
+    let currentTime = 0;
+    const animateScroll = function(){
+        currentTime += increment;
+        const val = easeInOutQuad(currentTime, start, change, duration);
+        scroller.scrollTop = Math.round(val);
+        if(currentTime < duration) {
+            setTimeout(animateScroll, increment);
+        } else if (cb && typeof cb ==='function') {
+            cb();
+        }
+    };
+    animateScroll();
+}
+
+// Return an element's offset wrt document element
+// https://j11y.io/jquery/#v=git&fn=jQuery.fn.offset
+function offsetTop(el) {
+    if (!el.getClientRects().length) {
+        return 0;
+    }
+    const bcr = el.getBoundingClientRect();
+    const win = el.ownerDocument.defaultView;
+    return bcr.top + win.pageYOffset;
+};
+
+
+export default {
+    mounted() {
+        this.focusScroll();
+    },
+    updated() {
+        this.focusScroll();
+    },
+    methods: {
+        focusScroll() {
+            let hash = this.$route.hash;
+            this.$nextTick(() => {
+                let el;
+                if (hash) {
+                    // We use an attribute querySelector rather than getElementByID, as some auto 
+                    // generated ID's are invalid, and some may appear more than once
+                    el = this.$el.querySelector(`[id="${hash.replace('#','')}"]`);
+                    this.scrollIntoView(el);
+                }
+                if (!el) {
+                    el = this.$el.querySelector('h1');
+                }
+                if (el) {
+                   el.tabIndex = -1;
+                   el.focus();
+                }
+            });
+        },
+        scrollIntoView(el) {
+            if (el) {
+                // Get the document scrolling element
+                const scroller = document.scrollingElement || document.documentElement || document.body;
+                // scroll heading into view (minus offset to account for nav top height
+                scrollTo(scroller, offsetTop(el) - 70, 100);
+            }
+        }
+    }
+}

--- a/docs/nuxt/pages/docs/index.vue
+++ b/docs/nuxt/pages/docs/index.vue
@@ -4,8 +4,10 @@
 
 <script>
     import readme from '~/../README.md';
+    import docsMixin from './docs-mixin';
 
     export default {
+        mixins: [ docsMixin ],
         layout: 'docs',
         computed: {
             readme() {

--- a/docs/nuxt/pages/docs/layout/index.vue
+++ b/docs/nuxt/pages/docs/layout/index.vue
@@ -25,9 +25,11 @@
 <script>
 import componentdoc from '~/components/componentdoc.vue';
 import docs from '~/../layout';
+import docsMixin from '../docs-mixin';
 
 export default {
     components: { componentdoc },
+    mixins: [ docsMixin ],
     layout: 'docs',
 
     data() {

--- a/docs/nuxt/pages/docs/misc/_misc.vue
+++ b/docs/nuxt/pages/docs/misc/_misc.vue
@@ -6,7 +6,7 @@
 
 <script>
 import docs from '~/../misc';
-import docsMixin from '../docsMixin';
+import docsMixin from '../docs-mixin';
 
 export default {
     mixins: [ docsMixin ],

--- a/docs/nuxt/pages/docs/misc/_misc.vue
+++ b/docs/nuxt/pages/docs/misc/_misc.vue
@@ -6,8 +6,10 @@
 
 <script>
 import docs from '~/../misc';
+import docsMixin from '../docsMixin';
 
 export default {
+    mixins: [ docsMixin ],
     layout: 'docs',
 
     fetch({ params, redirect }) {

--- a/docs/nuxt/pages/docs/reference/_reference.vue
+++ b/docs/nuxt/pages/docs/reference/_reference.vue
@@ -7,8 +7,10 @@
 
 <script>
 import reference from '../../../../reference';
+import docsMixin from '../docs-mixin';
 
 export default {
+    mixins: [ docsMixin ],
     layout: 'docs',
 
     fetch({ params, redirect }) {


### PR DESCRIPTION
Auto focuses the first header when a route changes and no hash specified

Auto Scrolls to header specified by hash if found, accounting for navbar offset.