### PR TITLE
fix(Progress): Bootstrap V4.beta.2 CSS height prop change

### DIFF
--- a/lib/components/progress-bar.vue
+++ b/lib/components/progress-bar.vue
@@ -27,7 +27,7 @@
             },
             progressBarStyles() {
                 return {
-                    width: (100 * (this.value / this.computedMax)) + '%',                    
+                    width: (100 * (this.value / this.computedMax)) + '%'
                 };
             },
             progress() {

--- a/lib/components/progress-bar.vue
+++ b/lib/components/progress-bar.vue
@@ -27,9 +27,7 @@
             },
             progressBarStyles() {
                 return {
-                    width: (100 * (this.value / this.computedMax)) + '%',
-                    height: this.computedHeight,
-                    lineHeight: this.computedHeight
+                    width: (100 * (this.value / this.computedMax)) + '%',                    
                 };
             },
             progress() {
@@ -39,11 +37,7 @@
             computedMax() {
                 // Prefer our max over parent setting
                 return typeof this.max === 'number' ? this.max : (this.$parent.max || 100);
-            },
-            computedHeight() {
-                // Prefer parent height over our height
-                return this.$parent.height || this.height || '1rem';
-            },
+            },            
             computedVariant() {
                 // Prefer our variant over parent setting
                 return this.variant || this.$parent.variant;
@@ -107,11 +101,7 @@
             showValue: {
                 type: Boolean,
                 default: null
-            },
-            height: {
-                type: String,
-                default: null
-            }
+            }           
         }
     };
 </script>

--- a/lib/components/progress.vue
+++ b/lib/components/progress.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="progress">
+    <div class="progress" :height="height">
         <slot>
             <b-progress-bar :value="value"
                             :max="max"
@@ -9,7 +9,6 @@
                             :striped="striped"
                             :show-progress="showProgress"
                             :show-value="showValue"
-                            :height="height"
             ></b-progress-bar>
         </slot>
     </div>


### PR DESCRIPTION
Move height prop from progress-bar to progress according to current Bootstrap4-beta2.
fixes #1216