### PR TITLE
Fix typo in modal README

### DIFF
--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -10,7 +10,7 @@ feature a handful of helpful sub-components, sizes, variants, accessibility, and
 
   <!-- Modal Component -->
   <b-modal id="modal1" title="Bootstrap-Vue">
-    <p clas="my-4">Hello from modal!</p>
+    <p class="my-4">Hello from modal!</p>
   </b-modal>
 </div>
 


### PR DESCRIPTION
Fixes `clas` typo in first code snippet