### PR TITLE
 feat(table): Add table caption and colgroup support

### DIFF
--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -384,7 +384,7 @@ export default {
 
 ## Table caption
 Add an optional caption to your table via the prop `caption` or the named
-slot `table-caption` (the slot takes precidence over the prop). The default
+slot `table-caption` (the slot takes precedence over the prop). The default
 Bootstrap V4 styling places the caption at the bottom of the table. You can
 override the position via [custom CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side).
 

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -382,6 +382,37 @@ export default {
 <!-- table-footer.vue -->
 ```
 
+## Table caption
+Add an optional caption to your table via the prop `caption` or the named
+slot `table-caption` (the slot takes precidence over the prop). The default
+Bootstrap V4 styling places the caption at the bottom of the table. You can
+override the position via [custom CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side).
+
+```html
+<template>
+  <b-table :items="items" :fields="fields">
+    <template slot="table-caption">
+      This is a table caption.
+    </template>
+  </b-table>
+</template>
+
+<script>
+export default {
+  data: {
+    fields: [ 'first_name', 'last_name', 'age' ],
+    items: [
+      { age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
+      { age: 21, first_name: 'Larsen', last_name: 'Shaw' },
+      { age: 89, first_name: 'Geneva', last_name: 'Wilson' }
+    ]
+  }
+};
+</script>
+
+<!-- table-caption.vue -->
+```
+
 
 ## Custom Data Rendering
 Custom rendering for each data field in a row is possible using either

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -382,7 +382,7 @@ export default {
 <!-- table-footer.vue -->
 ```
 
-## Table caption
+## Table `<caption>`
 Add an optional caption to your table via the prop `caption` or the named
 slot `table-caption` (the slot takes precedence over the prop). The default
 Bootstrap V4 styling places the caption at the bottom of the table. You can
@@ -412,6 +412,12 @@ export default {
 
 <!-- table-caption.vue -->
 ```
+
+## Table `<colgroup>`
+Use the named slot `table-colgroup` to specify `<colgroup>` and `<col>` elements
+for optional grouping and styling of table columns. Note the styles available via `<col>`
+elements are limited. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup)
+for details and usage.
 
 
 ## Custom Data Rendering

--- a/docs/components/table/meta.json
+++ b/docs/components/table/meta.json
@@ -111,6 +111,10 @@
   ],
   "slots": [
     {
+      "name": "table-caption",
+      "description": "Content to display in the table's caption element"
+    },
+    {
       "name": "[field]",
       "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
     },

--- a/docs/components/table/meta.json
+++ b/docs/components/table/meta.json
@@ -115,6 +115,10 @@
       "description": "Content to display in the table's caption element"
     },
     {
+      "name": "table-colgroup",
+      "description": "Slot to place custom colgroup and col elements"
+    },
+    {
       "name": "[field]",
       "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
     },

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -2,8 +2,8 @@
     <table :id="id || null"
            :aria-busy="computedBusy ? 'true' : 'false'"
            :class="tableClasses">
-        <caption v-if="caption || $slots['caption']">
-            <slot name="caption"><div v-html="caption"></div></slot>
+        <caption v-if="caption || $slots['table-caption']">
+            <slot name="table-caption"><div v-html="caption"></div></slot>
         </caption>
         <thead :class="headClasses">
             <tr>

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -2,6 +2,9 @@
     <table :id="id || null"
            :aria-busy="computedBusy ? 'true' : 'false'"
            :class="tableClasses">
+        <caption v-if="caption || $slots['caption']">
+            <slot name="caption"><div v-html="caption"></div></slot>
+        </caption>
         <thead :class="headClasses">
             <tr>
                 <th v-for="field in computedFields"
@@ -183,6 +186,10 @@ export default {
         id: {
             type: String,
             default: ''
+        },
+        caption: {
+            type: String,
+            default: null
         },
         items: {
             type: [Array, Function],

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -5,7 +5,7 @@
         <caption v-if="caption || $slots['table-caption']">
             <slot name="table-caption"><div v-html="caption"></div></slot>
         </caption>
-        <colgroup v-if="$slots['table-colgroup']></colgroup>
+        <colgroup v-if="$slots['table-colgroup']"></colgroup>
         <thead :class="headClasses">
             <tr>
                 <th v-for="field in computedFields"

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -5,6 +5,7 @@
         <caption v-if="caption || $slots['table-caption']">
             <slot name="table-caption"><div v-html="caption"></div></slot>
         </caption>
+        <colgroup v-if="$slots['table-colgroup']></colgroup>
         <thead :class="headClasses">
             <tr>
                 <th v-for="field in computedFields"


### PR DESCRIPTION
New prop `caption` and slot `table-caption` for placing content in the table's `<caption>` element.

If neither the prop nor slot are specified, the caption element is not rendered.  The slot takes precedence over the prop.

New slot `table-colgroup` to allow placement of `<colgroup>` and `<col>` elements for more table styling control