### PR TITLE
fix(dropdown): Bootstrap V4.beta.2 now has better hover/focus styling

### DIFF
--- a/lib/components/dropdown.vue
+++ b/lib/components/dropdown.vue
@@ -98,14 +98,3 @@
         }
     };
 </script>
-
-<style>
-.b-dropdown .dropdown-item:focus {
-    /* @See https://github.com/twbs/bootstrap/issues/23329 */
-    box-shadow: inset 0px 0px 400px 110px rgba(0, 0, 0, .09);
-}
-
-.b-dropdown .dropdown-item:active {
-    box-shadow: initial;
-}
-</style>

--- a/lib/components/nav-item-dropdown.vue
+++ b/lib/components/nav-item-dropdown.vue
@@ -78,13 +78,3 @@
         }
     };
 </script>
-
-<style>
-.b-nav-dropdown .dropdown-item:focus {
-    /* @See https://github.com/twbs/bootstrap/issues/23329 */
-    box-shadow: inset 0px 0px 400px 110px rgba(0, 0, 0, .09);
-}
-.b-nav-dropdown .dropdown-item:active {
-    box-shadow: initial;
-}
-</style>


### PR DESCRIPTION
Removed custom CSS for focus/hover styling as Bootstrap V4.beta.2 now has better hover/focus styling, although still not ideal.