### PR TITLE
Bug: In toggleClasses we expect strings instead of undefined variables.

### DIFF
--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -54,7 +54,7 @@
                 return [
                     'nav-link',
                     this.noCaret ? '' : 'dropdown-toggle',
-                    this.disabled ? disabled : ''
+                    this.disabled ? 'disabled' : ''
                 ];
             },
             menuClasses() {


### PR DESCRIPTION
I couldn't use disabled on b-nav-item-dropdown, because it breaks in toggleClasses computed property. This should fix it. I tested locally using the Playground and it works.

Thanks for this great project!

Amir