### PR TITLE
feat(table): add outlined option

### DIFF
--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -288,6 +288,7 @@ fields: [
 | ---- | -----------
 | `striped` | Add zebra-striping to the table rows within the `<tbody>`
 | `bordered` | For borders on all sides of the table and cells.
+| `outlined` | For a border on all sides of the table.
 | `small` | To make tables more compact by cutting cell padding in half.
 | `hover` | To enable a hover highlighting state on table rows within a `<tbody>`
 | `dark` | Invert the colors — with light text on dark backgrounds (equivalent to Bootstrap V4 class `.table-dark`)

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -385,6 +385,10 @@
                 type: Boolean,
                 default: false
             },
+            outlined: {
+                type: Boolean,
+                default: false
+            },
             dark: {
                 type: Boolean,
                 default() {
@@ -580,6 +584,7 @@
                     this.hover ? 'table-hover' : '',
                     this.dark ? 'table-dark' : '',
                     this.bordered ? 'table-bordered' : '',
+                    this.outlined ? 'bordered' : '',
                     responsive === true ? 'table-responsive' : (Boolean(responsive) ? `table-responsive-${responsive}` : ''),
                     this.fixed ? 'table-fixed' : '',
                     this.small ? 'table-sm' : ''


### PR DESCRIPTION
Adds a new option to draw a border around the table (outline), via the Boolean prop `outlined`.  When enabled the Bootstrap V4 class `bordered` is added to the table