### PR TITLE
[SSR/Nuxt] Change the way bootstrap-vue is imported

### DIFF
--- a/nuxt/plugin.js
+++ b/nuxt/plugin.js
@@ -1,4 +1,4 @@
 import Vue from 'vue'
-import BootstrapVue from 'bootstrap-vue'
+import BootstrapVue from 'bootstrap-vue/dist/bootstrap-vue.esm'
 
 Vue.use(BootstrapVue)


### PR DESCRIPTION
This way it will work with nuxt, without error.