### PR TITLE
fix(modal): Ensure body scrollbar is removed if modal destroyed before being closed

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -546,8 +546,10 @@
             },
             resetAdjustments() {
                 const modal = this.$refs.modal;
-                modal.style.paddingLeft = '';
-                modal.style.paddingRight = '';
+                if (modal) {
+                    modal.style.paddingLeft = '';
+                    modal.style.paddingRight = '';
+                }
             },
             checkScrollbar() {
                 const rect = getBCR(document.body);
@@ -645,6 +647,7 @@
             this.setResizeEvent(false);
             // Re-adjust body/navbar/fixed padding/margins (if needed)
             removeClass(document.body, 'modal-open');
+            this.resetAdjustments();
             this.resetScrollbar();
         }
     };

--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -84,9 +84,9 @@
     import bBtn from './button';
     import bBtnClose from './button-close';
     import { idMixin, listenOnRootMixin } from '../mixins';
-    import { isVisible, selectAll, select, getBCR, addClass, removeClass, setAttr, removeAttr, getAttr, eventOn, eventOff } from '../utils/dom';
     import { observeDom, warn } from '../utils';
     import { BvEvent } from '../classes';
+    import { isVisible, selectAll, select, getBCR, addClass, removeClass, setAttr, removeAttr, getAttr, hasAttr, eventOn, eventOff } from '../utils/dom';
 
     const Selector = {
         FIXED_CONTENT: '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top',
@@ -596,20 +596,26 @@
             resetScrollbar() {
                 // Restore fixed content padding
                 selectAll(Selector.FIXED_CONTENT).forEach(el => {
-                    el.style.paddingRight = getAttr(el, 'data-padding-right') || '';
-                    removeAttr(el,'data-padding-right');
+                    if (hasAttr(el, 'data-padding-right')) {
+                        el.style.paddingRight = getAttr(el, 'data-padding-right') || '';
+                        removeAttr(el,'data-padding-right');
+                    }
                 });
 
                 // Restore sticky content and navbar-toggler margin
                 selectAll(`${Selector.STICKY_CONTENT}, ${Selector.NAVBAR_TOGGLER}`).forEach(el => {
-                    el.style.marginRight = getAttr(el, 'data-margin-right') || '';
-                    removeAttr(el, 'data-margin-right');
+                    if (hasAttr(el, 'data-margin-right')) {
+                        el.style.marginRight = getAttr(el, 'data-margin-right') || '';
+                        removeAttr(el, 'data-margin-right');
+                    }
                 });
 
                 // Restore body padding
                 const body = document.body;
-                body.style.paddingRight = getAttr(body, 'data-padding-right') || '';
-                removeAttr(body, 'data-padding-right');
+                if (hasAttr(body, 'data-padding-right')) {
+                    body.style.paddingRight = getAttr(body, 'data-padding-right') || '';
+                    removeAttr(body, 'data-padding-right');
+                }
             }
 
         },
@@ -631,11 +637,15 @@
             }
         },
         beforeDestroy() {
+            // Ensure everything is back to normal
             if (this._observer) {
                 this._observer.disconnect();
                 this._observer = null;
             }
             this.setResizeEvent(false);
+            // Re-adjust body/navbar/fixed padding/margins (if needed)
+            removeClass(document.body, 'modal-open');
+            this.resetScrollbar();
         }
     };
 </script>

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -151,6 +151,15 @@ dom.getAttr = function(el, attr) {
     return null;
 };
 
+// Determine if an attribute exists on an element (returns true or false, or null if element not found)
+dom.hasAttr = function(el, attr) {
+    if (attr && dom.isElement(el)) {
+        return el.hasAttribute(attr);
+    }
+    return null;
+};
+
+ element.hasAttribute(name)
 // Retur nteh Bounding Client Rec of an element. Retruns null if not an element
 dom.getBCR = function(el) {
     return dom.isElement(el) ? el.getBoundingClientRect() : null;
@@ -238,6 +247,7 @@ export const matches = dom.matches;
 export const setAttr = dom.setAttr;
 export const removeAttr = dom.removeAttr;
 export const getAttr = dom.getAttr;
+export const hasAttr = dom.hasAttr;
 export const getBCR = dom.getBCR;
 export const getCS = dom.getCS;
 export const offset = dom.offset;

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -159,8 +159,7 @@ dom.hasAttr = function(el, attr) {
     return null;
 };
 
- element.hasAttribute(name)
-// Retur nteh Bounding Client Rec of an element. Retruns null if not an element
+// Return the Bounding Client Rec of an element. Retruns null if not an element
 dom.getBCR = function(el) {
     return dom.isElement(el) ? el.getBoundingClientRect() : null;
 };


### PR DESCRIPTION
Use case: If a modal is open on a child route and the route is changed, the modal is closed (destroyed), but body scrollbar and navbar/fixed content adjustments (margins/padding) were not being removed.

Note this PR does not address similar issues when modal is inside a `<keep-alive>` component.

Addresses issue #1167 
