### PR TITLE
fix(input-group): correct input-group right addon via prop

### DIFF
--- a/src/components/input-group/input-group.js
+++ b/src/components/input-group/input-group.js
@@ -43,7 +43,7 @@ export default {
         // Right slot / prop
         if (slots().right) {
             childNodes.push(slots().right);
-        } else if (props.left) {
+        } else if (props.right) {
             childNodes.push(h(InputGroupAddon, { domProps: { innerHTML: props.right } }))
         }
       


### PR DESCRIPTION
Found this issue on >=1.0.0, appeared in commit bd4c3c3.