### PR TITLE
feat(tabs): New props for adding classes to nav tab

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -43,9 +43,11 @@ by `card-body`.
 <!-- with-card.vue -->
 ```
 
+
 ## Pills variant
 
-Just add `pills` property to `<b-tabs>`.
+Tabs use the `tabs` styling by default. Just add `pills` property to `<b-tabs>` for
+the pill style variant.
 
 ```html
 <b-card no-body>
@@ -67,6 +69,7 @@ Just add `pills` property to `<b-tabs>`.
 
 Fade is enabled by default when changing tabs. It can disabled with `no-fade` property.
 
+
 ## Add Tabs without content
 
 If you want to add extra tabs that do not have any content, you can put them in `tabs` slot:
@@ -79,6 +82,19 @@ If you want to add extra tabs that do not have any content, you can put them in 
   </template>
 </b-tabs>
 ```
+
+
+## Apply custom classes to the generated nav-tabs or pills
+
+The tab selectors are based on Boostrap V4's `nav` markup ( i.e. `ul.nav > li.nav-item > a.nav-link`).
+In some situations, you may want to add classes to the `<li>` (nav-item) and/or the
+`<a>` (nav-link) on a per tab basis.   To do so, simply supply the classname to
+the `title-item-class` prop (for the `<li>` element) or `title-link-class` prop (for the
+`<a>` element).  Value's can be passed as a string or array of strings.
+
+Note: THe `ative` class is automatically applied to the `<a>` element. You may need to accomodate
+your custom classes for this.
+
 
 ## Advanced Examples
 

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -95,6 +95,43 @@ the `title-item-class` prop (for the `<li>` element) or `title-link-class` prop 
 Note: THe `ative` class is automatically applied to the `<a>` element. You may need to accomodate
 your custom classes for this.
 
+```html
+<template>
+  <b-card no-body>
+    <b-tabs card v-model="tabIndex">
+      <b-tab title="Tab 1" :title-link-class="linkClass(0)">
+        Tab Contents 1
+      </b-tab>
+      <b-tab title="Tab 2" :title-link-class="linkClass(1)">
+        Tab Contents 2
+      </b-tab>
+      <b-tab title="Tab 3" :title-link-class="linkClass(2)">
+        Tab Contents 3
+      </b-tab>
+    </b-tabs>
+  </b-card>
+</template>
+
+<script>
+  export default {
+    data: {
+      tabIndex: 0
+    },
+    methods: {
+      linkClass(idx) {
+        if (this.tabIndex === idx) {
+          return ['bg-success', 'text-light', 'font-weight-bold'];
+        } else {
+          return ['bg-info', 'text-light'];
+        }
+      }
+    }
+  }
+</script>
+
+<!-- with-classes.vue -->
+```
+
 
 ## Advanced Examples
 
@@ -138,7 +175,7 @@ your custom classes for this.
   export default {
     data: {
       tabIndex: 0
-    },
+    }
   }
 </script>
 

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -120,9 +120,9 @@ your custom classes for this.
     methods: {
       linkClass(idx) {
         if (this.tabIndex === idx) {
-          return ['bg-success', 'text-light', 'font-weight-bold'];
+          return ['bg-primary', 'text-light'];
         } else {
-          return ['bg-info', 'text-light'];
+          return ['bg-light', 'text-info'];
         }
       }
     }

--- a/src/components/tabs/tab.vue
+++ b/src/components/tabs/tab.vue
@@ -87,12 +87,12 @@
             },
             titleItemClass: {
                 // Sniffed by tabs.vue and added to nav 'li.nav-item'
-                type: [String, Array],
+                type: [String, Array, Object],
                 default: null
             },
             titleLinkClass: {
                 // Sniffed by tabs.vue and added to nav 'a.nav-link'
-                type: [String, Array],
+                type: [String, Array, Object],
                 default: null
             },
             headHtml: {

--- a/src/components/tabs/tab.vue
+++ b/src/components/tabs/tab.vue
@@ -85,8 +85,13 @@
                 type: String,
                 default: ''
             },
-            titleClass: {
+            titleItemClass: {
                 // Sniffed by tabs.vue and added to nav 'li.nav-item'
+                type: [String, Array],
+                default: null
+            },
+            titleLinkClass: {
+                // Sniffed by tabs.vue and added to nav 'a.nav-link'
                 type: [String, Array],
                 default: null
             },

--- a/src/components/tabs/tab.vue
+++ b/src/components/tabs/tab.vue
@@ -85,6 +85,11 @@
                 type: String,
                 default: ''
             },
+            titleClass: {
+                // Sniffed by tabs.vue and added to nav 'li.nav-item'
+                type: [String, Array],
+                default: null
+            },
             headHtml: {
                 type: String,
                 default: null

--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -18,8 +18,8 @@
                 @keydown.shift.right="setTab(tabs.length-1,false,-1)"
                 @keydown.shift.down="setTab(tabs.length-1,false,-1)"
             >
-                <li class="'nav-item" v-for="(tab, index) in tabs" role="presentation">
-                    <a :class="['nav-link',{active: tab.localActive, disabled: tab.disabled}]"
+                <li :class="['nav-item', tab.titleItemClass]" v-for="(tab, index) in tabs" role="presentation">
+                    <a :class="['nav-link',{active: tab.localActive, disabled: tab.disabled}, tab.titleLinkClass]"
                        :href="tab.href"
                        role="tab"
                        :aria-setsize="tabs.length"


### PR DESCRIPTION
Adds two new props to `<b-tab>`:
- `title-item-class` - gets added to the outer `<li class="nav-item">` element
- `title-link-class` - gets added to the inner `<a class="nav-link>` element

Closes issue #1265
