### PR TITLE
docs: Add info on imports

### DIFF
--- a/docs/components/componentdoc.vue
+++ b/docs/components/componentdoc.vue
@@ -1,30 +1,28 @@
 <template>
-    <div class="bd-content" v-if="component">
+    <section class="bd-content" v-if="component">
 
-        <b-row align-v="center">
+        <b-row tag="header" align-v="center">
             <b-col sm="9"><h2><code>{{tag}}</code></h2></b-col>
             <b-col sm="3" class="text-sm-right">
                 <b-btn variant="outline-secondary" size="sm" :href="githubURL" target="_blank">view source</b-btn>
             </b-col>
         </b-row>
 
-        <template v-if="props_items && props_items.length > 0">
+        <article v-if="props_items && props_items.length > 0">
             <h4>Properties</h4>
-            <section>
-                <b-table :items="props_items" :fields="props_fields" small head-variant="default" striped>
-                    <template slot="default" scope="field">
-                        <code v-if="field.value">{{field.value}}</code>
-                    </template>
-                </b-table>
-            </section>
-        </template>
+            <b-table :items="props_items" :fields="props_fields" small head-variant="default" striped>
+                <template slot="default" scope="field">
+                    <code v-if="field.value">{{field.value}}</code>
+                </template>
+            </b-table>
+        </article>
 
-        <template v-if="slots && slots.length > 0">
+        <article v-if="slots && slots.length > 0">
             <h4>Slots</h4>
             <b-table :items="slots" :fields="slots_fields" small head-variant="default" striped></b-table>
-        </template>
+        </article>
 
-        <template v-if="events && events.length > 0">
+        <article v-if="events && events.length > 0">
             <h4>Events</h4>
             <b-table :items="events" :fields="events_fields" small head-variant="default" striped>
                 <template slot="args" scope="field">
@@ -34,10 +32,9 @@
                     </div>
                 </template>
             </b-table>
-        </template>
+        </article>
 
-    </div>
-
+    </section>
 </template>
 
 <style scoped>

--- a/docs/components/componentdoc.vue
+++ b/docs/components/componentdoc.vue
@@ -45,7 +45,7 @@
 
 <script>
     import Vue from 'vue';
-    import _ from 'lodash';
+    import kebabCase from 'lodash/kebabCase';
 
     export default {
         props: {
@@ -140,7 +140,7 @@
                     const required = p.required ? 'Yes' : '';
 
                     return {
-                        prop: _.kebabCase(prop),
+                        prop: kebabCase(prop),
                         type,
                         required,
                         typeClass,
@@ -149,7 +149,7 @@
                 });
             },
             componentName() {
-                return _.kebabCase(this.component);
+                return kebabCase(this.component);
             },
             tag() {
                 return '<' + this.componentName + '>';
@@ -158,7 +158,7 @@
                 const base = 'https://github.com/bootstrap-vue/bootstrap-vue/tree/dev/src/components';
                 const isFunctional =  this.componentOptions.functional;
                 const slug = this.$route.params.slug;
-                return base + '/' + slug + '/' + _.kebabCase(this.component).replace(/^b-/, '') + (isFunctional ? '.js' : '.vue');
+                return base + '/' + slug + '/' + kebabCase(this.component).replace(/^b-/, '') + (isFunctional ? '.js' : '.vue');
             }
         }
     };

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -1,0 +1,82 @@
+<template>
+    <div class="bd-content" v-if="components.length > 0 || directives.length > 0">
+
+        <section v-if="components.length > 0">
+            <h3>Importing Individual Components</h3>
+            <b-table :items="componentImports" small head-variant="default" striped>
+                <template slot="component" scope="field">
+                    <code>{{field.value}}</code>
+                </template>
+                <template slot="import_path" scope="field">
+                    <code>{{field.value}}</code>
+                </template>
+            </b-table>
+        </section>
+
+        <section v-if="directives.length > 0">
+            <h3>Importing Individual Directives</h3>
+            <b-table :items="directiveImports" small head-variant="default" striped>
+                <template slot="directive" scope="field">
+                    <code>{{field.value}}</code>
+                </template>
+                <template slot="import_path" scope="field">
+                    <code>{{field.value}}</code>
+                </template>
+            </b-table>
+        </section>
+    </div>
+</template>
+
+<style scoped>
+    h3 {
+        padding: 20px 0;
+    }
+</style>
+
+<script>
+    import kebabCase from 'lodash/kebabCase';
+    export default {
+        props: {
+            meta: {}
+        },
+        methods: {
+            componentTag(component) {
+                return '<' + kebabCase(component) + '>';
+            },
+            componentPath(component) {
+                return '/bootstrap-vue/es/components/' + this.$route.params.slug + '/' + kebabCase(component).replace(/^b-/, '');
+            },
+            directiveAttr(directive) {
+                return kebabCase(directive);
+            },
+            directivePath(directive) {
+                const slug = kebabCase(directive).replace(/^v-b-/, '')
+                return '/bootstrap-vue/es/directives/' + slug + '/' + slug;
+            },
+        },
+        computed: {
+            componentImports() {
+               return this.components.map(c => {
+                 return {
+                   component: this.componentTag(c),
+                   import_path: this.componentPath(c)
+                 };
+               });
+            },
+            directiveImports() {
+               return this.directives.map(d => {
+                 return {
+                   directive: this.directiveAttr(d),
+                   import_path: this.directivePath(d)
+                 }
+               });
+            },
+            components() {
+               return [].concat(this.meta.component, this.meta.components).filter(c => c);
+            },
+            directives() {
+               return [].concat(this.meta.directive, this.meta.directives).filter(d => d);
+            }
+        }
+    };
+</script>

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -26,7 +26,7 @@
         </article>
 
         <article>
-            <h3>Importing {{meta.title}} as a plugin</h3>
+            <h3>Importing {{meta.title}} as a Vue plugin</h3>
             <p v-if="$route.name === 'docs-components-slug'">
                 This plugin includes all of the above listed individual
                 components<span v-if="directives.length"> and directives</span>.

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -25,7 +25,7 @@
             </b-table>
         </article>
 
-        <article v-if="meta.plugins && meta.plugins.length > 0">
+        <article>
             <h3>Importing {{meta.title}} as a plugin:</h3>
             <p v-if="$route.name === 'docs-components-slug'">
                 This plugin includes all of the above listed individual

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -26,7 +26,7 @@
         </article>
 
         <article>
-            <h3>Importing {{meta.title}} as a plugin:</h3>
+            <h3>Importing {{meta.title}} as a plugin</h3>
             <p v-if="$route.name === 'docs-components-slug'">
                 This plugin includes all of the above listed individual
                 components<span v-if="directives.length"> and directives</span>.

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -28,9 +28,13 @@
         <article v-if="meta.plugins && meta.plugins.length > 0">
             <h3>Importing {{meta.title}} as a plugin:</h3>
             <p v-if="$route.name === 'docs-components-slug'">
-              The plugin includes all of the above listed individual components<span v-if="directives.length"> and directives</span>.
+                This plugin includes all of the above listed individual
+                components<span v-if="directives.length"> and directives</span>.
+                Plugins also include any component aliases.
             </p>
-            <p v-else>The plugin includes all of the above listed individual directives.</p>
+            <p v-else>
+                This plugin includes all of the above listed individual directives.
+            </p>
             <p class="mb-0">
                 <code v-if="$route.name === 'docs-components-slug'">
                      import {{pluginName}} from 'bootstrap-vue/es/components/{{$route.params.slug}};
@@ -39,7 +43,9 @@
                      import {{pluginName}} from 'bootstrap-vue/es/directives/{{$route.params.slug}};
                 </code>
             </p>
-            <p><code>Vue.use({{pluginName}});</code></p>
+            <p>
+                <code>Vue.use({{pluginName}});</code>
+            </p>
             <template v-if="meta.plugins && meta.plugins.length > 0">
                 <p>This plugin also automatically includes the following plugins:</p>
                 <ul>

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="bd-content" v-if="components.length > 0 || directives.length > 0">
+    <section class="bd-content" v-if="components.length > 0 || directives.length > 0">
 
-        <section v-if="components.length > 0">
+        <article v-if="components.length > 0">
             <h3>Importing Individual Components</h3>
             <b-table :items="componentImports" small head-variant="default" striped>
                 <template slot="component" scope="field">
@@ -11,9 +11,9 @@
                     <code>{{field.value}}</code>
                 </template>
             </b-table>
-        </section>
+        </article>
 
-        <section v-if="directives.length > 0">
+        <article v-if="directives.length > 0">
             <h3>Importing Individual Directives</h3>
             <b-table :items="directiveImports" small head-variant="default" striped>
                 <template slot="directive" scope="field">
@@ -23,8 +23,9 @@
                     <code>{{field.value}}</code>
                 </template>
             </b-table>
-        </section>
-    </div>
+        </article>
+
+    </section>
 </template>
 
 <style scoped>

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -25,6 +25,25 @@
             </b-table>
         </article>
 
+        <article v-if="meta.plugins && meta.plugins.length > 0">
+            <h3>Importing {{meta.title}} as a Vue plugin</h3>
+            <p class="mb-0">
+                <code v-if="$route.name === 'docs-components-slug'">
+                     import {{pluginName}} from 'bootstrap-vue/es/components/{{$route.params.slug}};
+                </code>
+                <code v-else>
+                     import {{pluginName}} from 'bootstrap-vue/es/directives/{{$route.params.slug}};
+                </code>
+            </p>
+            <p><code>Vue.use({{pluginName}});</code></p>
+            <template v-if="meta.plugins && meta.plugins.length > 0">
+                <p>This plugin automatically includes the following plugins:</p>
+                <ul>
+                    <li v-for="plugin in meta.plugins" :key="plugin"><code>{{plugin}}</code></li>
+                </ul>
+            </template>
+        </article>
+
     </section>
 </template>
 
@@ -36,6 +55,7 @@
 
 <script>
     import kebabCase from 'lodash/kebabCase';
+    import startCase from 'lodash/startCase';
     export default {
         props: {
             meta: {}
@@ -56,20 +76,23 @@
             },
         },
         computed: {
+            pluginName() {
+                return startCase(this.$route.params.slug).replace(/\s+/g, '');
+            },
             componentImports() {
                return this.components.map(c => {
-                 return {
-                   component: this.componentTag(c),
-                   import_path: this.componentPath(c)
-                 };
+                   return {
+                       component: this.componentTag(c),
+                       import_path: this.componentPath(c)
+                   };
                });
             },
             directiveImports() {
                return this.directives.map(d => {
-                 return {
-                   directive: this.directiveAttr(d),
-                   import_path: this.directivePath(d)
-                 }
+                   return {
+                       directive: this.directiveAttr(d),
+                       import_path: this.directivePath(d)
+                   };
                });
             },
             components() {

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -26,7 +26,11 @@
         </article>
 
         <article v-if="meta.plugins && meta.plugins.length > 0">
-            <h3>Importing {{meta.title}} as a Vue plugin</h3>
+            <h3>Importing {{meta.title}} as a plugin:</h3>
+            <p v-if="$route.name === 'docs-components-slug'">
+              The plugin includes all of the above listed individual components<span v-if="directives.length"> and directives</span>.
+            </p>
+            <p v-else>The plugin includes all of the above listed individual directives.</p>
             <p class="mb-0">
                 <code v-if="$route.name === 'docs-components-slug'">
                      import {{pluginName}} from 'bootstrap-vue/es/components/{{$route.params.slug}};
@@ -37,7 +41,7 @@
             </p>
             <p><code>Vue.use({{pluginName}});</code></p>
             <template v-if="meta.plugins && meta.plugins.length > 0">
-                <p>This plugin automatically includes the following plugins:</p>
+                <p>This plugin also automatically includes the following plugins:</p>
                 <ul>
                     <li v-for="plugin in meta.plugins" :key="plugin"><code>{{plugin}}</code></li>
                 </ul>

--- a/docs/components/search.vue
+++ b/docs/components/search.vue
@@ -20,7 +20,8 @@
 </template>
 
 <script>
-import { groupBy, intersectionBy } from "lodash";
+import groupBy from "lodash/groupBy";
+import intersectionBy from "lodash/intersectionBy";
 import { makeTOC } from '~/utils';
 import { components as _components, directives as _directives, reference as _reference, misc as _misc } from '~/content';
 

--- a/docs/pages/docs/components/_slug.vue
+++ b/docs/pages/docs/components/_slug.vue
@@ -17,17 +17,20 @@
         </b-card>
 
         <componentdoc :component="component" :key="component" v-for="component in meta.components"></componentdoc>
+        
+        <importdoc :meta="meta"></importdoc>
     </div>
 </template>
 
 
 <script>
 import componentdoc from "~/components/componentdoc.vue";
+import importdoc from "~/components/importdoc.vue";
 import { components as _meta } from "~/content";
 import docsMixin from "~/plugins/docs-mixin";
 
 export default {
-  components: { componentdoc },
+  components: { componentdoc, importdoc },
   mixins: [docsMixin],
   layout: "docs",
 

--- a/docs/pages/docs/directives/_slug.vue
+++ b/docs/pages/docs/directives/_slug.vue
@@ -1,15 +1,19 @@
 <template>
     <div class="container">
         <div class="bd-content" v-html="readme" v-play></div>
+        
+        <importdoc :meta="meta"></importdoc>
     </div>
 </template>
 
 <script>
+import importdoc from '~/components/importdoc.vue';
 import { directives as _meta } from "~/content";
 import docsMixin from "~/plugins/docs-mixin";
 
 export default {
   mixins: [docsMixin],
+  components: { importdoc },
   layout: "docs",
 
   validate({ params }) {

--- a/src/components/collapse/package.json
+++ b/src/components/collapse/package.json
@@ -4,6 +4,7 @@
     "meta": {
         "title": "Collapse",
         "component": "bCollapse",
+        "directives": "vBToggle",
         "events": [
             {
                 "event": "show",

--- a/src/components/collapse/package.json
+++ b/src/components/collapse/package.json
@@ -4,7 +4,9 @@
     "meta": {
         "title": "Collapse",
         "component": "bCollapse",
-        "directives": "vBToggle",
+        "directives": [
+            "vBToggle"
+        ],
         "events": [
             {
                 "event": "show",

--- a/src/components/form/form-row.js
+++ b/src/components/form/form-row.js
@@ -1,22 +1,3 @@
-import { mergeData } from "../../utils";
+import bFormRow from "../layout/form-row";
 
-export const props = {
-    tag: {
-        type: String,
-        default: "div"
-    }
-};
-
-export default {
-    functional: true,
-    props,
-    render(h, { props, data, children }) {
-        return h(
-            props.tag,
-            mergeData(data, {
-                staticClass: "form-row"
-            }),
-            children
-        );
-    }
-};
+export default bFormRow;

--- a/src/components/form/package.json
+++ b/src/components/form/package.json
@@ -6,9 +6,9 @@
         "slug": "form",
         "component": "bForm",
         "components": [
-            "bFormRow",
             "bFormText",
-            "bFormFeedback"
+            "bFormFeedback",
+            "bFormRow"
         ],
         "events": [
             {

--- a/src/components/layout/form-row.js
+++ b/src/components/layout/form-row.js
@@ -1,0 +1,22 @@
+import { mergeData } from "../../utils";
+
+export const props = {
+    tag: {
+        type: String,
+        default: "div"
+    }
+};
+
+export default {
+    functional: true,
+    props,
+    render(h, { props, data, children }) {
+        return h(
+            props.tag,
+            mergeData(data, {
+                staticClass: "form-row"
+            }),
+            children
+        );
+    }
+};

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -1,7 +1,7 @@
 import bContainer from './container';
 import bRow from './row';
 import bCol from './col';
-import bFormRow from '../form/form-row';
+import bFormRow from './form-row';
 import { registerComponent } from '../../utils';
 
 /* eslint-disable no-var, no-undef, guard-for-in, object-shorthand */

--- a/src/components/modal/package.json
+++ b/src/components/modal/package.json
@@ -4,6 +4,9 @@
     "meta": {
         "title": "Modal",
         "component": "bModal",
+        "directives": [
+            "vBModal"
+        ],
         "events": [
             {
                 "event": "change",

--- a/src/components/nav/package.json
+++ b/src/components/nav/package.json
@@ -6,6 +6,8 @@
         "component": "bNav",
         "components": [
             "bNavItem",
+            "bNavText",
+            "bNavForm"
             "bNavItemDropdown"
         ],
         "plugins": [

--- a/src/components/nav/package.json
+++ b/src/components/nav/package.json
@@ -7,7 +7,7 @@
         "components": [
             "bNavItem",
             "bNavText",
-            "bNavForm"
+            "bNavForm",
             "bNavItemDropdown"
         ],
         "plugins": [

--- a/src/components/nav/package.json
+++ b/src/components/nav/package.json
@@ -7,6 +7,9 @@
         "components": [
             "bNavItem",
             "bNavItemDropdown"
+        ],
+        "plugins": [
+            "Dropdown"
         ]
     }
 }

--- a/src/components/navbar/index.js
+++ b/src/components/navbar/index.js
@@ -4,6 +4,7 @@ import bNavbarBrand from './navbar-brand';
 import bNavbarToggle from './navbar-toggle';
 import navPlugin from  '../nav';
 import collapsePlugin from  '../collapse';
+import dropdownPlugin from  '../dropdown';
 import { registerComponent } from '../../utils';
 
 /* eslint-disable no-var, no-undef, guard-for-in, object-shorthand */
@@ -23,6 +24,7 @@ const VuePlugin = {
     }
     Vue.use(navPlugin);
     Vue.use(collapsePlugin);
+    Vue.use(dropdownPlugin);
   }
 };
 

--- a/src/components/navbar/index.js
+++ b/src/components/navbar/index.js
@@ -3,6 +3,7 @@ import bNavbarNav from './navbar-nav';
 import bNavbarBrand from './navbar-brand';
 import bNavbarToggle from './navbar-toggle';
 import navPlugin from  '../nav';
+import collapsePlugin from  '../collapse';
 import { registerComponent } from '../../utils';
 
 /* eslint-disable no-var, no-undef, guard-for-in, object-shorthand */
@@ -21,6 +22,7 @@ const VuePlugin = {
       registerComponent(Vue, component, components[component]);
     }
     Vue.use(navPlugin);
+    Vue.use(collapsePlugin);
   }
 };
 

--- a/src/components/navbar/package.json
+++ b/src/components/navbar/package.json
@@ -16,7 +16,8 @@
         ],
         "plugins": [
             "Nav",
-            "Dropdown"
+            "Dropdown",
+            "Collapse"
         ]
     }
 }

--- a/src/components/navbar/package.json
+++ b/src/components/navbar/package.json
@@ -13,6 +13,10 @@
             "bNavText",
             "bNavItemDropdown",
             "bNavForm"
+        ],
+        "plugins": [
+            "Nav",
+            "Dropdown"
         ]
     }
 }

--- a/src/components/navbar/package.json
+++ b/src/components/navbar/package.json
@@ -8,11 +8,7 @@
         "components": [
             "bNavbarNav",
             "bNavbarBrand",
-            "bNavbarToggle",
-            "bNavItem",
-            "bNavText",
-            "bNavItemDropdown",
-            "bNavForm"
+            "bNavbarToggle"
         ],
         "plugins": [
             "Nav",

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -388,4 +388,4 @@ this.$root.$emit('bv::hide::popover');
 - [`<b-tooltip>` component](/docs/components/tooltip)
 
 
-## Directive Reference
+## Directive reference

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -387,3 +387,5 @@ this.$root.$emit('bv::hide::popover');
 - [`<b-popover>` component](/docs/components/popover)
 - [`<b-tooltip>` component](/docs/components/tooltip)
 
+
+## Directive Reference

--- a/src/directives/popover/package.json
+++ b/src/directives/popover/package.json
@@ -2,6 +2,7 @@
     "name": "@bootstrap-vue/popover",
     "version": "0.0.0",
     "meta": {
-        "title": "Popover"
+        "title": "Popover",
+        "directive": "vBPopover"
     }
 }

--- a/src/directives/scrollspy/README.md
+++ b/src/directives/scrollspy/README.md
@@ -346,4 +346,4 @@ new Vue({
 ```
 
 
-## Directive refernce
+## Directive reference

--- a/src/directives/scrollspy/README.md
+++ b/src/directives/scrollspy/README.md
@@ -344,3 +344,6 @@ new Vue({
   }
 })
 ```
+
+
+## Directive refernce

--- a/src/directives/scrollspy/package.json
+++ b/src/directives/scrollspy/package.json
@@ -2,6 +2,7 @@
     "name": "@bootstrap-vue/scrollspy",
     "version": "0.0.0",
     "meta": {
-        "title": "ScrollSpy"
+        "title": "Scrollspy",
+        "directive": "vBScrollspy"
     }
 }

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -313,3 +313,6 @@ this.$root.$emit('bv::hide::tooltip');
 - [`v-b-popover` directive](/docs/directives/popover)
 - [`<b-tooltip>` component](/docs/components/tooltip)
 - [`<b-popover>` component](/docs/components/popover)
+
+
+## Directive reference

--- a/src/directives/tooltip/package.json
+++ b/src/directives/tooltip/package.json
@@ -2,6 +2,7 @@
     "name": "@bootstrap-vue/tooltip",
     "version": "0.0.0",
     "meta": {
-        "title": "Tooltip"
+        "title": "Tooltip",
+        "directive": "vBTooltip"
     }
 }


### PR DESCRIPTION
Adds a new section to component and directive pages describing individual import and plugin use.

Also reduces documentation bundle size by importing only required functions from lodash