### PR TITLE
fix(modal): modal-open body class lost when switching between modals

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -414,7 +414,7 @@
                 this.setScrollbar();
                 this.adjustDialog();
                 addClass(document.body, 'modal-open');
-                removeClass(document.body, 'modal-closing');
+                removeClass(document.body, 'b-modal-closing');
                 this.setResizeEvent(true);
             },
             onEnter() {
@@ -438,16 +438,16 @@
             onBeforeLeave() {
                 this.is_transitioning = true;
                 this.setResizeEvent(false);
-                addClass(document.body, 'modal-closing');
+                addClass(document.body, 'b-modal-closing');
             },
             onLeave() {
                 // Remove the 'show' class
                 this.is_show = false;
             },
             onAfterLeave() {
-                if (hasClass(document.body, 'modal-closing')) {
+                if (hasClass(document.body, 'b-modal-closing')) {
                     removeClass(document.body, 'modal-open');
-                    removeClass(document.body, 'modal-closing');
+                    removeClass(document.body, 'b-modal-closing');
                 }
                 this.is_block = false;
                 this.resetAdjustments();

--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -106,7 +106,7 @@
     import { idMixin, listenOnRootMixin } from '../../mixins';
     import { observeDom, warn } from '../../utils';
     import BvEvent from '../../utils/bv-event.class';
-    import { isVisible, selectAll, select, getBCR, addClass, removeClass, setAttr, removeAttr, getAttr, hasAttr, eventOn, eventOff } from '../../utils/dom';
+    import { isVisible, selectAll, select, getBCR, addClass, removeClass, hasClass, setAttr, removeAttr, getAttr, hasAttr, eventOn, eventOff } from '../../utils/dom';
 
     const Selector = {
         FIXED_CONTENT: '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top',
@@ -414,6 +414,7 @@
                 this.setScrollbar();
                 this.adjustDialog();
                 addClass(document.body, 'modal-open');
+                removeClass(document.body, 'modal-closing');
                 this.setResizeEvent(true);
             },
             onEnter() {
@@ -437,13 +438,17 @@
             onBeforeLeave() {
                 this.is_transitioning = true;
                 this.setResizeEvent(false);
+                addClass(document.body, 'modal-closing');
             },
             onLeave() {
                 // Remove the 'show' class
                 this.is_show = false;
             },
             onAfterLeave() {
-                removeClass(document.body, 'modal-open');
+                if (hasClass(document.body, 'modal-closing')) {
+                    removeClass(document.body, 'modal-open');
+                    removeClass(document.body, 'modal-closing');
+                }
                 this.is_block = false;
                 this.resetAdjustments();
                 this.resetScrollbar();


### PR DESCRIPTION
This fixes #1325, preventing `modal-open` class lost on document body when a new modal opens before the previous one's transition is over.

This sets a new custom class `modal-closing` on body during transition, I am not sure if that's appropriate. It could probably be better to use a flag variable on `this.$root`.