### PR TITLE
fix(tabs): Apply `small` class to parent `ul.nav`

### DIFF
--- a/lib/components/tabs.vue
+++ b/lib/components/tabs.vue
@@ -6,7 +6,7 @@
         </div>
 
         <div :class="{'card-header': card}">
-            <ul :class="['nav','nav-' + navStyle, card ? 'card-header-'+navStyle : null]"
+            <ul :class="['nav','nav-' + navStyle, card ? 'card-header-'+navStyle : null, small ? 'small' : '']"
                 role="tablist"
                 tabindex="0"
                 @keydown.left="previousTab"
@@ -18,7 +18,7 @@
                 @keydown.shift.right="setTab(tabs.length-1,false,-1)"
                 @keydown.shift.down="setTab(tabs.length-1,false,-1)"
             >
-                <li :class="['nav-item', small ? 'small' : '']" v-for="(tab, index) in tabs" role="presentation">
+                <li class="'nav-item" v-for="(tab, index) in tabs" role="presentation">
                     <a :class="['nav-link',{active: tab.localActive, disabled: tab.disabled}]"
                        :href="tab.href"
                        role="tab"

--- a/lib/components/tabs.vue
+++ b/lib/components/tabs.vue
@@ -18,8 +18,8 @@
                 @keydown.shift.right="setTab(tabs.length-1,false,-1)"
                 @keydown.shift.down="setTab(tabs.length-1,false,-1)"
             >
-                <li class="nav-item" v-for="(tab, index) in tabs" role="presentation">
-                    <a :class="['nav-link',{small: small, active: tab.localActive, disabled: tab.disabled}]"
+                <li :class="['nav-item', small ? 'small' : '']" v-for="(tab, index) in tabs" role="presentation">
+                    <a :class="['nav-link',{active: tab.localActive, disabled: tab.disabled}]"
                        :href="tab.href"
                        role="tab"
                        :aria-setsize="tabs.length"


### PR DESCRIPTION
Applying the `small` class to the parent `ul.nav` rather than the individual `nav-links` allows for proper sizing inheritance of items added to the "tabs" named slot.

Addresses issues #1248