### PR TITLE
 feat(table): Add toggleable row details support 

### DIFF
--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -50,7 +50,7 @@ and `camelCase` to individual words and capitalizes each word. Example conversio
 
 These titles wil be displayed in the table header, in the order they appear in the
 **first** record of data. See the [**Fields**](#fields-column-definitions-) section
-below for cusomizing how field headings appear.
+below for customizing how field headings appear.
 
 **Note:** Field order is not guaranteed. Fields will typically appear in the order they
 were defined in the first row, but this may not always be the case depending on the version
@@ -624,7 +624,7 @@ or a `head-clicked` event.
 ```
 
 ## Row details support
-If you would optionally like to display aditional record information (such as
+If you would optionally like to display additional record information (such as
 columns not specified in the fields definition array), you can use the scoped slot
 `row-details`, in combination with the special item record Boolean property
 `_rowDetails`.

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -54,7 +54,7 @@ below for customizing how field headings appear.
 
 **Note:** Field order is not guaranteed. Fields will typically appear in the order they
 were defined in the first row, but this may not always be the case depending on the version
-of broswer in use. See section [**Fields (column definitions)**](#fields-column-definitions-)
+of browser in use. See section [**Fields (column definitions)**](#fields-column-definitions-)
 below to see how to guarantee the order of fields.
 
 Record data may also have additional special reserved name keys for colorizing

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -53,18 +53,20 @@ These titles wil be displayed in the table header, in the order they appear in t
 below for cusomizing how field headings appear.
 
 **Note:** Field order is not guaranteed. Fields will typically appear in the order they
-were defined in the first row, but this may not always be the case dpending on the version
-of borswer in use. See section [**Fields (column definitions)**](#fields-column-definitions-)
+were defined in the first row, but this may not always be the case depending on the version
+of broswer in use. See section [**Fields (column definitions)**](#fields-column-definitions-)
 below to see how to guarantee the order of fields.
 
 Record data may also have additional special reserved name keys for colorizing
-rows and individual cells (variants). Supported optional item record modifier properties
-(make sure your field keys do not conflict with these names):
+rows and individual cells (variants), and for triggering additional row detail. The supported
+optional item record modifier properties (make sure your field keys do not conflict with
+these names):
 
 | Property | Type | Description
 | ---------| ---- | -----------
 | `_cellVariants` | Object | Bootstrap contextual state applied to individual cells. Keyed by field (Supported values: `active`, `success`, `info`, `warning`, `danger`)
 | `_rowVariant` | String | Bootstrap contextual state applied to the entire row (Supported values: `active`, `success`, `info`, `warning`, `danger`)
+| `_showDetails` | Boolean | Used to trigger the display of the `row-details` scoped slot. See section [Row details support](#row-details-support) below for additional information
 
 **Example: Using variants for table cells**
 ```html
@@ -619,6 +621,64 @@ or a `head-clicked` event.
   <!-- We use click.stop here to prevent 'sort-changed' or 'head-clicked' events -->
   <input type="checkbox" :value="foo.column" v-model="selected" @click.stop>
 </template>
+```
+
+## Row details support
+If you would optionally like to display aditional record information (such as
+columns not specified in the fields definition array), you can use the scoped slot
+`row-details`, in combination with the special item record Boolean property
+`_rowDetails`.
+
+If the record has it's `_showDetails` property set to `true`, and a `row-details`
+scoped slot exists, a new row will be shown just below the item, with the contents
+of the scoped slot.
+
+**Note:** the `_showDetails` property **must** exist in the items data for proper
+reactive detection of changes in `_showDetails`.
+
+Available scoped variables:
+
+| Property | Description
+| -------- | -----------
+| `item` | The entire row record data object
+| `index` | The current visible row number
+
+```html
+<template>
+  <b-table :items="items" :fields="fields">
+    <template slot="show_details" scope="row">
+      <b-form-checkbox v-model="row.item._showDetails"></b-form-checkbox>
+    </template>
+    <template slot="row-details" scope="row">
+      <b-card>
+        <b-row class="mb-2">
+          <b-col sm="3" class="text-sm-right"><b>Age:</b></b-col>
+          <b-col>{{ row.item.age }}</b-col>
+        </b-row>
+        <b-row>
+          <b-col sm="3" class="text-sm-right"><b>Is Active:</b></b-col>
+          <b-col>{{ row.item.isActive }}</b-col>
+        </b-row>
+      </b-card>
+    </template>
+  </b-table>
+</template>
+
+<script>
+export default {
+  data: {
+    fields: [ 'first_name', 'last_name', 'show_details' ],
+    items: [
+      { isActive: true,  age: 40, first_name: 'Dickerson', last_name: 'Macdonald', _showDetails: false },
+      { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw', _showDetails: false },
+      { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson', _showDetails: false },
+      { isActive: true,  age: 38, first_name: 'Jami', last_name: 'Carney', _showDetails: false }
+    ]
+  }
+};
+</script>
+
+<!-- table-details.vue -->
 ```
 
 

--- a/docs/components/table/meta.json
+++ b/docs/components/table/meta.json
@@ -131,6 +131,10 @@
       "description": "Scoped slot for custom rendering of field footer. See docs for scoped footer"
     },
     {
+      "name": "row-details",
+      "description": "Scoped slot for optional rendering aditional record details. See docs for Row details support"
+    },
+    {
       "name": "empty",
       "description": "Content to display when no items are present in the `items` array"
     },

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -64,30 +64,37 @@
                       :columns="computedFields.length"
                       :fields="computedFields"></slot>
             </tr>
-            <tr v-for="(item,index) in computedItems"
-                :key="index"
-                :class="rowClasses(item)"
-                @click="rowClicked($event,item,index)"
-                @dblclick="rowDblClicked($event,item,index)"
-                @mouseenter="rowHovered($event,item,index)">
-                <template v-for="field in computedFields">
-                    <td v-if="$scopedSlots[field.key]"
-                        :class="tdClasses(field, item)"
-                        :key="field.key">
-                        <slot :name="field.key"
-                              :value="getFormattedValue(item, field)"
-                              :unformatted="item[field.key]"
-                              :item="item"
-                              :index="index"
-                        ></slot>
+            <template v-for="(item,index) in computedItems">
+                <tr :key="index"
+                    :class="rowClasses(item)"
+                    @click="rowClicked($event,item,index)"
+                    @dblclick="rowDblClicked($event,item,index)"
+                    @mouseenter="rowHovered($event,item,index)">
+                    <template v-for="field in computedFields">
+                        <td v-if="$scopedSlots[field.key]"
+                            :class="tdClasses(field, item)"
+                            :key="field.key">
+                            <slot :name="field.key"
+                                  :value="getFormattedValue(item, field)"
+                                  :unformatted="item[field.key]"
+                                  :item="item"
+                                  :index="index"
+                            ></slot>
+                        </td>
+                        <td v-else
+                            :class="tdClasses(field, item)"
+                            :key="field.key"
+                            v-html="getFormattedValue(item, field)"
+                        ></td>
+                    </template>
+                </tr>
+                <tr v-if="item._showDetails && $scopedSlots['row-details']"
+                    :key="`${index}-details`">
+                    <td :colspan="computedFields.length">
+                        <slot name="row-details" :item="item" :index="index"></slot>
                     </td>
-                    <td v-else
-                        :class="tdClasses(field, item)"
-                        :key="field.key"
-                        v-html="getFormattedValue(item, field)"
-                    ></td>
-                </template>
-            </tr>
+                </tr>
+            </template>
             <tr v-if="showEmpty && (!computedItems || computedItems.length === 0)">
                 <td :colspan="computedFields.length">
                     <div v-if="filter"


### PR DESCRIPTION
Adds new scoped slot `row-details`, and special item record property `_showDetails`, when used in combination will display a "details" row below the item row.  Refer to the update docs for usage and example.

Addresses issue https://github.com/bootstrap-vue/bootstrap-vue/issues/1158#issuecomment-334036004