### PR TITLE
fix(form-textarea): initial value population

### DIFF
--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -13,6 +13,7 @@ export default {
         directives: [
           { name: 'model', rawName: 'v-model', value: t.localValue, expression: 'localValue' }
         ],
+        domProps: { value: t.value },
         attrs: {
           id: t.safeId(),
           name: t.name,


### PR DESCRIPTION
`<b-form-textarea>` wasn't pre-populating the text area value on mount.

Closes #1368