### PR TITLE
fix(button): Don't ovrwrite user supplied tabindex if not disabled

### DIFF
--- a/lib/components/button.js
+++ b/lib/components/button.js
@@ -99,7 +99,7 @@ export default {
                 // Tab index is used when the component becomes a link.
                 // Links are tabable, but don't allow disabled,
                 // so we mimic that functionality by disabling tabbing.
-                tabindex: props.disabled && isLink ? "-1" : null
+                tabindex: props.disabled && isLink ? "-1" : (data.$attrs['tabindex'] || null)
             },
             on
         };

--- a/lib/components/button.js
+++ b/lib/components/button.js
@@ -99,7 +99,7 @@ export default {
                 // Tab index is used when the component becomes a link.
                 // Links are tabable, but don't allow disabled,
                 // so we mimic that functionality by disabling tabbing.
-                tabindex: props.disabled && isLink ? "-1" : (data.attrs['tabindex'] || null)
+                tabindex: props.disabled && isLink ? "-1" : (data.attrs ? data.attrs['tabindex'] : null)
             },
             on
         };

--- a/lib/components/button.js
+++ b/lib/components/button.js
@@ -99,7 +99,7 @@ export default {
                 // Tab index is used when the component becomes a link.
                 // Links are tabable, but don't allow disabled,
                 // so we mimic that functionality by disabling tabbing.
-                tabindex: props.disabled && isLink ? "-1" : (data.$attrs['tabindex'] || null)
+                tabindex: props.disabled && isLink ? "-1" : (data.attrs['tabindex'] || null)
             },
             on
         };


### PR DESCRIPTION
A user supplied `tabindex` attribut on `b-button` was being overwritten as `null`

This fix preserves the users original tabindex when not disabled

Addresses issue #1119