### PR TITLE
feat(modal): fix for overflowing centered modal

### DIFF
--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -288,13 +288,6 @@ Vertically center your modal in the viewport by setting the `centered` prop.
 <!-- modal-center-v.vue -->
 ```
 
-**Warning:** Vertically centered modals are not suited for when the content is tall.
-They are best suited when the content is only one or two lines, such as Yes/No or
-OK/Cancel confirmation dialogs. When the resultant modal is taller than the viewport,
-the modal header (and parts of the top of the modal content) will become inaccessible.
-This issue becomes more prevalent on smaller screens.
-
-
 ## Using the grid
 Utilize the Bootstrap grid system within a modal by nesting `<b-container fluid>` within
 the modal-body. Then, use the normal grid system `<b-row>` (or `<b-form-row>`) and `<b-col>`

--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -8,9 +8,7 @@
     .modal-dialog-centered {
         display: flex;
         align-items: center;
-        height: 100%;
-        margin-top: 0 !important;
-        margin-bottom: 0 !important;
+        min-height: calc(100% - 30px);
     }
     .modal-dialog-centered .modal-content {
         width: 100%;


### PR DESCRIPTION
Based on changes introduced via https://github.com/twbs/bootstrap/pull/24803

Prevents header from getting cut off when vertically centered modal overflows.

Once Bootstrap V4.beta.3 is released, the custom CSS can be removed from the component.