### PR TITLE
perf: reduce minified code size

### DIFF
--- a/build/build
+++ b/build/build
@@ -15,8 +15,10 @@ rollup -c build/rollup.config.esm.js
 uglify=`pwd`/node_modules/.bin/uglifyjs
 cd dist
 
+# We use --mangle but not --compress to reduce file size
+# --compress unfortunately removes the 'imports' from the top of hte ESM build
 for f in *.js; do
     o=`echo $f | sed s/\.js/.min.js/`
     echo "$f ~> $o"
-    $uglify $f --source-map -o $o
+    $uglify $f --mangle --source-map -o $o
 done


### PR DESCRIPTION
Using Uglify's `--mangle` option.

The `--compress` option unfortunately removes the two `import` lines from the ESM build. Because of that we don't include the `--compress` option, unless we individually compress each file with different options. i.e setting the ES level to 6 for the ESM build.