### PR TITLE
feat(pagination): New prop for adding link to the last page in pagination

### DIFF
--- a/src/components/pagination/pagination.vue
+++ b/src/components/pagination/pagination.vue
@@ -74,6 +74,25 @@
             <span class="page-link" v-html="ellipsisText"></span>
         </li>
 
+        <!-- Last Page Link -->
+        <li v-if="showLastPage && showLastDots" role="none presentation">
+          <a :class="pageLinkClasses(numberOfPages)"
+             :disabled="disabled"
+             :aria-disabled="disabled ? 'true' : null"
+             :aria-label="labelPage + ' ' + numberOfPages"
+             :aria-checked="isActive(numberOfPages) ? 'true' : 'false'"
+             :aria-controls="ariaControls || null"
+             :aria-posinset="numberOfPages"
+             :aria-setsize="numberOfPages"
+             role="menuitemradio"
+             href="#"
+             :tabindex="isActive(numberOfPages) ? '0' : '-1'"
+             @click.prevent="setPage($event, numberOfPages)"
+             @keydown.enter.prevent="setPage($event, numberOfPages)"
+             @keydown.space.prevent="setPage($event, numberOfPages)"
+          >{{ numberOfPages }}</a>
+        </li>
+
         <!-- Goto Next page -->
         <li v-if="isActive(numberOfPages) || disabled" class="page-item disabled" role="none presentation" aria-hidden="true">
             <span class="page-link" v-html="nextText"></span>

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -90,6 +90,10 @@ const props = {
     ellipsisText: {
         type: String,
         default: '&hellip;'
+    },
+    showLastPage: {
+      type: Boolean,
+      default: false
     }
 };
 


### PR DESCRIPTION
This PR provides property for showing link to the last page in pagination (like a button with number not like arrow to the first or last). Link will be show only if last ellipsis are shown (looks sensibly for me). It is necessary when need to show how many pages we have.