### PR TITLE
fix(form-input): BS V4.beta.2 is missing width:100% on readonly plaintext

### DIFF
--- a/lib/components/form-input.vue
+++ b/lib/components/form-input.vue
@@ -104,7 +104,9 @@
             },
             inputClass() {
                 return [
-                    this.plaintext ? `form-control-plaintext` : 'form-control',
+                    this.plaintext ? 'form-control-plaintext' : 'form-control',
+                    // Fix missing width:100% in Bootstrap V4.beta.2
+                    this.plaintext ? 'w-100' : '',
                     this.sizeFormClass,
                     this.stateClass
                 ];

--- a/lib/components/form-textarea.vue
+++ b/lib/components/form-textarea.vue
@@ -78,6 +78,8 @@
             inputClass() {
                 return [
                     this.plaintext ? 'form-control-plaintext' : 'form-control',
+                    // Interim fix until BS V4.beta.3 is released
+                    this.plaintext ? 'w-100' : '',
                     this.sizeFormClass,
                     this.stateClass
                 ];


### PR DESCRIPTION
This is an interim fix until BS V4.beta.3 is released: https://github.com/twbs/bootstrap/pull/24486