### PR TITLE
fix(docs): Correct "the" misspellings

### DIFF
--- a/docs/components/form-input/README.md
+++ b/docs/components/form-input/README.md
@@ -26,7 +26,7 @@
 
 ## Input type
 
-`<b-form-input>` defaults to a `text` input, but you can set teh `type` prop to one
+`<b-form-input>` defaults to a `text` input, but you can set the `type` prop to one
 of the supported types: `text`, `password`, `email`, `number`, `url`, `tel`, `search`,
 `date`, `datetime`, `datetime-local`, `month`, `week`, `time`,`range`, or `color`.
 

--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -23,7 +23,7 @@ Things to know when using popover component:
  - Popovers must be hidden before their corresponding markup elements have been removed from the DOM.
 
 The `<b-popover>` component inserts a hidden (`display: none;`) `<div>` intermediate container
-element at the point in the DOM where the `<b-popover>` component is placed.  This may 
+element at the point in the DOM where the `<b-popover>` component is placed.  This may
 affect layout and/or styling of components such as `<b-button-group>`, `<b-button-toolbar>`,
 and `<b-input-group>`. To avoid these posible layout issues, place the `<b-popover>`
 component **outside** of theese types of components.
@@ -66,7 +66,7 @@ Positioning is relative to the trigger element.
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
   </div>
-   
+
   <div class="popover bs-popover-right bs-popover-right-docs">
     <div class="arrow"></div>
     <h3 class="popover-header">Popover right</h3>
@@ -183,7 +183,7 @@ This `blur` trigger must be used in combination with the `click` trigger.
     <b-row>
       <b-col md="6" class="py-4 text-center">
         <b-btn id="exPopover2" variant="primary">Using properties</b-btn>
-        <b-popover target="exPopover2" 
+        <b-popover target="exPopover2"
             title="Prop Examples"
             triggers="hover focus"
             content="Embedding content using properties is easy">
@@ -200,7 +200,7 @@ This `blur` trigger must be used in combination with the `click` trigger.
       </b-col>
     </b-row>
 
-  </b-container>  
+  </b-container>
 </template>
 
 <script>
@@ -236,7 +236,7 @@ export default {
 
 ## `v-b-popover` Directive usage
 
-Just need quick popovers without too much markup? Use the 
+Just need quick popovers without too much markup? Use the
 [`v-b-popover` directive](/docs/directives/popover):
 
 ```html
@@ -304,7 +304,7 @@ small screens can be harder to deal with on mobile devices (such as smart-phones
       </b-btn>
     </div>
 
-    <!-- output from teh popover interaction -->
+    <!-- output from the popover interaction -->
     <b-card title="Returned values:" v-if="input1Return && input2Return">
       <p class="card-text" style="max-width:20rem;">
         Name: <strong>{{ input1Return }}</strong><br>
@@ -314,7 +314,7 @@ small screens can be harder to deal with on mobile devices (such as smart-phones
 
     <!-- Our popover title and content render container -->
     <!-- We use placement 'auto' so popover fits in the best spot on viewport -->
-    <!-- We specify the same container as teh trigger button, so that popover is close to button in tab sequence -->
+    <!-- We specify the same container as the trigger button, so that popover is close to button in tab sequence -->
     <b-popover target="exPopoverReactive1"
                triggers="click"
                placement="auto"

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -39,7 +39,7 @@ keyed objects. Example format:
 ]
 ```
 `<b-table>` automatically samples the first row to extract field names (they keys in the
-record data). Field names are automatically "humanized" by converting `kebab-case`, `snake_case`, 
+record data). Field names are automatically "humanized" by converting `kebab-case`, `snake_case`,
 and `camelCase` to individual words and capitalizes each word. Example conversions:
 
  - `first_name` becomes `First Name`
@@ -80,7 +80,7 @@ const items = [
     isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson',
     _rowVariant: 'danger'
   },
-  { 
+  {
     isActive: true,  age: 40, first_name: 'Thor', last_name: 'Macdonald',
     _cellVariants: { isActive: 'success', age: 'info', first_name: 'warning' }
   },
@@ -384,7 +384,7 @@ export default {
 
 
 ## Custom Data Rendering
-Custom rendering for each data field in a row is possible using either 
+Custom rendering for each data field in a row is possible using either
 [scoped slots](http://vuejs.org/v2/guide/components.html#Scoped-Slots)
 or formatter callback function.
 
@@ -392,7 +392,7 @@ or formatter callback function.
 Scoped slots give you greater control over how the record data apepars.
 If you want to add an extra field which does not exist in the records,
 just add it to the `fields` array, And then reference the field(s) in the scoped
-slot(s).  
+slot(s).
 
 **Example: Custom data rendering with scoped slots**
 ```html
@@ -471,10 +471,10 @@ event:
 
 ### Formatter callback
 One more option to customize field output is to use formatter callback function.
-To enable this field's property `formatter` is used. Value of this property may be 
+To enable this field's property `formatter` is used. Value of this property may be
 String or function reference. In case of a String value, function must be defined at
 parent component's methods. Providing formatter as `Function`, it must be declared at
-global scope (window or as global mixin at Vue). 
+global scope (window or as global mixin at Vue).
 
 Callback function accepts three arguments - `value`, `key`, and `item`, and should
 return the formatted value as a string (basic HTML is supported)
@@ -494,7 +494,7 @@ return the formatted value as a string (basic HTML is supported)
 <script>
 export default {
   data: {
-    fields: [ 
+    fields: [
       {
         // A column that needs custom formatting,
         // calling formatter 'fullName' in this app
@@ -504,7 +504,7 @@ export default {
       },
       // A regular column
       'age',
-      {  
+      {
         // A regular column with custom formatter
         key: 'sex',
         formatter: (value) => { return value.charAt(0).toUpperCase(); }
@@ -524,7 +524,7 @@ export default {
       { name: { first: 'Rubin', last: 'Kincade' }, sex: 'male', age: 73 },
       { name: { first: 'Shirley', last: 'Partridge' }, sex: 'female', age: 62 }
     ]
-  }, 
+  },
   methods: {
       fullName(value){
           return `${value.first} ${value.last}`;
@@ -592,13 +592,13 @@ column in ascending direction (smallest first), while clicking on it again will 
 of sorting.  Clicking on a non-sortable column will clear the sorting.
 
 You can control which column is pre-sorted and the order of sorting (ascending or
-descending). To pre-specify the column to be sorted, set the `sort-by` prop to 
+descending). To pre-specify the column to be sorted, set the `sort-by` prop to
 the field's key.  Set the sort direction by setting `sort-desc` to either `true`
 (for descending) or `false` (for ascending, the default).
 
 The props `sort-by` and `sort-desc` can be turned into _two-way_ (syncable) props by
 adding the `.sync` modifier. Your bound variables will then be updated accordingly
-based on the current sort critera. See the 
+based on the current sort critera. See the
 [Vue docs](http://vuejs.org/v2/guide/components.html#sync-Modifier) for details
 on the `.sync` prop modifier
 
@@ -705,7 +705,7 @@ items passing the filter routine. Treat this argument as read-only.
 
 Setting the prop `filter` to null or an empty string will disable local items filtering.
 
-See teh [Complete Example](#complete-example) below for an example of using the
+See the [Complete Example](#complete-example) below for an example of using the
 `filter` feature.
 
 

--- a/docs/components/tabs/meta.json
+++ b/docs/components/tabs/meta.json
@@ -7,7 +7,7 @@
   "events": [
     {
       "event": "input",
-      "description": "Emits when a tab is shown. USed to update teh v-model",
+      "description": "Emits when a tab is shown. USed to update the v-model",
       "args": [
         {
           "arg": "tab_index"

--- a/docs/reference/variants/README.md
+++ b/docs/reference/variants/README.md
@@ -11,7 +11,7 @@ by their varaint name, rather than by the underlying CSS classname
 * `warning` - <span class="text-warning">Warning</span>
 * `danger` - <span class="text-danger">danger</span>
 * `info` - <span class="text-info">Info</span>
-* `light` - <span class="text-light">Light</span> 
+* `light` - <span class="text-light">Light</span>
 * `dark` - <span class="text-dark">Dark</span>
 
 The base variants will translate to various Bootstrap V4 contextual class
@@ -61,7 +61,7 @@ These translate to class names `badge-<variant>`.
 ### Button variants
 All the **base variants** plus:
 * `outline-<base variant>`
-* `link` which renders teh button with the look of a link but retains button padding and margins.
+* `link` which renders the button with the look of a link but retains button padding and margins.
 
 These translate to class names `btn-<variant>` and `btn-outline-<variant>`.
 
@@ -81,6 +81,6 @@ components) via the standard HTML `class="..."` attribute.
 
 ## Creating custom variants
 When creating custom variants, follow the Bootstrap V4 varian CSS class naming
-scheme and they will become available to the various components that use that 
+scheme and they will become available to the various components that use that
 scheme (i.e. create a custom CSS class `btn-purple` and `purple` becomes a
 vailid variant to use on `<b-button>`).


### PR DESCRIPTION
This commit corrects all misspellings of "the" in the docs.