### PR TITLE
fix(button-group): Bootstrap V4.beta.2 CSS changes

### DIFF
--- a/lib/components/button-group.js
+++ b/lib/components/button-group.js
@@ -29,7 +29,8 @@ export default {
             props.tag,
             mergeData(data, {
                 class: {
-                    props.vertical ? "btn-group-vertical" : "btn-group",
+                    "btn-group": !props.vertical,
+                    "btn-group-vertical": props.vertical,
                     [`btn-group-${props.size}`]: Boolean(props.size)
                 },
                 attrs: { "role": props.ariaRole }

--- a/lib/components/button-group.js
+++ b/lib/components/button-group.js
@@ -28,9 +28,8 @@ export default {
         return h(
             props.tag,
             mergeData(data, {
-                staticClass: "btn-group",
                 class: {
-                    "btn-group-vertical": props.vertical,
+                    props.vertical ? "btn-group-vertical" : "btn-group",
                     [`btn-group-${props.size}`]: Boolean(props.size)
                 },
                 attrs: { "role": props.ariaRole }

--- a/tests/components/button-group.spec.js
+++ b/tests/components/button-group.spec.js
@@ -1,28 +1,24 @@
-import { loadFixture, testVM } from "../helpers";
+import { loadFixture, testVM } from "../helpers"
 
 describe("button-group", async () => {
-    beforeEach(loadFixture("button-group"));
-    testVM();
+    beforeEach(loadFixture("button-group"))
+    testVM()
 
-    const btnRefs = ["basic", "vertical", "size"];
+    it("basic should contain base class", async () => {
+        const { app: { $refs } } = window
 
-    it("should contain base class", async () => {
-        const { app: { $refs } } = window;
-
-        btnRefs.forEach(ref => {
-            expect($refs[ref]).toHaveClass("btn-group");
-        });
+        expect($refs.basic).toHaveClass("btn-group")
     });
 
     it("should apply vertical class", async () => {
-        const { app: { $refs } } = window;
+        const { app: { $refs } } = window
 
-        expect($refs.vertical).toHaveClass("btn-group-vertical");
+        expect($refs.vertical).toHaveClass("btn-group-vertical")
     });
 
     it("should apply size class", async () => {
-        const { app: { $refs } } = window;
+        const { app: { $refs } } = window
 
-        expect($refs.size).toHaveClass("btn-group-sm");
+        expect($refs.size).toHaveClass("btn-group-sm")
     });
 });


### PR DESCRIPTION
Having both btn-group and btn-group-vertical applied causes styling issues under Bootstrap V4.beta.2 CSS