### PR TITLE
fix(package.json): Move Bootstrap back to dev deps and update popper.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "vue": "^2.4.2"
   },
   "dependencies": {
-    "bootstrap": "^4.0.0-beta.2",
     "lodash.startcase": "^4.4.0",
     "popper.js": "^1.12.5",
     "vue-functional-data-merge": "^1.0.6"
@@ -71,6 +70,7 @@
     "@nuxtjs/pwa": "^0.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^4.1.5",
+    "bootstrap": "^4.0.0-beta.2",
     "clean-css": "^4.1.9",
     "codecov": "^2.3.0",
     "codemirror": "^5.30.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "lodash.startcase": "^4.4.0",
-    "popper.js": "^1.12.5",
+    "popper.js": "^1.12.6",
     "vue-functional-data-merge": "^1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
As bootstrap is only needed to build the documentation site, move it back to `devDependencies` from `dependencies`, as the final bootstrap-vue JavaScript dist files import nothing from Bootstrap.

We should update the getting started docs to use bootstrap v4.0.0-beta.2, and possibly a few of the examples too.