### PR TITLE
feat(table): allow custom attributes in table td cell

### DIFF
--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -256,6 +256,7 @@ The following field properties are recognized:
 | `thClass` | String or Array | Class name (or array of class names) to add to header/footer `<th>` cell
 | `thStyle` | Object | JavaScript object representing CSS styles you would like to apply to the table field `<th>`
 | `variant` | String | Apply contextual class to the `<th>` **and** `<td>` in the column - `active`, `success`, `info`, `warning`, `danger` (these variants map to classes `thead-${variant}`, `table-${variant}`, or `bg-${variant}` accordingly)
+| `tdAttr` | Object | JavaScript object representing additional attributes to apply to the `td` cell
 
 **Notes:**
  - _Field properties, if not present, default to `null` unless otherwise stated above._

--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -73,7 +73,8 @@
                     <template v-for="field in computedFields">
                         <td v-if="$scopedSlots[field.key]"
                             :class="tdClasses(field, item)"
-                            :key="field.key">
+                            :key="field.key"
+                            v-bind="field.tdAttr">
                             <slot :name="field.key"
                                   :value="getFormattedValue(item, field)"
                                   :unformatted="item[field.key]"
@@ -85,6 +86,7 @@
                             :class="tdClasses(field, item)"
                             :key="field.key"
                             v-html="getFormattedValue(item, field)"
+                            v-bind="field.tdAttr"
                         ></td>
                     </template>
                 </tr>


### PR DESCRIPTION
Hi,

This pull request allows us to add additional attributes to a `<td>` cell in `<b-table>`

We are converting a plain html table to use `<b-table>`. It's responsive, such that on small screens, the table header is hidden and we use the following css for the td cells

```css
    td {
      display: block; border:none; padding:6px 10px;

      &:first-child {padding-top: .5em;}
      &:last-child {padding-bottom: .5em; border-bottom:1px solid #e8e8e8; padding-bottom:15px;}

      &:before {
        content: attr(data-th)": ";
        font-weight: bold;
        width: 6.5em; // magic number :( adjust according to your own content
        display: inline-block;

        @include media-breakpoint-up(md) {
          display: none;
        }
      }
    }
```

essentially, placing the header text to the left of the cell and turning the table into a vertical list. it works quite well for our use case.

with `<b-table>`, I need to pass in a `data-th` attribute to the `<td>` node. I'm doing this using a new property on the fields object.

I'm not sure if this is how you would prefer to handle it, please let me know your thoughts (perhaps this could be extended to `th` and `tr`).

thanks