### PR TITLE
docs(link): Document b-link component

### DIFF
--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -147,19 +147,25 @@ If using toggle button style for a radio or checkbox style interface, it is best
 built-in `button` style support of [`<b-form-radio-group>`](/docs/components/form-radios) and
 [`b-checkbox-group>`](/docs/components/form-checkboxes).
 
+
 ## Router link support
 
-Refer to [`vue-router`](https://router.vuejs.org/) docs for the various `<router-link>` related props.
+Refer to the [`Router support`](/docs/reference/router/links) reference docs for the
+various supported `<router-link>` related props.
 
-Note the `tag` attribute for `<router-link>` is referred to as `router-tag` in `bootstrap-vue`.
+Note the `<router-link>` prop `tag` is referred to as `router-tag` in `bootstrap-vue`.
+
 
 ## Button component alias
 
 `<b-button>` can also be used by its shorter alias `<b-btn>`.
 
+
 ## See also
 
-- [`<b-button-group>`](./button-group)
-- [`<b-button-toolbar>`](./button-toolbar)
+- [`<b-button-group>`](/docs/components/button-group)
+- [`<b-button-toolbar>`](/docs/components/button-toolbar)
+- [`<b-link>`](/docs/compoents/link)
+
 
 ## Component Reference

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -1,6 +1,5 @@
 import bButton from './button';
 import bButtonClose from './button-close';
-import bLink from './link';
 import { registerComponents, vueUse } from '../../utils';
 
 /* eslint-disable no-var, no-undef, guard-for-in, object-shorthand */
@@ -9,8 +8,7 @@ const components = {
   bButton,
   bBtn: bButton,
   bButtonClose,
-  bBtnClose: bButtonClose,
-  bLink
+  bBtnClose: bButtonClose
 };
 
 const VuePlugin = {

--- a/src/components/button/link.js
+++ b/src/components/button/link.js
@@ -1,3 +1,0 @@
-import bLink from '../link/link';
-
-export default bLink;

--- a/src/components/button/package.json
+++ b/src/components/button/package.json
@@ -5,7 +5,6 @@
         "title": "Button",
         "component": "bButton",
         "components": [
-            "bLink",
             "bButtonClose"
         ],
         "events": [

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -35,8 +35,17 @@ Disable link functionality by setting the `disabled` prop to true.
 ```
 
 Disabling a link will set the Bootstrap V4 `.disabled` class on the link
-(for proper styling) as well as handles stoping event propegation and preventing
-the default action from occuring.
+as well as handles stoping event propegation and preventing the default action
+from occuring.
+
+**Note:** Boostrap V4 CSS currently does not style disbled links differently than
+non-disabled links. You can use hte following custom CSS to style disabled links:
+
+```css
+a.disabled {
+  pointer-events: none;
+}
+```
 
 
 ## Component Reference

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -34,8 +34,9 @@ Disable link functionality by setting the `disabled` prop to true.
 <!-- link-disabled.vue -->
 ```
 
-Disabling a link will set teh `.disabled` class on the link as well as stoping event
-propegation and prevents the default action from occuring.
+Disabling a link will set the Bootstrap V4 `.disabled` class on the link
+(for proper styling) as well as handles stoping event propegation and preventing
+the default action from occuring.
 
 
 ## Component Reference

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -1,7 +1,7 @@
 # Links
 
 > Use Bootstrap-Vue’s custom `b-link` component for generating a standard link or `<router-link>`.
-`<b-link>` supports the `disabled` state and `click` event propegation.
+`<b-link>` supports the `disabled` state and `click` event propagation.
 
 `<b-link>` is the building block for most Bootstrap-Vue components that offer link functionality.
 
@@ -28,7 +28,7 @@ Disable link functionality by setting the `disabled` prop to true.
 
 ```html
 <div>
-   <b-link href="#foo" disabled=>Disabled Link</b-link>
+   <b-link href="#foo" disabled>Disabled Link</b-link>
 </div>
 
 <!-- link-disabled.vue -->

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -1,0 +1,41 @@
+# Links
+
+> Use Bootstrap-Vue’s custom `b-link` component for generating a standard link or `<router-link>`.
+`<b-link>` supports the `disabled` state and `click` event propegation.
+
+`<b-link>` is the building block for most Bootstrap-Vue components that offer link functionality.
+
+```html
+<div>
+   <b-link href="#foo">Link</b-link>
+</div>
+
+<!-- link-example.vue -->
+```
+
+
+## Link type
+
+By specifying a value in the `href` prop, a standard link (`<a>`) element will be rendered.
+To generate a `<router-link>` instead, specify the route location via the `to` prop.
+
+Router links support various additional props.  Refer to the [Router support](/docs/reference/router-links)
+reference section for details.
+
+## Link disabled state
+
+Disable link functionality by setting the `disabled` prop to true.
+
+```html
+<div>
+   <b-link href="#foo" disabled=>Disabled Link</b-link>
+</div>
+
+<!-- link-disabled.vue -->
+```
+
+Disabling a link will set teh `.disabled` class on the link as well as stoping event
+propegation and prevents the default action from occuring.
+
+
+## Component Reference

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -1,7 +1,7 @@
 # Links
 
-> Use Bootstrap-Vue’s custom `b-link` component for generating a standard link or `<router-link>`.
-`<b-link>` supports the `disabled` state and `click` event propagation.
+> Use Bootstrap-Vue’s custom `b-link` component for generating a standard `<a>` link or
+`<router-link>`. `<b-link>` supports the `disabled` state and `click` event propagation.
 
 `<b-link>` is the building block for most Bootstrap-Vue components that offer link functionality.
 

--- a/src/components/link/package.json
+++ b/src/components/link/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@bootstrap-vue/link",
+    "version": "1.0.0",
+    "meta": {
+        "title": "Link",
+        "component": "bLink",
+        "events": [
+            {
+                "event": "click",
+                "description": "when link clicked"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds documentation for the `<b-link>` component,

And makes it available as a basic plugin.  Removes the inclusion of `b-link` in the `button` plugin.