### PR TITLE
feat(table): Add option to use drag-and-drop reordering with Vue.Draggable #873

### DIFF
--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -1205,4 +1205,13 @@ export default {
 <!-- table-complete-1.vue -->
 ```
 
+## Drag and Drop Reordering with Vue.Draggable
+To incorporate reordering rows within a table, pass the `draggable` property in as `true`. The variable passed into `:items` will be updated with the newly mutated array as you reorder the array of items.
+
+Note: This does not currently work with `top-row` or `row-details`!
+
+```html
+<b-table :draggable='true' :items='items'></b-table>
+```
+
 ## Component Reference

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "rollup-plugin-vue": "^2.4.2",
     "rollup-watch": "^4.3.1",
     "standard-version": "^4.2.0",
-    "uglify-es": "^3.1.1"
+    "uglify-es": "^3.1.1",
+    "vuedraggable": "^2.14.1"
   },
   "jest": {
     "testRegex": "spec.js$",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,9 +1007,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@^4.0.0-beta:
-  version "4.0.0-beta"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.tgz#dc5928175d2e71310bc668cf9e05a907211b72a6"
+bootstrap@^4.0.0-beta.2:
+  version "4.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.2.tgz#4d67d2aa2219f062cd90bc1247e6747b9e8fd051"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -5131,9 +5131,9 @@ pngjs@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.3.0.tgz#1f5730c189c94933b81beda2ab2f8e2855263a8f"
 
-popper.js@^1.12.5:
-  version "1.12.5"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.5.tgz#229e4dea01629e1f1a1e26991ffade5024220fa6"
+popper.js@^1.12.6:
+  version "1.12.6"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.6.tgz#91e12a97b07815258b76915d64044e8ac053d426"
 
 postcss-apply@^0.8.0:
   version "0.8.0"
@@ -6531,6 +6531,10 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@^1.6.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.6.1.tgz#d120d103fbb9f60c7db27814a1384072e6c6e083"
+
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
@@ -7262,6 +7266,12 @@ vue-template-validator@^1.1.5:
 vue@~2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.4.2.tgz#a9855261f191c978cc0dc1150531b8d08149b58c"
+
+vuedraggable@^2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-2.14.1.tgz#034e1e052e25b9388429ae96db9eb6f2c3b10d87"
+  dependencies:
+    sortablejs "^1.6.0"
 
 vuex@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
Adding drag and drop functionality to table. Passing in the `:draggable='true'` property does not currently work with `top-row` or `row-details`, as it will skew the internal `<draggable>` counter and move incorrect items. 