### PR TITLE
fix(button-close): switch to slots() from children

### DIFF
--- a/src/components/button/button-close.js
+++ b/src/components/button/button-close.js
@@ -18,7 +18,7 @@ const props = {
 export default {
     functional: true,
     props,
-    render(h, { props, data, listeners, children }) {
+    render(h, { props, data, listeners, slots }) {
         const componentData = {
             staticClass: "close",
             class: {
@@ -40,9 +40,9 @@ export default {
             }
         };
         // Careful not to override the slot with innerHTML
-        if (!children.length) {
-            componentData.domProps = { innerHTML: "×" };
+        if (!slots().default) {
+            componentData.domProps = { innerHTML: "&times;" };
         }
-        return h("button", mergeData(data, componentData), children);
+        return h("button", mergeData(data, componentData), slots().default);
     }
 };


### PR DESCRIPTION
Switching from `children` to `slots().default` appears to fix the original issue with SSR rendering of `&times;`