### PR TITLE
[fix] Fix server-side / client side html mismatch caused by button-close.js

### DIFF
--- a/lib/components/button-close.js
+++ b/lib/components/button-close.js
@@ -41,7 +41,7 @@ export default {
         };
         // Careful not to override the slot with innerHTML
         if (!children.length) {
-            componentData.domProps = { innerHTML: "×" };
+            componentData.domProps = { innerHTML: "&times;" };
         }
         return h("button", mergeData(data, componentData), children);
     }


### PR DESCRIPTION
This should fix the mismatch in server/client HTML by using an HTML entity.

As seen in #1195 