### PR TITLE
feat(table): caption positioning prop

### DIFF
--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -443,8 +443,7 @@ export default {
 ## Table caption
 Add an optional caption to your table via the prop `caption` or the named
 slot `table-caption` (the slot takes precedence over the prop). The default
-Bootstrap V4 styling places the caption at the bottom of the table. You can
-override the position via [custom CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side).
+Bootstrap V4 styling places the caption at the bottom of the table:
 
 ```html
 <template>
@@ -470,6 +469,38 @@ export default {
 
 <!-- table-caption.vue -->
 ```
+
+You can have the caption placed at the top of the table by setting the
+`caption-top` prop to `true`:
+
+```html
+<template>
+  <b-table :items="items" :fields="fields" caption-top>
+    <template slot="table-caption">
+      This is a table caption at the top.
+    </template>
+  </b-table>
+</template>
+
+<script>
+export default {
+  data: {
+    fields: [ 'first_name', 'last_name', 'age' ],
+    items: [
+      { age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
+      { age: 21, first_name: 'Larsen', last_name: 'Shaw' },
+      { age: 89, first_name: 'Geneva', last_name: 'Wilson' }
+    ]
+  }
+};
+</script>
+
+<!-- table-caption-top.vue -->
+```
+
+You can also use [custom CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side)
+to control the caption positioning.
+
 
 ## Table colgroup
 Use the named slot `table-colgroup` to specify `<colgroup>` and `<col>` elements

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -2,7 +2,7 @@
     <table :id="id || null"
            :aria-busy="computedBusy ? 'true' : 'false'"
            :class="tableClasses">
-        <caption v-if="caption || $slots['table-caption']">
+        <caption v-if="caption || $slots['table-caption']" :style="captionStyles">
             <slot name="table-caption"><div v-html="caption"></div></slot>
         </caption>
         <colgroup v-if="$slots['table-colgroup']">
@@ -203,6 +203,10 @@ export default {
         caption: {
             type: String,
             default: null
+        },
+        captionTop: {
+            type: Boolean,
+            default: false
         },
         items: {
             type: [Array, Function],
@@ -440,6 +444,10 @@ export default {
         footClasses() {
             const variant = this.footVariant || this.headVariant || null;
             return variant ? 'thead-' + variant : '';
+        },
+        captionClasses() {
+            // Move caption to top
+            return this.captionTop ? { captionSide: 'top' } : {};
         },
         hasProvider() {
             return this.items instanceof Function;

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -445,7 +445,7 @@ export default {
             const variant = this.footVariant || this.headVariant || null;
             return variant ? 'thead-' + variant : '';
         },
-        captionClasses() {
+        captionStyles() {
             // Move caption to top
             return this.captionTop ? { captionSide: 'top' } : {};
         },


### PR DESCRIPTION
Adds a Boolean prop `caption-top`, which when set will move the caption to the top of the table

Since merging this would live update the online documentation, we should wait to merge once we are ready to release v1.0.3