### PR TITLE
feat(navbar-nav): New b-navbar-nav component

### DIFF
--- a/docs/components/nav/README.md
+++ b/docs/components/nav/README.md
@@ -63,7 +63,7 @@ Use the pill style by setting the prop `pills`.
 
 Force your `b-nav` content to extend the full available width.
 
-### fill
+### Fill
 
 To proportionately fill all available space with your `<b-nav-item>` components,
 set the `fill` prop. Notice that all horizontal space is occupied, but not
@@ -99,7 +99,7 @@ will be the same width.
 
 ## Vertical variation
 
-By default navs appear on a horizontal line. Stack your navigation by setting
+By default `<b-nav>` appear on a horizontal line. Stack your navigation by setting
 the `vertical` prop.
 
 ```html
@@ -110,7 +110,7 @@ the `vertical` prop.
   <b-nav-item disabled>Disabled</b-nav-item>
 </b-nav>
 
-<!-- nav-vetical.vue -->
+<!-- nav-vertical.vue -->
 ```
 
 ## Dropdown support
@@ -157,7 +157,7 @@ a `<nav>` element around `<b-nav>`. Do **not** add the role to the `<b-nav>` its
 as this would prevent it from being announced as an actual list by assistive technologies.
 
 When using a `<b-nav-item-dropdown>` in your `<b-nav>`, be sure to assign a unique `id`
-prop value to the `<b-nav-dropdown>` so that the apropriate `aria-*` attributes can
+prop value to the `<b-nav-dropdown>` so that the appropriate `aria-*` attributes can
 be automatically generated.
 
 ## See Also

--- a/docs/components/nav/README.md
+++ b/docs/components/nav/README.md
@@ -141,8 +141,10 @@ Refer to [`<b-dropdown>`](../dropdown) for a list of supported sub-components.
 
 ## Using in Navbar
 
-When using `<b-nav>` within a `<b-navbar>`, set the `is-nav-bar` prop to ensure that the proper
-classes and handlers can be applied.
+Using `<b-nav>` within a `<b-navbar>` has been deprecated as of Bootstrap-Vue v1.0.0-beta.10.
+Please use the [`<b-navbar-nav>`](/docs/components/navbar) component instead.
+
+Prop `is-nav-bar` has been deprecated and will be removed in a future release.
 
 ## Tabbed content support
 
@@ -160,8 +162,8 @@ be automatically generated.
 
 ## See Also
 
-- [`<b-tabs>`](./tabs) to create tabbable panes of local content, even via dropdown menus.
-- [`<b-navbar>`](./navbar) a wrapper that positions branding, navigation, and other elements in a concise header.
-- [`<b-dropdown>`](./dropdown) for sub-components that you can place inside `<b-nav-item-dropdown>`
+- [`<b-tabs>`](/docs/components/tabs) to create tabbable panes of local content, even via dropdown menus.
+- [`<b-navbar>`](/docs/components/navbar) a wrapper that positions branding, navigation, and other elements in a concise header.
+- [`<b-dropdown>`](/docs/components/dropdown) for sub-components that you can place inside `<b-nav-item-dropdown>`
 
 ## Component Reference

--- a/docs/components/navbar/README.md
+++ b/docs/components/navbar/README.md
@@ -12,13 +12,13 @@ It’s easily extensible and thanks to our Collapse plugin, it can easily integr
 
   <b-collapse is-nav id="nav_collapse">
 
-    <b-nav is-nav-bar>
+    <b-navbar-nav>
       <b-nav-item href="#">Link</b-nav-item>
       <b-nav-item href="#" disabled>Disabled</b-nav-item>
-    </b-nav>
+    </b-navbar-nav>
 
     <!-- Right aligned nav items -->
-    <b-nav is-nav-bar class="ml-auto">
+    <b-navbar-nav class="ml-auto">
 
       <b-nav-form>
         <b-form-input size="sm" class="mr-sm-2" type="text" placeholder="Search"/>
@@ -40,7 +40,7 @@ It’s easily extensible and thanks to our Collapse plugin, it can easily integr
         <b-dropdown-item href="#">Profile</b-dropdown-item>
         <b-dropdown-item href="#">Signout</b-dropdown-item>
       </b-nav-item-dropdown>
-    </b-nav>
+    </b-navbar-nav>
 
   </b-collapse>
 </b-navbar>
@@ -72,12 +72,12 @@ Control the placement of the navbar by setting one of two props:
 Navbars come with built-in support for a handful of sub-components. Choose from the following as needed:
 
 - `<b-navbar-brand>` for your company, product, or project name.
-- `<b-nav is-nav-bar>` for a full-height and lightweight navigation (including support for dropdowns).
+- `<b-navbar-nav>` for a full-height and lightweight navigation (including support for dropdowns).
 - `<b-nav-item>` for link (and router-link) action items
 - `<b-nav-item-dropdown>` for navbar dropdown menus
 - `<b-nav-text>` for adding vertically centered strings of text.
-- `<b-navbar-form>` for any form controls and actions.
-- `<b-navbar-toggler>` for use with the `<b-collapse>` component.
+- `<b-nav-form>` for any form controls and actions.
+- `<b-nav-toggle>` for use with the `<b-collapse is-nav>` component.
 - `<b-collapse is-nav>` for grouping and hiding navbar contents by a parent breakpoint.
 
 ### `<b-navbar-brand>`
@@ -138,20 +138,19 @@ to properly size. Here are some examples to demonstrate:
 <!-- navbar-brand-4.vue -->
 ```
 
-### `<b-nav is-nav-bar>`
+### `<b-navbar-nav>`
 
-Navbar navigation links build on our `<b-nav>` parent component with their own modifier
-class and require the use of `<b-collapse>` toggler for proper responsive styling.
+Navbar navigation links build on the `<b-navbar-nav>` parent component and requires the
+use of `<b-collapse is-nav>` and `<b-nav-toggle>` toggler for proper responsive styling.
 Navigation in navbars will also grow to occupy as much horizontal space as possible to
 keep your navbar contents securely aligned.
 
-Be sure to set the prop `is-nav-bar` on `<b-nav>` for proper alignment!
-
-`<b-nav>` in navbar context supports the following components:
+`<b-navbar-nav>` supports the following components:
 
 - `<b-nav-item>` for link (and router-link) action items
 - `<b-nav-text>` for adding vertically centered strings of text.
 - `<b-nav-item-dropdown>` for navbar dropdown menus
+- `<b-nav-form>` for adding simple forms to the navbar.
 
 ### `<b-nav-item>`
 
@@ -175,9 +174,9 @@ adjusts vertical alignment and horizontal spacing for strings of text.
         <b-nav-toggle target="nav_text_collapse"></b-nav-toggle>
         <b-navbar-brand>BootstrapVue</b-navbar-brand>
         <b-collapse is-nav id="nav_text_collapse">
-            <b-nav is-nav-bar>
+            <b-navbar-nav>
                 <b-nav-text>Navbar text</b-nav-text>
-            </b-nav>
+            </b-navbar-nav>
         </b-collapse>
     </b-navbar>
 </div>
@@ -187,15 +186,15 @@ adjusts vertical alignment and horizontal spacing for strings of text.
 
 ### `<b-nav-item-dropdown>`
 
-For `<b-nav-item-dropdown>` usage, see the [`<b-dropdown>`](./dropdown) docs.
-Note split dropdowns are not supported in `<b-navbar>`.
+For `<b-nav-item-dropdown>` usage, see the [`<b-dropdown>`](/docs/components/dropdown) docs.
+Note split dropdowns are not supported in `<b-navbar>` and `<b-navbar-nav>`.
 
 ```html
 <div>
   <b-navbar type="dark" variant="primary" toggleable>
     <b-nav-toggle target="nav_dropdown_collapse"></b-nav-toggle>
     <b-collapse is-nav id="nav_dropdown_collapse">
-      <b-nav is-nav-bar>
+      <b-navbar-nav>
         <b-nav-item href="#">Home</b-nav-item>
         <b-nav-item href="#">Link</b-nav-item>
         <!-- Navbar dropdowns -->
@@ -209,7 +208,7 @@ Note split dropdowns are not supported in `<b-navbar>`.
           <b-dropdown-item href="#">Account</b-dropdown-item>
           <b-dropdown-item href="#">Settings</b-dropdown-item>
         </b-nav-item-dropdown>
-      </b-nav>
+      </b-navbar-nav>
     </b-collapse>
   </b-navbar>
 </div>
@@ -255,7 +254,7 @@ Input groups work as well:
 Navbars are responsive by default, but you can easily modify them to change that. Responsive
 behavior depends on our `<b-collapse>` component.
 
-Wrap `<b-nav is-nav-bar>` components in a `<b-collapse is-nav>` (remember to set the `is-nav` prop!)
+Wrap `<b-navbar-nav>` components in a `<b-collapse is-nav>` (**remember to set the `is-nav` prop!**)
 to specify content that will collapse based on a particular breakpoint.
 
 Use `<b-nav-toggle>` to control the collapse component and set the `toggleable` prop to
@@ -263,7 +262,7 @@ the breakpoint you would like content to automatically collapse. Possible values
 `md`, and `lg`. Setting togleable to `true` (or with no explicit value) will set the
 breakpoint to `sm`. setting to `false` will disable collapsing.
 
-See the first example on this page for reference, and also refer to [`<b-collapse>`](./collapse) for
+See the first example on this page for reference, and also refer to [`<b-collapse>`](/docs/components/collapse) for
 details on the collapse component.
 
 ## Component Reference

--- a/docs/components/navbar/README.md
+++ b/docs/components/navbar/README.md
@@ -249,20 +249,23 @@ Input groups work as well:
 <!-- navbar-form-2.vue -->
 ```
 
-## Responsive collapsing content
-
+### `<b-nav-toggle>` and `<b-collapse is-nav>`
 Navbars are responsive by default, but you can easily modify them to change that. Responsive
 behavior depends on our `<b-collapse>` component.
 
-Wrap `<b-navbar-nav>` components in a `<b-collapse is-nav>` (**remember to set the `is-nav` prop!**)
-to specify content that will collapse based on a particular breakpoint.
+Wrap `<b-navbar-nav>` components in a `<b-collapse is-nav>` (**remember to set the `is-nav`
+prop!**) to specify content that will collapse based on a particular breakpoint. Assign a
+document unique `id` value on `<b-collapse>`.
 
-Use `<b-nav-toggle>` to control the collapse component and set the `toggleable` prop to
-the breakpoint you would like content to automatically collapse. Possible values are `sm`,
-`md`, and `lg`. Setting togleable to `true` (or with no explicit value) will set the
-breakpoint to `sm`. setting to `false` will disable collapsing.
+Use `<b-nav-toggle>`, with its `target` prop set to the `id` of `<b-collapse>`, to
+control the collapse component. Set the `toggleable` prop on `<b-navbar>` to the
+desired breakpoint you would like content to automatically collapse at. Possible
+`toggleable`values are `sm`, `md`, and `lg`. Setting togleable to `true` (or with no
+explicit value) will set the breakpoint to `sm`, while setting it to `false` will
+disable collapsing.
 
-See the first example on this page for reference, and also refer to [`<b-collapse>`](/docs/components/collapse) for
-details on the collapse component.
+See the first example on this page for reference, and also refer to
+[`<b-collapse>`](/docs/components/collapse) for details on the collapse component.
+
 
 ## Component Reference

--- a/docs/components/navbar/meta.json
+++ b/docs/components/navbar/meta.json
@@ -2,11 +2,12 @@
   "title": "Navbar",
   "component": "bNavbar",
   "components": [
-    "bNavItemDropdown",
+    "bNavbarNav",
+    "bNavbarBrand"
     "bNavToggle",
     "bNavItem",
     "bNavText",
+    "bNavItemDropdown",
     "bNavForm",
-    "bNavbarBrand"
   ]
 }

--- a/docs/components/navbar/meta.json
+++ b/docs/components/navbar/meta.json
@@ -3,11 +3,11 @@
   "component": "bNavbar",
   "components": [
     "bNavbarNav",
-    "bNavbarBrand"
+    "bNavbarBrand",
     "bNavToggle",
     "bNavItem",
     "bNavText",
     "bNavItemDropdown",
-    "bNavForm",
+    "bNavForm"
   ]
 }

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -55,6 +55,7 @@ import bNavItem from "./nav-item";
 import bNavItemDropdown from "./nav-item-dropdown.vue";
 import bNavToggle from "./nav-toggle.vue";
 import bNavbar from "./navbar";
+import bNavbarNav from "./navbar-nav";
 import bNavbarBrand from "./navbar-brand";
 import bNavText from "./nav-text";
 import bNavForm from "./nav-form";
@@ -140,6 +141,7 @@ export {
     bMediaAside,
     bModal,
     bNavbar,
+    bNavbarNav,
     bNavbarBrand,
     bNavText,
     bNavForm,

--- a/lib/components/nav.js
+++ b/lib/components/nav.js
@@ -1,4 +1,4 @@
-import { mergeData } from "../utils";
+import { mergeData, warn } from "../utils";
 
 export const props = {
     tag: {
@@ -35,6 +35,9 @@ export default {
     functional: true,
     props,
     render(h, { props, data, children }) {
+        if (props.isNavBar) {
+            warn("b-nav: Prop 'is-nav-bar' is deprecated. Please use component '<b-navbar-nav>' instead.");
+        }
         return h(
             props.tag,
             mergeData(data, {

--- a/lib/components/nav.js
+++ b/lib/components/nav.js
@@ -38,12 +38,12 @@ export default {
         return h(
             props.tag,
             mergeData(data, {
-                staticClass: "nav",
                 class: {
+                    "nav": !props.isNavBar,
                     "navbar-nav": props.isNavBar,
-                    "nav-tabs": props.tabs,
-                    "nav-pills": props.pills,
-                    "flex-column": props.vertical,
+                    "nav-tabs": props.tabs && !props.isNavBar,
+                    "nav-pills": props.pills && !props.isNavBar,
+                    "flex-column": props.vertical && !props.isNavBar,
                     "nav-fill": props.fill,
                     "nav-justified": props.justified
                 }

--- a/lib/components/navbar-nav.js
+++ b/lib/components/navbar-nav.js
@@ -1,0 +1,34 @@
+import { mergeData } from "../utils";
+
+export const props = {
+    tag: {
+        type: String,
+        default: "ul"
+    },
+    fill: {
+        type: Boolean,
+        default: false
+    },
+    justified: {
+        type: Boolean,
+        default: false
+    }
+};
+
+export default {
+    functional: true,
+    props,
+    render(h, { props, data, children }) {
+        return h(
+            props.tag,
+            mergeData(data, {
+                staticClass: "navbar-nav",
+                class: {
+                    "nav-fill": props.fill,
+                    "nav-justified": props.justified
+                }
+            }),
+            children
+        );
+    }
+};


### PR DESCRIPTION
The class 'nav' is no longer used in BS V4.beta.2 when the nav is a navbar-nav.

Introduce a new lightweight functional `<b-navbar-nav>` component.

Deprecate `is-nav-bar` prop on `<b-nav>`