### PR TITLE
feat(tooltip+popover): Allow delay to be object in component versions

### DIFF
--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -229,7 +229,7 @@ export default {
 | `placement` | `'top'` | Positioning of the popover, relative to the trigger element. | `top`, `bottom`, `left`, `right`, `auto`, `topleft`, `topright`, `bottomleft`, `bottomright`, `lefttop`, `leftbottom`, `righttop`, `rightbottom`
 | `triggers` | `'click'` |  Space separated list of which event(s) will trigger open/close of popover | `hover`, `focus`, `click`. Note `blur` is a special use case to close popover on next click.
 | `no-fade` | `false` | Disable fade animation when set to `true` | `true` or `false`
-| `delay` | `0` | Number of milliseconds to delay showing and hidding of popover | `0` and up, integers only.
+| `delay` | `0` | Number of milliseconds to delay showing and hidding of popover. Can also be specified as an object in the form of `{ show: 123, hide: 456 }` allowing different show and hide delays | `0` and up, integers only.
 | `offset` | `0` | Number of pixels to shift the center of the popover. Also affects the position of the popover arrow. | Any negative or positive integer
 | `container` | `null` | String ID of element to append rendered popover into. If `null` or element not found, popover is appended to `<body>` (default) | Any valid in-document unique  element ID.
 

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -154,7 +154,7 @@ The default position is `top`. Positioning is relative to the trigger element.
 | `placement` | `top` | Positioning of the tooltip, relative to the trigger element. | `top`, `bottom`, `left`, `right`, `auto`, `topleft`, `topright`, `bottomleft`, `bottomright`, `lefttop`, `leftbottom`, `righttop`, `rightbottom`
 | `triggers` | `hover focus` |  Space separated list of which event(s) will trigger open/close of tooltip | `hover`, `focus`, `click`. Note `blur` is a special use case to close tooltip on next click, usually used in conjunction with `click`.
 | `no-fade` | `false` | Disable fade animation when set to `true` | `true` or `false`
-| `delay` | `0` | Number of milliseconds to delay showing and hidding of tooltip | `0` and up, integers only.
+| `delay` | `0` | Number of milliseconds to delay showing and hidding of popover. Can also be specified as an object in the form of `{ show: 123, hide: 456 }` allowing different show and hide delays | `0` and up, integers only.
 | `offset` | `0` | Number of pixels to shift the center of the tooltip | Any negative or positive integer
 | `container` | `null` | String ID of element to append rendered tooltip into. If `null` or element not found, tooltip is appended to `<body>` (default) | Any valid in-document unique  element ID.
 

--- a/lib/mixins/toolpop.js
+++ b/lib/mixins/toolpop.js
@@ -38,7 +38,7 @@ export default {
             type: [String, Object]
         },
         delay: {
-            type: Number,
+            type: [Number, Object, String],
             default: 0
         },
         offset: {
@@ -105,6 +105,7 @@ export default {
     computed: {
         baseConfig() {
             const cont = this.container;
+            let delay = (typeof this.delay === 'object') ? this.delay : (parseInt(this.delay, 10) || 0);
             return {
                 // Title prop
                 title: (this.title || '').trim() || '',
@@ -115,7 +116,7 @@ export default {
                 // Container curently needs to be an ID with '#' prepended, if null then body is used
                 container: cont ? (/^#/.test(cont) ? cont : `#${cont}`) : false,
                 // Show/Hide delay
-                delay: parseInt(this.delay, 10) || 0,
+                delay: delay || 0,
                 // Offset can be css distance. if no units, pixels are assumed
                 offset: this.offset || 0,
                 // Disable fade Animation?


### PR DESCRIPTION
The `delay` prop now optionally accepts an object in the form `{ show: 123, hide: 123}` to specify the show and hide delays individually.

Addresses issue #1130 
