### PR TITLE
fix(input-group): BS V4.beta CSS no longer has the `has-${state}` classes

### DIFF
--- a/lib/components/input-group.vue
+++ b/lib/components/input-group.vue
@@ -27,8 +27,7 @@
             classObject() {
                 return [
                     'input-group',
-                    this.size ? ('input-group-' + this.size) : '',
-                    this.state ? ('has-' + this.state) : ''
+                    this.size ? ('input-group-' + this.size) : ''
                 ];
             }
         },
@@ -38,10 +37,6 @@
                 defualt: null
             },
             size: {
-                type: String,
-                default: null
-            },
-            state: {
                 type: String,
                 default: null
             },


### PR DESCRIPTION
Remove unnecessary prop `state` from `b-input-group`