### PR TITLE
fix(dom utils): use getBoundingClientRect() to determine element visibility

### DIFF
--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -52,7 +52,8 @@ dom.isElement = function(el) {
 dom.isVisible = function(el) {
     return dom.isElement(el) &&
            document.body.contains(el) &&
-           (el.offsetParent !== null || el.offsetWidth > 0 || el.offsetHeight > 0);
+           el.getBoundingClientRect().height > 0 &&
+           el.getBoundingClientRect().width > 0
 };
 
 // Determine if an element is disabled


### PR DESCRIPTION
`Element.offsetParent`/`offsetHeight`/`offsetWidth` does not work on `<svg>` elements.

Swtching to `Element.getBoundingClientRect().height` and `.width` gets around this limitation