### PR TITLE
fix(modal): Modal jumps when dialog height changes

### DIFF
--- a/lib/components/modal.vue
+++ b/lib/components/modal.vue
@@ -387,6 +387,7 @@
                 this.is_transitioning = true;
                 this.checkScrollbar();
                 this.setScrollbar();
+                this.adjustDialog();
                 addClass(document.body, 'modal-open');
                 this.setResizeEvent(true);
             },


### PR DESCRIPTION
Building on #1058...  If the modal dialog's content height changed (e.g., "v-if" conditionally displayed an error message), the `padding-right` could be applied inconsistently.

twbs/bootstrap#23672 fixed this by calling `this.adjustDialog()` during `onBeforeEnter()`, as well