### PR TITLE
feat(tabs): vertical tabs + new props for adding classes to inner elements

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -64,6 +64,92 @@ the pill style variant.
 <!-- tabs-pills.vue -->
 ```
 
+## Bottom placement of tab controls
+
+Move the tab controls to the bottom by setting the prop `end`
+
+```html
+<b-card no-body>
+    <b-tabs pills card end>
+        <b-tab title="Tab 1" active>
+            Tab Contents
+        </b-tab>
+        <b-tab title="Tab 2">
+            Tab Contents 2
+        </b-tab>
+    </b-tabs>
+</b-card>
+
+<!-- tabs-bottom.vue -->
+```
+
+**Note:** the `bottom` prop has been deprecated in favor of the `end` prop.
+
+## Vertical tabs
+
+Have the tab controls placed on the lefthand side by setting the `vertical` prop to `true`.
+
+```html
+<b-card no-body>
+    <b-tabs pills card virtical>
+        <b-tab title="Tab 1" active>
+            Tab Contents
+        </b-tab>
+        <b-tab title="Tab 2">
+            Tab Contents 2
+        </b-tab>
+        <b-tab title="Tab 3">
+            Tab Contents 3
+        </b-tab>
+    </b-tabs>
+</b-card>
+
+<!-- tabs-vertical.vue -->
+```
+
+Move the tab controls to the right hand side by setting the `end` prop:
+
+```html
+<b-card no-body>
+    <b-tabs pills card virtical end>
+        <b-tab title="Tab 1" active>
+            Tab Contents
+        </b-tab>
+        <b-tab title="Tab 2">
+            Tab Contents 2
+        </b-tab>
+        <b-tab title="Tab 3">
+            Tab Contents 3
+        </b-tab>
+    </b-tabs>
+</b-card>
+
+<!-- tabs-vertical-end.vue -->
+```
+
+The width of the vertical tab controls will expand to fit the width of the tab title.
+To control the width, set a [width utility class](/docs/reference/size-props#sizing-utility-classes)
+via the prop `nav-wrapper-class`. You can use values such as `w-25` (25% width), `w-50` (50% width),
+or max-width vlaues such as `mw-25` or `mw-50`.
+
+```html
+<b-card no-body>
+    <b-tabs pills card virtical nav-wrapper-class="w-50">
+        <b-tab title="Tab 1" active>
+            Tab Contents
+        </b-tab>
+        <b-tab title="Tab 2">
+            Tab Contents 2
+        </b-tab>
+        <b-tab title="Tab 3">
+            Tab Contents 3
+        </b-tab>
+    </b-tabs>
+</b-card>
+
+<!-- tabs-vertical-width.vue -->
+```
+
 
 ## Fade animation
 

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -91,7 +91,7 @@ Have the tab controls placed on the lefthand side by setting the `vertical` prop
 
 ```html
 <b-card no-body>
-    <b-tabs pills card virtical>
+    <b-tabs pills card vertical>
         <b-tab title="Tab 1" active>
             Tab Contents
         </b-tab>
@@ -111,7 +111,7 @@ Move the tab controls to the right hand side by setting the `end` prop:
 
 ```html
 <b-card no-body>
-    <b-tabs pills card virtical end>
+    <b-tabs pills card vertical end>
         <b-tab title="Tab 1" active>
             Tab Contents
         </b-tab>
@@ -129,12 +129,12 @@ Move the tab controls to the right hand side by setting the `end` prop:
 
 The width of the vertical tab controls will expand to fit the width of the tab title.
 To control the width, set a [width utility class](/docs/reference/size-props#sizing-utility-classes)
-via the prop `nav-wrapper-class`. You can use values such as `w-25` (25% width), `w-50` (50% width),
-or max-width vlaues such as `mw-25` or `mw-50`.
+via the prop `nav-wrapper-class`. You can use values such as `w-25` (25% width), `w-50` (50% width), etc.,
+or column classes such as `col-2`, `col-3`, etc.
 
 ```html
 <b-card no-body>
-    <b-tabs pills card virtical nav-wrapper-class="w-50">
+    <b-tabs pills card vertical nav-wrapper-class="w-50">
         <b-tab title="Tab 1" active>
             Tab Contents
         </b-tab>
@@ -150,10 +150,15 @@ or max-width vlaues such as `mw-25` or `mw-50`.
 <!-- tabs-vertical-width.vue -->
 ```
 
+**Note:** overflowing text may occur if your width is narrower than the tab title. You
+may need additional custom styling.
+
 
 ## Fade animation
 
 Fade is enabled by default when changing tabs. It can disabled with `no-fade` property.
+Note you should use the `<b-nav-item>` component when adding contentless-tabs to maintain
+correct sizing and alignment. See the advanced usage examples below for an example.
 
 
 ## Add Tabs without content
@@ -178,7 +183,7 @@ In some situations, you may want to add classes to the `<li>` (nav-item) and/or 
 the `title-item-class` prop (for the `<li>` element) or `title-link-class` prop (for the
 `<a>` element).  Value's can be passed as a string or array of strings.
 
-Note: THe `ative` class is automatically applied to the `<a>` element. You may need to accomodate
+Note: THe `ative` class is automatically applied to the active tabs `<a>` element. You may need to accomodate
 your custom classes for this.
 
 ```html

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -83,7 +83,12 @@ Visually move the tab controls to the bottom by setting the prop `end`
 <!-- tabs-bottom.vue -->
 ```
 
+Bottom placement visually works best with the `pills` variant. When using the default 
+`tabs` vairiant, you may want to provided your own custom styling classes, as Bootstrap
+V4 CSS assumes the tabs will always be placed on the top of the tabs content.
+
 **Note:** the `bottom` prop has been deprecated in favor of the `end` prop.
+
 
 ## Vertical tabs
 
@@ -149,6 +154,10 @@ or column classes such as `col-2`, `col-3`, etc.
 
 <!-- tabs-vertical-width.vue -->
 ```
+
+Vertical placement visually works best with the `pills` variant. When using the default 
+`tabs` vairiant, you may want to provided your own custom styling classes, as Bootstrap
+V4 CSS assumes the tabs will always be placed on the top of the tabs content.
 
 **Note:** overflowing text may occur if your width is narrower than the tab title. You
 may need additional custom styling.

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -183,8 +183,8 @@ In some situations, you may want to add classes to the `<li>` (nav-item) and/or 
 the `title-item-class` prop (for the `<li>` element) or `title-link-class` prop (for the
 `<a>` element).  Value's can be passed as a string or array of strings.
 
-Note: THe `ative` class is automatically applied to the active tabs `<a>` element. You may need to accomodate
-your custom classes for this.
+Note: The `active` class is automatically applied to the active tabs `<a>` element. You may need
+to accomodate your custom classes for this.
 
 ```html
 <template>

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -83,9 +83,13 @@ Visually move the tab controls to the bottom by setting the prop `end`
 <!-- tabs-bottom.vue -->
 ```
 
-Bottom placement visually works best with the `pills` variant. When using the default 
+**Caveats:**
+- Bottom placement visually works best with the `pills` variant. When using the default 
 `tabs` vairiant, you may want to provided your own custom styling classes, as Bootstrap
 V4 CSS assumes the tabs will always be placed on the top of the tabs content.
+- To provide a better user experience with bottom palced controls, ensure that the
+content of each tab pane is the same height and fits completely within the visible
+viewport, otherwise the user will need to scroll up to read the start of the tabed content.
 
 **Note:** the `bottom` prop has been deprecated in favor of the `end` prop.
 

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -91,7 +91,7 @@ V4 CSS assumes the tabs will always be placed on the top of the tabs content.
 content of each tab pane is the same height and fits completely within the visible
 viewport, otherwise the user will need to scroll up to read the start of the tabed content.
 
-**Note:** the `bottom` prop has been deprecated in favor of the `end` prop.
+**Note:** _the `bottom` prop has been deprecated in favor of the `end` prop._
 
 
 ## Vertical tabs
@@ -163,8 +163,7 @@ Vertical placement visually works best with the `pills` variant. When using the 
 `tabs` vairiant, you may want to provided your own custom styling classes, as Bootstrap
 V4 CSS assumes the tabs will always be placed on the top of the tabs content.
 
-**Note:** overflowing text may occur if your width is narrower than the tab title. You
-may need additional custom styling.
+**Note:** _overflowing text may occur if your width is narrower than the tab title. You may need additional custom styling._
 
 
 ## Fade animation
@@ -196,8 +195,7 @@ In some situations, you may want to add classes to the `<li>` (nav-item) and/or 
 the `title-item-class` prop (for the `<li>` element) or `title-link-class` prop (for the
 `<a>` element).  Value's can be passed as a string or array of strings.
 
-Note: The `active` class is automatically applied to the active tabs `<a>` element. You may need
-to accomodate your custom classes for this.
+**Note:** _The `active` class is automatically applied to the active tabs `<a>` element. You may need to accomodate your custom classes for this._
 
 ```html
 <template>

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -66,7 +66,7 @@ the pill style variant.
 
 ## Bottom placement of tab controls
 
-Move the tab controls to the bottom by setting the prop `end`
+Visually move the tab controls to the bottom by setting the prop `end`
 
 ```html
 <b-card no-body>
@@ -107,7 +107,7 @@ Have the tab controls placed on the lefthand side by setting the `vertical` prop
 <!-- tabs-vertical.vue -->
 ```
 
-Move the tab controls to the right hand side by setting the `end` prop:
+Visually move the tab controls to the right hand side by setting the `end` prop:
 
 ```html
 <b-card no-body>

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -57,6 +57,7 @@ export default {
     tabClasses () {
       return [
         'tab-pane',
+        (this.$parent && this.$parent.card) ? 'card-body' : '',
         this.show ? 'show' : '',
         this.computedFade ? 'fade' : '',
         this.disabled ? 'disabled' : '',

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -116,8 +116,10 @@ export default {
         class: [
           {
             'card-header': (t.card && !t.vertical),
-            'border-bottom-0': (t.end || t.bottom),
-            'col-auto': t.vertical
+            'card-footer': (t.card && !t.vertical && (t.end || t.bottom)),
+            'col-auto': t.vertical,
+            'order-2': (t.end || t.bottom),
+            'order-1': !(t.end || t.bottom)
           },
           t.navWrapperClass
         ]
@@ -141,7 +143,15 @@ export default {
       'div',
       {
         ref: 'tabsContainer',
-        class: [ 'tab-content', { col: t.vertical }, t.contentClass ],
+        class: [
+          'tab-content',
+          {
+            col: t.vertical,
+            'order-1': (t.end || t.bottom),
+            'order-2': !(t.end || t.bottom)
+          },
+          t.contentClass
+        ],
         attrs: { id: t.safeId('_BV_tab_container_') }
       },
       [ t.$slots.default, empty ]
@@ -154,11 +164,7 @@ export default {
         class: [ 'tabs', { 'row': t.vertical, 'no-gutters': (t.vertical && t.card) } ],
         attrs: { id: t.safeId() }
       },
-      [
-        (t.end || t.bottom) ? content : h(false),
-        [ navs ],
-        (t.end || t.bottom) ? h(false) : content
-      ]
+      [ content, [ navs ] ]
     )
   },
   data () {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -115,7 +115,7 @@ export default {
       {
         class: [
           {
-            'card-header': (t.card && !t.vertical),
+            'card-header': (t.card && !t.vertical && !(t.end || t.bottom)),
             'card-footer': (t.card && !t.vertical && (t.end || t.bottom)),
             'col-auto': t.vertical,
             'order-2': (t.end || t.bottom),

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -89,38 +89,75 @@ export default {
     })
 
     // Nav 'button' wrapper
-    const navs = h(
+    let navs = h(
       'ul',
       {
-        class: [ 'nav', `nav-${t.navStyle}`, { [`card-header-${t.navStyle}`]: this.card, small: t.small }, t.navClass ],
+        class: [
+          'nav',
+          `nav-${t.navStyle}`,
+          {
+            [`card-header-${t.navStyle}`]: (t.card && !t.vertical),
+            'card-header': (t.card && t.vertical),
+            'h-100': (t.card && t.vertical),
+            'flex-column': t.vertical,
+            'border-bottom-0': t.vertical,
+            small: t.small
+          },
+          t.navClass
+        ],
         attrs: { role: 'tablist', tabindex: '0' },
         on: { keydown: t.onKeynav }
       },
       [ buttons, t.$slots.tabs ]
     )
+    navs = h(
+      'div',
+      {
+        class: [
+          {
+            'card-header': (t.card && !t.vertical),
+            'border-bottom-0': (t.end || t.bottom),
+            'col-auto': t.vertical
+          },
+          t.navWrapperClass
+        ]
+      },
+      [ navs ]
+    )
+
+    let empty
+    if (tabs && tabs.length) {
+      empty = h(false)
+    } else {
+      empty = h(
+        'div',
+        { class: [ 'tab-pane', 'active', { 'card-body': t.card } ] },
+        t.$slots.empty
+      )
+    }
 
     // Main content section
     const content = h(
       'div',
       {
         ref: 'tabsContainer',
-        class: [ 'tab-content', { 'card-body': t.card }, t.contentClass ],
+        class: [ 'tab-content', { col: t.vertical }, t.contentClass ],
         attrs: { id: t.safeId('_BV_tab_container_') }
       },
-      [ t.$slots.default, (tabs && tabs.length) ? h(false) : t.$slots.empty ]
+      [ t.$slots.default, empty ]
     )
 
     // Render final output
     return h(
       t.tag,
       {
-        class: [ 'tabs' ],
+        class: [ 'tabs', { 'row': t.vertical, 'no-gutters': (t.vertical && t.card) } ],
         attrs: { id: t.safeId() }
       },
       [
-        t.bottom ? content : h(false),
-        h('div', { class: [ { 'card-header': t.card }, t.navWrapperClass ] }, [ navs ]),
-        t.bottom ? h(false) : content
+        (t.end || t.bottom) ? content : h(false),
+        [ navs ],
+        (t.end || t.bottom) ? h(false) : content
       ]
     )
   },
@@ -151,7 +188,16 @@ export default {
       type: Boolean,
       default: false
     },
+    vertical: {
+      type: Boolean,
+      default: false
+    },
     bottom: {
+      type: Boolean,
+      default: false
+    },
+    end: {
+      // Synonym for 'bottom'
       type: Boolean,
       default: false
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -92,7 +92,7 @@ export default {
     const navs = h(
       'ul',
       {
-        class: [ 'nav', `nav-${t.navStyle}`, { [`card-header-${t.navStyle}`]: this.card, small: t.small } ],
+        class: [ 'nav', `nav-${t.navStyle}`, { [`card-header-${t.navStyle}`]: this.card, small: t.small }, t.navClass ],
         attrs: { role: 'tablist', tabindex: '0' },
         on: { keydown: t.onKeynav }
       },
@@ -104,7 +104,7 @@ export default {
       'div',
       {
         ref: 'tabsContainer',
-        class: [ 'tab-content', { 'card-body': t.card } ],
+        class: [ 'tab-content', { 'card-body': t.card }, t.contentClass ],
         attrs: { id: t.safeId('_BV_tab_container_') }
       },
       [ t.$slots.default, (tabs && tabs.length) ? h(false) : t.$slots.empty ]
@@ -119,7 +119,7 @@ export default {
       },
       [
         t.bottom ? content : h(false),
-        h('div', { class: { 'card-header': t.card } }, [ navs ]),
+        h('div', { class: [ { 'card-header': t.card }, t.navWrapperClass] }, [ navs ]),
         t.bottom ? h(false) : content
       ]
     )
@@ -163,7 +163,19 @@ export default {
       // This prop is sniffed by the tab child
       type: Boolean,
       default: false
-    }
+    },
+    contentClass: {
+      type: [String, Array, Object],
+      default: null
+    },
+    navClass: {
+      type: [String, Array, Object],
+      default: null
+    },
+    navWrapperClass: {
+      type: [String, Array, Object],
+      default: null
+    },
   },
   watch: {
     currentTab (val, old) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -152,7 +152,7 @@ export default {
     return h(
       t.tag,
       {
-        class: [ 'tabs', { 'row': t.vertical,  'no-gutters': (t.vertical && t.card) } ],
+        class: [ 'tabs', { 'row': t.vertical, 'no-gutters': (t.vertical && t.card) } ],
         attrs: { id: t.safeId() }
       },
       [

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -101,6 +101,7 @@ export default {
             'h-100': (t.card && t.vertical),
             'flex-column': t.vertical,
             'border-bottom-0': t.vertical,
+            'rounded-0': t.vertical,
             small: t.small
           },
           t.navClass
@@ -164,7 +165,7 @@ export default {
         class: [ 'tabs', { 'row': t.vertical, 'no-gutters': (t.vertical && t.card) } ],
         attrs: { id: t.safeId() }
       },
-      [ content, [ navs ] ]
+      [ [ navs ], content ]
     )
   },
   data () {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -119,6 +119,7 @@ export default {
             'card-header': (t.card && !t.vertical && !(t.end || t.bottom)),
             'card-footer': (t.card && !t.vertical && (t.end || t.bottom)),
             'col-auto': t.vertical,
+            'col-12': !t.vertical,
             'order-2': (t.end || t.bottom),
             'order-1': !(t.end || t.bottom)
           },
@@ -147,7 +148,8 @@ export default {
         class: [
           'tab-content',
           {
-            col: t.vertical,
+            'col': t.vertical,
+            'col-12': !t.vertical,
             'order-1': (t.end || t.bottom),
             'order-2': !(t.end || t.bottom)
           },
@@ -162,7 +164,7 @@ export default {
     return h(
       t.tag,
       {
-        class: [ 'tabs', { 'row': t.vertical, 'no-gutters': (t.vertical && t.card) } ],
+        class: [ 'tabs', 'row', { 'no-gutters': (t.vertical && t.card) } ],
         attrs: { id: t.safeId() }
       },
       [ [ navs ], content ]

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -119,7 +119,7 @@ export default {
       },
       [
         t.bottom ? content : h(false),
-        h('div', { class: [ { 'card-header': t.card }, t.navWrapperClass] }, [ navs ]),
+        h('div', { class: [ { 'card-header': t.card }, t.navWrapperClass ] }, [ navs ]),
         t.bottom ? h(false) : content
       ]
     )
@@ -175,7 +175,7 @@ export default {
     navWrapperClass: {
       type: [String, Array, Object],
       default: null
-    },
+    }
   },
   watch: {
     currentTab (val, old) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -106,7 +106,7 @@ export default {
           },
           t.navClass
         ],
-        attrs: { role: 'tablist', tabindex: '0' },
+        attrs: { role: 'tablist', tabindex: '0', id: t.safeId('_BV_tab_controls_') },
         on: { keydown: t.onKeynav }
       },
       [ buttons, t.$slots.tabs ]
@@ -118,10 +118,7 @@ export default {
           {
             'card-header': (t.card && !t.vertical && !(t.end || t.bottom)),
             'card-footer': (t.card && !t.vertical && (t.end || t.bottom)),
-            'col-auto': t.vertical,
-            'col-12': !t.vertical,
-            'order-2': (t.end || t.bottom),
-            'order-1': !(t.end || t.bottom)
+            'col-auto': t.vertical
           },
           t.navWrapperClass
         ]
@@ -145,16 +142,7 @@ export default {
       'div',
       {
         ref: 'tabsContainer',
-        class: [
-          'tab-content',
-          {
-            'col': t.vertical,
-            'col-12': !t.vertical,
-            'order-1': (t.end || t.bottom),
-            'order-2': !(t.end || t.bottom)
-          },
-          t.contentClass
-        ],
+        class: [ 'tab-content', { 'col': t.vertical }, t.contentClass ],
         attrs: { id: t.safeId('_BV_tab_container_') }
       },
       [ t.$slots.default, empty ]
@@ -164,10 +152,14 @@ export default {
     return h(
       t.tag,
       {
-        class: [ 'tabs', 'row', { 'no-gutters': (t.vertical && t.card) } ],
+        class: [ 'tabs', { 'row': t.vertical,  'no-gutters': (t.vertical && t.card) } ],
         attrs: { id: t.safeId() }
       },
-      [ [ navs ], content ]
+      [
+        (t.end || t.bottom) ? content : h(false),
+        [ navs ],
+        (t.end || t.bottom) ? h(false) : content
+      ]
     )
   },
   data () {


### PR DESCRIPTION
Adds support for vertical tabs via the `vertical` prop

Also adds the following new props:
- `container-class` added to the `.tab-container` div
- `nav-class` added to the `.nav` tab controls
- `nav-wrapper-class` added to div wrapper around nav tab controls

