### PR TITLE
feat(card): New prop body-class

### DIFF
--- a/lib/components/card-body.js
+++ b/lib/components/card-body.js
@@ -3,6 +3,10 @@ import { assign } from "../utils/object";
 import { cardMixin } from "../mixins";
 
 export const props = assign({}, copyProps(cardMixin.props, prefixPropName.bind(null, "body")), {
+    bodyClass: {
+        type: [String, Object, Array],
+        default: null
+    },
     title: {
         type: String,
         default: null
@@ -52,12 +56,15 @@ export default {
             props.bodyTag,
             mergeData(data, {
                 staticClass: "card-body",
-                class: {
-                    "card-img-overlay": props.overlay,
-                    [`bg-${props.bodyBgVariant}`]: Boolean(props.bodyBgVariant),
-                    [`border-${props.bodyBorderVariant}`]: Boolean(props.bodyBorderVariant),
-                    [`text-${props.bodyTextVariant}`]: Boolean(props.bodyTextVariant)
-                }
+                class: [
+                    {
+                        "card-img-overlay": props.overlay,
+                        [`bg-${props.bodyBgVariant}`]: Boolean(props.bodyBgVariant),
+                        [`border-${props.bodyBorderVariant}`]: Boolean(props.bodyBorderVariant),
+                        [`text-${props.bodyTextVariant}`]: Boolean(props.bodyTextVariant)
+                    },
+                    props.bodyClass || {}
+                ]
             }),
             cardBodyChildren
         );


### PR DESCRIPTION
Similar to header-class and footer-class when using the integrated b-card-body in b-card.

Addresses issue #1249