### PR TITLE
feat(progress): Add configurable transition time support + Rounded ends

### DIFF
--- a/src/components/progress/README.md
+++ b/src/components/progress/README.md
@@ -34,12 +34,15 @@ export default {
 
 <!-- progress-1.vue -->
 ```
+
+
 ## Value
 Set the maximum value with the `max` prop (default is `100`), and the current value via the
 `value` prop (default `0`).
 
 When creating multiple bars in a sinple process, place hte value prop on the individual
 `<b-progress-bar>` sub components (see the **Multiple Bars** section below for more details)
+
 
 ## Labels
 Add labels to your progress bars by either enabling `show-progress` (percentage of max) or
@@ -119,6 +122,7 @@ Precedence order for label methods:
 - no label
 
 
+
 ## Width and Height
 `<b-progress>` will always expand to the maximum with of it's parent container. To
 change the width, place `<b-progress>` in a standard Bootstrap column or apply
@@ -173,6 +177,7 @@ export default {
 
 <!-- progress-height.vue -->
 ```
+
 
 ## Backgrounds
 Use background variants to change the appearance of individual progress bars.
@@ -283,6 +288,41 @@ Notes:
  - Animated progress bars don’t work in Opera 12 — as they don’t support CSS3 animations.
 
 
+## Transition support
+You can enable transitioning from one value to another by setting a transition duration
+time via the `transition-time` prop.  The value is specified in seconds.
+
+```html
+<template>
+<div>
+    <b-progress transition-time="0.5" :value="value" :max="max"</b-progress>
+    <b-progress transition-time="0.25" class="mt-1" :max="max">
+      <b-progress-bar :value="value*(6/10)" variant="success"></b-progress-bar>
+      <b-progress-bar :value="value*(2.5/10)" variant="warning"></b-progress-bar>
+      <b-progress-bar :value="value*(1.5/10)" variant="danger"></b-progress-bar>
+    </b-progress>
+    <b-btn class="mt-4" @click="clicked">Click me</b-btn>
+</div>
+</template>
+
+<script>
+export default {
+  data: {
+    value: 75,
+    max: 100
+  },
+  methods: {
+    clicked() {
+      this.value = Math.random() * this.max;
+    }
+  }
+}
+</script>
+
+<!-- progress-transition.vue -->
+```
+
+
 ## Multiple bars
 Include multiple `<b-progress-bar>` sub-components in a `<b-progress>` component to build
 a horizontally stacked set of progress bars.
@@ -328,7 +368,7 @@ export default {
 `<b-prgress-bar>` will inherit most of the props from the `<b-progress>` parent component,
 but you can override any of the props by setting them on the `<b-progress-bar>`
 
-Notes:
+**Notes:**
 - `height`, if speified, should always set on the `<b-progress>` component.
 - `<b-progress-bar>` will not inherit `value` from `<b-progress>`.
 

--- a/src/components/progress/README.md
+++ b/src/components/progress/README.md
@@ -193,6 +193,7 @@ The default variant is `primary`.
       <div class="col-sm-10 pt-1">
         <b-progress :value="bar.value"
                     :variant="bar.variant"
+                    :transition-time="0.6"
                     :key="bar.variant"
         ></b-progress>
       </div>

--- a/src/components/progress/README.md
+++ b/src/components/progress/README.md
@@ -289,9 +289,25 @@ Notes:
  - Animated progress bars don’t work in Opera 12 — as they don’t support CSS3 animations.
 
 
+## Rounded ends
+The default progress bar has slightly rounded corners.  You can make the ends fully rounded by
+setting the prop `rounded` on `<b-progress>`.
+
+```html
+<div>
+  <b-progress :value="75" rounded class="my-2"></b-progress>
+  <b-progress :value="75" rounded height="3rem" class="my-2"></b-progress>
+</div>
+
+<!-- progress-rounded.vue -->
+```
+
+
 ## Transition support
-You can enable transitioning from one value to another by setting a transition duration
-time via the `transition-time` prop.  The value is specified in seconds.
+Bootstrap V4.beta.2 removed the default transition from progress-bar, although Bootstrap-Vue
+allows you to enable transitioning from one value to another by setting a transition
+duration time via the `transition-time` prop.  The value is specified in seconds and can
+be fractional.
 
 ```html
 <template>
@@ -370,7 +386,8 @@ export default {
 but you can override any of the props by setting them on the `<b-progress-bar>`
 
 **Notes:**
-- `height`, if speified, should always set on the `<b-progress>` component.
+- `height`, if speified, must be set on the `<b-progress>` component.
+- `rounded`, if speified, must set on the `<b-progress>` component.
 - `<b-progress-bar>` will not inherit `value` from `<b-progress>`.
 
 

--- a/src/components/progress/progress-bar.vue
+++ b/src/components/progress/progress-bar.vue
@@ -27,7 +27,8 @@
             },
             progressBarStyles() {
                 return {
-                    width: (100 * (this.value / this.computedMax)) + '%'
+                    width: (100 * (this.value / this.computedMax)) + '%',
+                    transition: this.computedTransition
                 };
             },
             progress() {
@@ -53,6 +54,11 @@
             computedAnimated() {
                 // Prefer our animated over parent setting
                 return typeof this.animated === 'boolean' ? this.animated : (this.$parent.animated || false);
+            },
+            computedTransition() {
+                // Prefer our transitionTime over parent setting
+                let txTime = this.transitionTime || this.$parent.transitionTime
+                return txTime ? `width ${txTime}s` : null;
             },
             computedShowProgress() {
                 // Prefer our showProgress over parent setting
@@ -92,6 +98,10 @@
             },
             animated: {
                 type: Boolean,
+                default: null
+            },
+            transitionTime: {
+                type: [Number, String],
                 default: null
             },
             showProgress: {

--- a/src/components/progress/progress.vue
+++ b/src/components/progress/progress.vue
@@ -6,6 +6,7 @@
                             :precision="precision"
                             :variant="variant"
                             :animated="animated"
+                            :transition-time="transitionTime"
                             :striped="striped"
                             :show-progress="showProgress"
                             :show-value="showValue"
@@ -32,6 +33,10 @@
             animated: {
                 type: Boolean,
                 default: false
+            },
+            transitionTime: {
+                type: [Number, String],
+                default: null
             },
             height: {
                 type: String,

--- a/src/components/progress/progress.vue
+++ b/src/components/progress/progress.vue
@@ -72,7 +72,7 @@
             progressStyle() {
               return [
                   this.height ? { height: this.height } : {},
-                  (this.rounded && this.height) ? { border-radius: `calc(${this.height} / 2)` } : {}
+                  (this.rounded && this.height) ? { borderRadius: `calc(${this.height} / 2)` } : {}
               ]
             }
         }

--- a/src/components/progress/progress.vue
+++ b/src/components/progress/progress.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="progress" :style="progressHeight">
+    <div class="progress" :style="progressStyle">
         <slot>
             <b-progress-bar :value="value"
                             :max="max"
@@ -42,6 +42,10 @@
                 type: String,
                 default: '1rem'
             },
+            rounded: {
+                type Boolean,
+                default: false
+            },
             precision: {
                 type: Number,
                 default: 0
@@ -65,8 +69,11 @@
             }
         },
         computed: {
-            progressHeight() {
-              return this.height ? { height: this.height } : {};
+            progressStyle() {
+              return [
+                  this.height ? { height: this.height } : {},
+                  (this.rounded && this.height) ? { border-radius: `calc(${this.height}/2)` } : {}
+              ]
             }
         }
     };

--- a/src/components/progress/progress.vue
+++ b/src/components/progress/progress.vue
@@ -72,7 +72,7 @@
             progressStyle() {
               return [
                   this.height ? { height: this.height } : {},
-                  (this.rounded && this.height) ? { border-radius: `calc(${this.height}/2)` } : {}
+                  (this.rounded && this.height) ? { border-radius: `calc(${this.height} / 2)` } : {}
               ]
             }
         }

--- a/src/components/progress/progress.vue
+++ b/src/components/progress/progress.vue
@@ -43,7 +43,7 @@
                 default: '1rem'
             },
             rounded: {
-                type Boolean,
+                type: Boolean,
                 default: false
             },
             precision: {


### PR DESCRIPTION
For some strange reason Bootstrap V4.beta.2 removed the default transition (`width 0.6s ease`) from class `.progress-bar`, so the progress bar no longer animates when the value changes. There is no mention in the BSV4 PR https://github.com/twbs/bootstrap/pull/22703 as to why transition was removed.

This PR adds in configurable transition support via a new prop `transition-time` (value given in seconds), and applies the transition as an inline style.

If `transition-time` is not set, then no transition between values will occur (unless CSS is used to provide transition support).

I've asked in the BS PR as to why this might have been removed. So we may want to hold off on this PR until we hear an answer from the TWBS team