### PR TITLE
fix(carousel): Minor adjustments to focusout/mouseout event handler

### DIFF
--- a/lib/components/carousel.vue
+++ b/lib/components/carousel.vue
@@ -5,7 +5,7 @@
          :style="{background}"
          :aria-busy="isSliding ? 'true' : 'false'"
          @mouseenter="pause"
-         @mouseleave="start"
+         @mouseleave="restart"
          @focusin="pause"
          @focusout="restart"
          @keydown.left.stop.prevent="prev"
@@ -242,7 +242,7 @@
 
             // Re-Start auto rotate slides when focus/hover leaves the carousel
             restart(evt) {
-                if (!evt.relatedTarget || !this.$el.contains(evt.relatedTarget)) {
+                if (!this.$el.contains(document.activeElement)) {
                     this.start();
                 }
             },


### PR DESCRIPTION
This fix keeps the carousel paused while focus (activeElement) remains inside the carousel container.

Addresses the second part of issue #1235 
