### PR TITLE
feat(tooltip+popover): programmatically disable/enable tooltip or popover

### DIFF
--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -36,7 +36,7 @@ code {
 }
 
 blockquote {
-  font-size: 1.25rem;
+  font-size: 1.1rem;
   font-weight: 300;
 }
 

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -270,7 +270,8 @@ Setting it to `true` will show the popover, while setting it to `false` will hid
 <!-- popover-show-sync.vue -->
 ```
 
-Programmatic control can also be affected by submitting `'open'` and `'close'` events to the popover by reference.
+Programmatic control can also be affected by submitting `'open'` and `'close'`
+events to the popover by reference.
 
 ```html
 <template>
@@ -397,11 +398,12 @@ triggers and handle control yourself as demonstrated by the second Popover.
 You can also use `$root` events to trigger the showing and hiding of popover(s).
 See the **Hiding and showing popovers via $root events** section below for details.
 
-### Disabling popover
+### Programmatically disabling popover
 
 You can disable popover via the Boolean prop `disabled` (default is `false`)
 Setting it to `true` will disable the popover. If the popover is currently visible
-when disabled is set to `false`, the popover will close.
+when disabled is set to `false`, it will remain visible until it is enabled or
+programmatically closed..
 
 ```html
 <template>
@@ -434,8 +436,47 @@ when disabled is set to `false`, the popover will close.
 <!-- popover-disable.vue -->
 ```
 
-When disabled, the popover cannot be opened programmatically (either via the `show` prop,
+Programmatic control can also be affected by submitting `'enable'` and `'disable'`
+events to the popover by reference.
+
+```html
+<template>
+  <div class="d-flex flex-column text-md-center">
+    <div class="p-2">
+      <b-btn id="popoverButton-disableevent" variant="primary">I have a popover</b-btn>
+    </div>
+    <div class="p-2">
+      <b-btn class="px-1" @click="onEnable">Enable</b-btn>
+      <b-btn class="px-1" @click="onDisable">Disable</b-btn>
+    </div>
+
+    <b-popover ref="popover" target="popoverButton-disableevent" title="Popover">
+      Hello <strong>World!</strong>
+    </b-popover>
+  </div>
+</template>
+
+<script>
+  export default {
+    methods: {
+      onEnable() {
+        this.$refs.popover.$emit('enable')
+      },
+      onDisable() {
+        this.$refs.popover.$emit('disable')
+      }
+    }
+  }
+</script>
+
+<!-- popover-disabled-event.vue -->
+```
+
+When disabled, the popover can be opened programmatically (either via the `show` prop,
 methods or events).
+
+You can also use `$root` events to trigger disabling and enabling of popover(s).
+See the **Disabling and enabling popovers via $root events** section below for details.
 
 
 ## `v-b-popover` Directive usage
@@ -631,29 +672,61 @@ export default {
 ```
 
 ## Hiding and showing popovers via $root events
-You can close (hide) all open popovers by emitting the `bv::hide::popover` event on $root:
+You can close (hide) **all open popovers** by emitting the `bv::hide::popover` event on $root:
 
 ```js
 this.$root.$emit('bv::hide::popover');
 ```
 
-To close a specific popover, pass the trigger element's `id` as the first argument:
+To close a **specific popover**, pass the trigger element's `id` as the first argument:
 
 ```js
 this.$root.$emit('bv::show::popover', 'my-trigger-button-id');
 ```
 
-To open (show) a specific popover, pass the trigger element's `id` as the first argument when
+To open (show) a **specific popover**, pass the trigger element's `id` as the first argument when
 emitting the `bv::show::popover` event:
 
 ```js
 this.$root.$emit('bv::show::popover', 'my-trigger-button-id');
 ```
 
+To open all popovers simultaneously, omit the `id` argument when emitting the
+`bv::show::popover` event.
+
+These events work for both the component **and** directive versions of popover.
+
+Note the **trigger element** must exist in the DOM and be in a visible state in order for the
+popover to instantiate and show.
+
+
+## Disabling and enabling popovers via $root events
+You can disable **all** popovers by emitting the `bv::disable::popover` event on $root:
+
+```js
+this.$root.$emit('bv::disable::popover');
+```
+
+To disable a **specific popover**, pass the trigger element's `id` as the first argument:
+
+```js
+this.$root.$emit('bv::disable::popover', 'my-trigger-button-id');
+```
+
+To enable a **specific popover**, pass the trigger element's `id` as the first argument when
+emitting the `bv::enable::popover` event:
+
+```js
+this.$root.$emit('bv::enable::popover', 'my-trigger-button-id');
+```
+
+To enable all popovers simultaneously, omit the `id` argument when emitting the
+`bv::enable::popover` event.
+
 These events work for both the component and directive versions of popover.
 
-Note the trigger element must exist in the DOM and be in a visible state in order for the
-popover to show.
+Note the **trigger element** must exist in the DOM and be in a visible state in order for the
+popover to be enabled or disabled.
 
 
 ## Accessibility

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -397,6 +397,46 @@ triggers and handle control yourself as demonstrated by the second Popover.
 You can also use `$root` events to trigger the showing and hiding of popover(s).
 See the **Hiding and showing popovers via $root events** section below for details.
 
+### Disabling popover
+
+You can disable popover via the Boolean prop `disabled` (default is `false`)
+Setting it to `true` will disnable the popover. If the popover is currently visible
+when disabled is set to `false`, the popover will close.
+
+```html
+<template>
+  <div class="d-flex flex-column text-md-center">
+    <div class="p-2">
+      <b-btn id="popoverButton-disable" variant="primary">I have a popover</b-btn>
+    </div>
+    <div class="p-2">
+      <b-btn class="px-1" @click="disabled = !disabled">
+        {{ disabled ? 'Enable' : 'Disable' }} Popover
+      </b-btn>
+
+      <b-popover :disabled"disabled" target="popoverButton-disable" title="Popover">
+        Hello <strong>World!</strong>
+      </b-popover>
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        disabled: false
+      }
+    }
+  }
+</script>
+
+<!-- popover-disable.vue -->
+```
+
+When disabled, the popover cannot be opened programmatically (either via the `show` prop,
+methods or events).
+
 
 ## `v-b-popover` Directive usage
 

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -154,8 +154,8 @@ Use the `focus` trigger by itself to dismiss popovers on the next click that the
 the element receive focus, assuming it is in the tab sequence of the page).
 
 You can, however, specify your trigger as `click blur`,  which will make only a
-click activate the popover, and either a click on the element, _or_ losing foucus
-to another element or part of the document, will close the popover.
+click activate the popover, and either a click on the element, _or_ losing focus
+to another element or part of the document will close the popover.
 
 The special `blur` trigger must be used in combination with the `click` trigger.
 
@@ -227,9 +227,9 @@ export default {
 
 | Prop | Default | Description | Supported values
 | ---- | ------- | ----------- | ----------------
-| `target` | `null` | String ID of element, or a reference to an element or component, that you want to trigger the popover. **Required** | Any valid, in-document unique element ID, or in-document element/component reference
-| `title` | `null` | Title of popover (text only, no HTML). if HTML is required, place it in the `title` named slot | Plain text
-| `content` | `null` | Content of popover (text only, no HTML). if HTML is required, place it in the default slot | Plain text
+| `target` | `null` | Element string ID, or a reference to an element or component, that you want to trigger the popover. **Required** | Any valid in-document unique element ID, or in-document element/component reference
+| `title` | `null` | Popover title (text only, no HTML). If HTML is required, place it in the `title` named slot | Plain text
+| `content` | `null` | Popover content (text only, no HTML). If HTML is required, place it in the default slot | Plain text
 | `placement` | `'right'` | Positioning of the popover, relative to the trigger element. | `auto`, `top`, `bottom`, `left`, `right`, `topleft`, `topright`, `bottomleft`, `bottomright`, `lefttop`, `leftbottom`, `righttop`, `rightbottom`
 | `sync` | `false` | Programmatic control of the Popover display state. Recommended to use with [sync modifier](https://vuejs.org/v2/guide/components.html#sync-Modifier). | `true`, `false`
 | `triggers` | `'click'` | Space separated list of which event(s) will trigger open/close of popover using built-in handling | `hover`, `focus`, `click`. Note `blur` is a special use case to close popover on next click.
@@ -324,12 +324,12 @@ on `<b-popover>`:
 ```
 
 A popover which is opened programmatically via the 'show' property or by an event call
-can only be closed programmatically. Built-in triggers will not work... until a trigger
-event tries to open the popover even though it is already open.
+can only be closed programmatically. Built-in triggers will work inadequatly, because trigger
+event will try to open the popover even though it is already opened.
 
 In the below example, when the first Popover is opened with the 'open' event, it will
-take two on-button clicks to close it. Play with the below demo to understand this. When
-you desire graceful handling of both programmatic control external to the Popover
+take two button clicks to close it. Play with the below demo to understand this. When
+you desire graceful handling of both programmatic control of the Popover
 component as well as user interaction triggers, you should disable built-in
 triggers and handle control yourself as demonstrated by the second Popover.
 
@@ -529,11 +529,11 @@ information on the directive usage.
 
 You can even make your `<b-popover>` content interactive. Just remember not to use the
 `focus`, `hover` or `blur` triggers (use only `click`), otherwsie your popover will
-close automatically as soon as someone trys to interact with the content.
+close automatically as soon as someone will try to interact with the content.
 
 If you absolutely must use a trigger other than `click` (or want to disable closing of the
 popover when the trigger element is clicked a second time), then you can either:
- - Listen for the `hide` event on the `<b-popover>` element, and call the `preventDefault()` method (when apropriate) on the `BvEvent` passed to your `hide` handler, or
+ - Listen for the `hide` event on the `<b-popover>` element, and call the `preventDefault()` method (when apropriate) on the `BvEvent` passed to your `hide` handler;
  - Disable your trigger element (if possible) as soon as the popover opens (via the `show` event), and re-enable it when apropriate.
 
 For practical purposes, interactive content popovers should be minimal. The maximum

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -400,7 +400,7 @@ See the **Hiding and showing popovers via $root events** section below for detai
 ### Disabling popover
 
 You can disable popover via the Boolean prop `disabled` (default is `false`)
-Setting it to `true` will disnable the popover. If the popover is currently visible
+Setting it to `true` will disable the popover. If the popover is currently visible
 when disabled is set to `false`, the popover will close.
 
 ```html

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -34,7 +34,7 @@ The target element **must** exist in the document before `<b-popover>` is mounte
 If the target element is not found during mount, the popover will never open. Always
 place your `<b-popover>` component lower in the DOM than your target element.
 
-**Note:** _When using slots for content and/or title, `<b-popover>` transfers the
+>**Note:** _When using slots for content and/or title, `<b-popover>` transfers the
 rendered DOM from those slots into the popover's markup when shown, and returns
 them back to the `<b-popover>` component when hidden. This may cause some issues
 in rare circumstances, so please test your implmentation accordingly! The `title`
@@ -148,7 +148,7 @@ popover will close. I.e. if a popover has the trigger `focus click`, and it was 
 `focus`, and the user then clicks the trigger element, they must click it again **and**
 move focus to close the popover.
 
-### Dismiss on next click (self dimissing)
+### Dismiss on next click (self-dimissing)
 Use the `focus` trigger by itself to dismiss popovers on the next click that the user makes.
 `focus` also makes the popover activate on both `focus` and `click` (as a click makes
 the element receive focus, assuming it is in the tab sequence of the page).
@@ -417,8 +417,12 @@ your `disabled` value will be updated as long as you have provided the `.sync` p
     </div>
     <div class="p-2">
       <b-btn @click="disabled = !disabled">
-        {{ disabled ? 'Enable' : 'Disable' }} Popover
+        {{ disabled ? 'Enable' : 'Disable' }} Popover by prop
       </b-btn>
+      
+      <b-btn @click="disableByRoot">
+              {{ disabled ? 'Enable' : 'Disable' }} Popover by Root event
+            </b-btn>
 
       <b-popover :disabled.sync="disabled" target="popoverButton-disable" title="Popover">
         Hello <strong>World!</strong>
@@ -433,6 +437,15 @@ your `disabled` value will be updated as long as you have provided the `.sync` p
       return {
         disabled: false
       }
+    },
+    methods: {
+       disableByRoot() {
+           if (this.disabled){
+               this.$root.$emit('bv::enable::popover')
+           }else{
+               this.$root.$emit('bv::disable::popover')
+           }
+       } 
     }
   }
 </script>
@@ -528,13 +541,13 @@ information on the directive usage.
 ## Advanced `<b-popover>` usage with reactive content
 
 You can even make your `<b-popover>` content interactive. Just remember not to use the
-`focus`, `hover` or `blur` triggers (use only `click`), otherwsie your popover will
+`focus`, `hover` or `blur` triggers (use only `click`), otherwise your popover will
 close automatically as soon as someone will try to interact with the content.
 
 If you absolutely must use a trigger other than `click` (or want to disable closing of the
 popover when the trigger element is clicked a second time), then you can either:
- - Listen for the `hide` event on the `<b-popover>` element, and call the `preventDefault()` method (when apropriate) on the `BvEvent` objewct passed to your `hide` handler;
- - Disable your trigger element (if possible) as soon as the popover begins to open (via the `show` event), and re-enable it when apropriate (i.e. via the `hide` or `hidden` event).
+ - Listen for the `hide` event on the `<b-popover>` element, and call the `preventDefault()` method (when appropriate) on the `BvEvent` object passed to your `hide` handler;
+ - Disable your trigger element (if possible) as soon as the popover begins to open (via the `show` event), and re-enable it when appropriate (i.e. via the `hide` or `hidden` event).
 
 For practical purposes, interactive content popovers should be minimal. The maximum
 width of the popover is hard coded by Bootstrap V4 CSS to `276px`. Tall popovers on
@@ -700,8 +713,7 @@ To open all popovers simultaneously, omit the `id` argument when emitting the
 
 These events work for both the component **and** directive versions of popover.
 
-Note the **trigger element** must exist in the DOM and be in a visible state in order for the
-popover to instantiate and show.
+>**Note:** _The **trigger element** must exist in the DOM and be in a visible state in order for the popover to instantiate and show._
 
 
 ## Disabling and enabling popovers via $root events
@@ -729,8 +741,7 @@ To enable all popovers simultaneously, omit the `id` argument when emitting the
 
 These events work for both the component and directive versions of popover.
 
-Note the **trigger element** must exist in the DOM in order for the popover to be
-enabled or disabled.
+>**Note:** _The **trigger element** must exist in the DOM in order for the popover to be enabled or disabled._
 
 
 ## Accessibility
@@ -745,7 +756,7 @@ your triggering element (assuming `focus` is not used as a trigger method), as w
 have done in the above example.
 
 You may also want to implement focus containment in the popover content while the
-user is interactiving with it (keeping focus inside the popover until it is closed
+user is interacting with it (keeping focus inside the popover until it is closed
 by the user).
 
 

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -414,7 +414,7 @@ when disabled is set to `false`, the popover will close.
         {{ disabled ? 'Enable' : 'Disable' }} Popover
       </b-btn>
 
-      <b-popover :disabled"disabled" target="popoverButton-disable" title="Popover">
+      <b-popover :disabled="disabled" target="popoverButton-disable" title="Popover">
         Hello <strong>World!</strong>
       </b-popover>
     </div>

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -148,7 +148,7 @@ popover will close. I.e. if a popover has the trigger `focus click`, and it was 
 `focus`, and the user then clicks the trigger element, they must click it again **and**
 move focus to close the popover.
 
-### Dismiss on next click (self-dimissing)
+### Dismiss on next click (self-dismissing)
 Use the `focus` trigger by itself to dismiss popovers on the next click that the user makes.
 `focus` also makes the popover activate on both `focus` and `click` (as a click makes
 the element receive focus, assuming it is in the tab sequence of the page).

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -231,12 +231,12 @@ export default {
 | `title` | `null` | Popover title (text only, no HTML). If HTML is required, place it in the `title` named slot | Plain text
 | `content` | `null` | Popover content (text only, no HTML). If HTML is required, place it in the default slot | Plain text
 | `placement` | `'right'` | Positioning of the popover, relative to the trigger element. | `auto`, `top`, `bottom`, `left`, `right`, `topleft`, `topright`, `bottomleft`, `bottomright`, `lefttop`, `leftbottom`, `righttop`, `rightbottom`
-| `sync` | `false` | Programmatic control of the Popover display state. Recommended to use with [sync modifier](https://vuejs.org/v2/guide/components.html#sync-Modifier). | `true`, `false`
-| `triggers` | `'click'` | Space separated list of which event(s) will trigger open/close of popover using built-in handling | `hover`, `focus`, `click`. Note `blur` is a special use case to close popover on next click.
+| `disabled` | `false` | Programmatic control of the Popover display state. Recommended to use with [sync modifier](https://vuejs.org/v2/guide/components.html#sync-Modifier). | `true`, `false`
+| `triggers` | `'click'` | Space separated list of event(s), which will trigger open/close of popover using built-in handling | `hover`, `focus`, `click`. Note `blur` is a special use case to close popover on next click.
 | `no-fade` | `false` | Disable fade animation when set to `true` | `true` or `false`
-| `delay` | `0` | Number of milliseconds to delay showing and hidding of popover. Can also be specified as an object in the form of `{ show: 100, hide: 400 }` allowing different show and hide delays | `0` and up, integers only.
-| `offset` | `0` | Number of pixels to shift the center of the popover. Also affects the position of the popover arrow. | Any negative or positive integer
-| `container` | `null` | String ID of element to append rendered popover into. If `null` or element not found, popover is appended to `<body>` (default) | Any valid in-document unique  element ID.
+| `delay` | `0` | Delay showing and hidding of popover by specified number of milliseconds. Can also be defined as an object in the form of `{ show: 100, hide: 400 }` allowing different show and hide delays | `0` and up, integers only.
+| `offset` | `0` | Shift the center of the popover by specified number of pixels. Also affects the position of the popover arrow. | Any negative or positive integer
+| `container` | `null` | Element string ID to append rendered popover into. If `null` or element not found, popover is appended to `<body>` (default) | Any valid in-document unique  element ID.
 
 
 ### Programmatically show and hide popover

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -392,6 +392,7 @@ triggers and handle control yourself as demonstrated by the second Popover.
     }
   }
 </script>
+
 <!-- popover-advanced-caution.vue -->
 ```
 
@@ -400,10 +401,11 @@ See the **Hiding and showing popovers via $root events** section below for detai
 
 ### Programmatically disabling popover
 
-You can disable popover via the syncable Boolean prop `disabled` (default is `false`)
+You can disable popover via the syncable Boolean prop `disabled` (default vlaue is `false`)
 Setting it to `true` will disable the popover. If the popover is currently visible
 when disabled is set to `false`, it will remain visible until it is enabled or
-programmatically closed..
+programmatically closed. If the popover is disabled/enabled via $root events (see below),
+your `disabled` value will be updated as long as you have provided the `.sync` prop modifier.
 
 ```html
 <template>
@@ -725,14 +727,14 @@ To enable all popovers simultaneously, omit the `id` argument when emitting the
 
 These events work for both the component and directive versions of popover.
 
-Note the **trigger element** must exist in the DOM and be in a visible state in order for the
-popover to be enabled or disabled.
+Note the **trigger element** must exist in the DOM in order for the popover to be
+enabled or disabled.
 
 
 ## Accessibility
 Popovers, in their current implementation, are not overly accessible when used as interactive
-components. Content may not be activly read to screen reader users, and the popover
-markup not be located close to the trigger element in the DOM (as popovers usually
+components. Content may not be actively read to screen reader users, and the popover
+markup might not be located close to the trigger element in the DOM (as popovers usually
 get appended to the end of `<body>`).
 
 When using popovers as interactive component, you should transfer focus into the
@@ -743,5 +745,6 @@ have done in the above example.
 You may also want to implement focus containment in the popover content while the
 user is interactiving with it (keeping focus inside the popover until it is closed
 by the user).
+
 
 ## Component Reference

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -410,7 +410,7 @@ when disabled is set to `false`, the popover will close.
       <b-btn id="popoverButton-disable" variant="primary">I have a popover</b-btn>
     </div>
     <div class="p-2">
-      <b-btn class="px-1" @click="disabled = !disabled">
+      <b-btn @click="disabled = !disabled">
         {{ disabled ? 'Enable' : 'Disable' }} Popover
       </b-btn>
 

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -420,8 +420,8 @@ your `disabled` value will be updated as long as you have provided the `.sync` p
         {{ disabled ? 'Enable' : 'Disable' }} Popover by prop
       </b-btn>
       
-      <b-btn @click="disableByRoot">
-        {{ disabled ? 'Enable' : 'Disable' }} Popover by Root event
+      <b-btn @click="disableByRef">
+        {{ disabled ? 'Enable' : 'Disable' }} Popover by $ref event
       </b-btn>
 
       <b-popover :disabled.sync="disabled" target="popoverButton-disable" title="Popover">
@@ -439,11 +439,11 @@ your `disabled` value will be updated as long as you have provided the `.sync` p
       }
     },
     methods: {
-       disableByRoot() {
+       disableByRef() {
            if (this.disabled){
-               this.$root.$emit('bv::enable::popover')
+               this.$refs.popover.$emit('enable')
            }else{
-               this.$root.$emit('bv::disable::popover')
+               this.$refs.popover.$emit('disable')
            }
        } 
     }

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -154,10 +154,10 @@ Use the `focus` trigger by itself to dismiss popovers on the next click that the
 the element receive focus, assuming it is in the tab sequence of the page).
 
 You can, however, specify your trigger as `click blur`,  which will make only a
-click activate the popover, and either a click on the element - _or losing foucus
-to another element or part of the document_ - will close the popover.
+click activate the popover, and either a click on the element, _or_ losing foucus
+to another element or part of the document, will close the popover.
 
-This `blur` trigger must be used in combination with the `click` trigger.
+The special `blur` trigger must be used in combination with the `click` trigger.
 
 
 ## `<b-popover>` Component basic usage

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -421,8 +421,8 @@ your `disabled` value will be updated as long as you have provided the `.sync` p
       </b-btn>
       
       <b-btn @click="disableByRoot">
-              {{ disabled ? 'Enable' : 'Disable' }} Popover by Root event
-            </b-btn>
+        {{ disabled ? 'Enable' : 'Disable' }} Popover by Root event
+      </b-btn>
 
       <b-popover :disabled.sync="disabled" target="popoverButton-disable" title="Popover">
         Hello <strong>World!</strong>

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -234,7 +234,7 @@ export default {
 | `disabled` | `false` | Programmatic control of the Popover display state. Recommended to use with [sync modifier](https://vuejs.org/v2/guide/components.html#sync-Modifier). | `true`, `false`
 | `triggers` | `'click'` | Space separated list of event(s), which will trigger open/close of popover using built-in handling | `hover`, `focus`, `click`. Note `blur` is a special use case to close popover on next click.
 | `no-fade` | `false` | Disable fade animation when set to `true` | `true` or `false`
-| `delay` | `0` | Delay showing and hidding of popover by specified number of milliseconds. Can also be defined as an object in the form of `{ show: 100, hide: 400 }` allowing different show and hide delays | `0` and up, integers only.
+| `delay` | `0` | Delay showing and hiding of popover by specified number of milliseconds. Can also be defined as an object in the form of `{ show: 100, hide: 400 }` allowing different show and hide delays | `0` and up, integers only.
 | `offset` | `0` | Shift the center of the popover by specified number of pixels. Also affects the position of the popover arrow. | Any negative or positive integer
 | `container` | `null` | Element string ID to append rendered popover into. If `null` or element not found, popover is appended to `<body>` (default) | Any valid in-document unique  element ID.
 

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -5,7 +5,9 @@ element via the `<b-popover>` component or [`v-b-popover`](/docs/directives/popo
 
 ```html
 <div class="my-3">
-  <b-btn v-b-popover.hover="'I am popover content!'" title="Popover Title">Hover Me</b-btn>
+  <b-btn v-b-popover.hover="'I am popover content!'" title="Popover Title">
+    Hover Me
+  </b-btn>
 </div>
 
 <!-- popover-example-1.vue -->

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -400,7 +400,7 @@ See the **Hiding and showing popovers via $root events** section below for detai
 
 ### Programmatically disabling popover
 
-You can disable popover via the Boolean prop `disabled` (default is `false`)
+You can disable popover via the syncable Boolean prop `disabled` (default is `false`)
 Setting it to `true` will disable the popover. If the popover is currently visible
 when disabled is set to `false`, it will remain visible until it is enabled or
 programmatically closed..
@@ -416,7 +416,7 @@ programmatically closed..
         {{ disabled ? 'Enable' : 'Disable' }} Popover
       </b-btn>
 
-      <b-popover :disabled="disabled" target="popoverButton-disable" title="Popover">
+      <b-popover :disabled.sync="disabled" target="popoverButton-disable" title="Popover">
         Hello <strong>World!</strong>
       </b-popover>
     </div>

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -533,8 +533,8 @@ close automatically as soon as someone will try to interact with the content.
 
 If you absolutely must use a trigger other than `click` (or want to disable closing of the
 popover when the trigger element is clicked a second time), then you can either:
- - Listen for the `hide` event on the `<b-popover>` element, and call the `preventDefault()` method (when apropriate) on the `BvEvent` passed to your `hide` handler;
- - Disable your trigger element (if possible) as soon as the popover opens (via the `show` event), and re-enable it when apropriate.
+ - Listen for the `hide` event on the `<b-popover>` element, and call the `preventDefault()` method (when apropriate) on the `BvEvent` objewct passed to your `hide` handler;
+ - Disable your trigger element (if possible) as soon as the popover begins to open (via the `show` event), and re-enable it when apropriate (i.e. via the `hide` or `hidden` event).
 
 For practical purposes, interactive content popovers should be minimal. The maximum
 width of the popover is hard coded by Bootstrap V4 CSS to `276px`. Tall popovers on

--- a/src/components/popover/package.json
+++ b/src/components/popover/package.json
@@ -47,11 +47,11 @@
             },
             {
                 "event": "enabled",
-                "description": "Emitted when popover is enabled"
+                "description": "Emitted when popover becomes enabled"
             },
             {
                 "event": "disabled",
-                "description": "Emitted when popover is disabled"
+                "description": "Emitted when popover becomes disabled"
             },
             {
                 "event": "bv::popover::show",
@@ -95,7 +95,7 @@
             },
             {
                 "event": "bv::popover::enabled",
-                "description": "Emitted on $root when popover is enabled",
+                "description": "Emitted on $root when popover becomes enabled",
                 "args": [
                     {
                         "arg": "bvEvent",
@@ -105,7 +105,7 @@
             },
             {
                 "event": "bv::popover::disabled",
-                "description": "Emitted on $root when popover is disabled",
+                "description": "Emitted on $root when popover becomes disabled",
                 "args": [
                     {
                         "arg": "bvEvent",

--- a/src/components/popover/package.json
+++ b/src/components/popover/package.json
@@ -7,7 +7,7 @@
         "events": [
             {
                 "event": "show",
-                "description": "When popover is about to be shown. Cancelable",
+                "description": "Emitted when popover is about to be shown. Cancelable",
                 "args": [
                     {
                         "arg": "bvEvent",
@@ -17,7 +17,7 @@
             },
             {
                 "event": "shown",
-                "description": "When popover is shown",
+                "description": "Emitted when popover is shown",
                 "args": [
                     {
                         "arg": "bvEvent",
@@ -27,7 +27,7 @@
             },
             {
                 "event": "hide",
-                "description": "When popover is about to be hidden. Cancelable",
+                "description": "Emitted when popover is about to be hidden. Cancelable",
                 "args": [
                     {
                         "arg": "bvEvent",
@@ -37,13 +37,21 @@
             },
             {
                 "event": "hidden",
-                "description": "When popover is hidden",
+                "description": "Emitted when popover is hidden",
                 "args": [
                     {
                         "arg": "bvEvent",
                         "description": "bvEvent object."
                     }
                 ]
+            },
+            {
+                "event": "enabled",
+                "description": "Emitted when popover is enabled"
+            },
+            {
+                "event": "disabled",
+                "description": "Emitted when popover is disabled"
             },
             {
                 "event": "bv::popover::show",
@@ -78,6 +86,26 @@
             {
                 "event": "bv::popover::hidden",
                 "description": "Emitted on $root when popover is hidden",
+                "args": [
+                    {
+                        "arg": "bvEvent",
+                        "description": "bvEvent object."
+                    }
+                ]
+            },
+            {
+                "event": "bv::popover::enabled",
+                "description": "Emitted on $root when popover is enabled",
+                "args": [
+                    {
+                        "arg": "bvEvent",
+                        "description": "bvEvent object."
+                    }
+                ]
+            },
+            {
+                "event": "bv::popover::disabled",
+                "description": "Emitted on $root when popover is disabled",
                 "args": [
                     {
                         "arg": "bvEvent",

--- a/src/components/popover/package.json
+++ b/src/components/popover/package.json
@@ -7,11 +7,11 @@
         "events": [
             {
                 "event": "show",
-                "description": "Emitted when popover is about to be shown. Cancelable",
+                "description": "Emitted when popover is about to be shown. Cancelable. Call bvEvent.preventDefault() to cancel show.",
                 "args": [
                     {
                         "arg": "bvEvent",
-                        "description": "bvEvent object. Call bvEvent.preventDefault() to cancel show."
+                        "description": "bvEvent object"
                     }
                 ]
             },
@@ -27,11 +27,11 @@
             },
             {
                 "event": "hide",
-                "description": "Emitted when popover is about to be hidden. Cancelable",
+                "description": "Emitted when popover is about to be hidden. Cancelable. Call bvEvent.preventDefault() to cancel hide.",
                 "args": [
                     {
                         "arg": "bvEvent",
-                        "description": "bvEvent object. Call bvEvent.preventDefault() to cancel hide."
+                        "description": "bvEvent object"
                     }
                 ]
             },
@@ -55,11 +55,11 @@
             },
             {
                 "event": "bv::popover::show",
-                "description": "Emitted on $root when popover is about to be shown. Cancelable",
+                "description": "Emitted on $root when popover is about to be shown. Cancelable. Call bvEvent.preventDefault() to cancel show.",
                 "args": [
                     {
                         "arg": "bvEvent",
-                        "description": "bvEvent object. Call bvEvent.preventDefault() to cancel show."
+                        "description": "bvEvent object"
                     }
                 ]
             },
@@ -75,11 +75,11 @@
             },
             {
                 "event": "bv::popover::hide",
-                "description": "Emitted on $root when popover is about to be hidden. Cancelable",
+                "description": "Emitted on $root when popover is about to be hidden. Cancelable. Call bvEvent.preventDefault() to cancel hide.",
                 "args": [
                     {
                         "arg": "bvEvent",
-                        "description": "bvEvent object. Call bvEvent.preventDefault() to cancel hide."
+                        "description": "bvEvent object"
                     }
                 ]
             },

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -217,7 +217,7 @@ when disabled is set to `false`, the tooltip will close.
       <b-btn id="tooltipButton-disable" variant="primary">I have a tooltip</b-btn>
     </div>
     <div class="p-2">
-      <b-btn class="px-1" @click="disabled = !disabled">
+      <b-btn @click="disabled = !disabled">
         {{ disabled ? 'Enable' : 'Disable' }} Tooltip
       </b-btn>
 

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -270,7 +270,7 @@ prop modifier.
         {{ disabled ? 'Enable' : 'Disable' }} Tooltip by prop
       </b-btn>
             
-      <b-btn @click="disableByRoot">
+      <b-btn @click="disableByRef">
         {{ disabled ? 'Enable' : 'Disable' }} Tooltip by $ref event
       </b-btn>
 
@@ -289,7 +289,7 @@ prop modifier.
       }
     },
     methods: {
-      disableByRoot () {
+      disableByRef () {
         if (this.disabled) {
           this.$refs.tooltip.$emit('enable')
         } else {

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -221,7 +221,7 @@ when disabled is set to `false`, the tooltip will close.
         {{ disabled ? 'Enable' : 'Disable' }} Tooltip
       </b-btn>
 
-      <b-tooltip :disabled"disabled" target="tooltipButton-disable">
+      <b-tooltip :disabled="disabled" target="tooltipButton-disable">
         Hello <strong>World!</strong>
       </b-tooltip>
     </div>

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -35,7 +35,7 @@ your `<b-tooltip>` component lower in the DOM than your target element.
 **Note:** _When using the default slot for the title, `<b-tooltip>` transfers the
 rendered DOM from that slot into the tooltip's markup when shown, and returns
 the content back to the `<b-tooltip>` component when hidden. This may cause some issues
-in rare circumstances, so please test your implmentation accordingly! The `title`
+in rare circumstances, so please test your implementation accordingly! The `title`
 prop does not have this behavior. For simple tooltips, we recommend using the
 `v-b-tooltip` directive and enable the `html` modifer if needed._
 
@@ -157,14 +157,14 @@ by `focus`, and the user then clicks the trigger element, they must click it aga
 
 | Prop | Default | Description | Supported values
 | ---- | ------- | ----------- | ----------------
-| `target` | `null` | String ID of element, or a reference to an element or component, that you want to trigger the tooltip. **Required** | Any valid, in-document unique element ID, element reference or component reference
-| `title` | `null` | Content of tooltip (text only, no HTML). if HTML is required, place it in the default slot | Plain text
-| `placement` | `top` | Positioning of the tooltip, relative to the trigger element. | `top`, `bottom`, `left`, `right`, `auto`, `topleft`, `topright`, `bottomleft`, `bottomright`, `lefttop`, `leftbottom`, `righttop`, `rightbottom`
-| `triggers` | `hover focus` |  Space separated list of which event(s) will trigger open/close of tooltip | `hover`, `focus`, `click`. Note `blur` is a special use case to close tooltip on next click, usually used in conjunction with `click`.
+| `target` | `null` | Element String ID, or a reference to an element or component, that you want to trigger the tooltip. **Required** | Any valid, in-document unique element ID, element reference or component reference
+| `title` | `null` |  Tooltip content (text only, no HTML). if HTML is required, place it in the default slot | Plain text
+| `placement` | `top` | Tooltip position, relative to the trigger element. | `top`, `bottom`, `left`, `right`, `auto`, `topleft`, `topright`, `bottomleft`, `bottomright`, `lefttop`, `leftbottom`, `righttop`, `rightbottom`
+| `triggers` | `hover focus` |  Space separated list of event(s), which will trigger open/close of tooltip | `hover`, `focus`, `click`. Note `blur` is a special use case to close tooltip on next click, usually used in conjunction with `click`.
 | `no-fade` | `false` | Disable fade animation when set to `true` | `true` or `false`
-| `delay` | `0` | Number of milliseconds to delay showing and hidding of popover. Can also be specified as an object in the form of `{ show: 100, hide: 400 }` allowing different show and hide delays | `0` and up, integers only.
-| `offset` | `0` | Number of pixels to shift the center of the tooltip | Any negative or positive integer
-| `container` | `null` | String ID of element to append rendered tooltip into. If `null` or element not found, tooltip is appended to `<body>` (default) | Any valid in-document unique  element ID.
+| `delay` | `0` | Delay showing and hiding of tooltip by specified number of milliseconds. Can also be specified as an object in the form of `{ show: 100, hide: 400 }` allowing different show and hide delays | `0` and up, integers only.
+| `offset` | `0` | Shift the center of the tooltip by specified number of pixels | Any negative or positive integer
+| `container` | `null` | Element string ID to append rendered tooltip into. If `null` or element not found, tooltip is appended to `<body>` (default) | Any valid in-document unique element ID.
 
 
 ### Programmatically show and hide tooltip

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -204,6 +204,46 @@ on `<b-tooltip>`:
 You can also use `$root` events to trigger the showing and hiding of tooltip(s).
 See the **Hiding and showing tooltips via $root events** section below for details.
 
+### Disabling tooltip
+
+You can disable tooltip via the Boolean prop `disabled` (default is `false`)
+Setting it to `true` will disable the tooltip. If the tooltip is currently visible
+when disabled is set to `false`, the tooltip will close.
+
+```html
+<template>
+  <div class="d-flex flex-column text-md-center">
+    <div class="p-2">
+      <b-btn id="tooltipButton-disable" variant="primary">I have a tooltip</b-btn>
+    </div>
+    <div class="p-2">
+      <b-btn class="px-1" @click="disabled = !disabled">
+        {{ disabled ? 'Enable' : 'Disable' }} Tooltip
+      </b-btn>
+
+      <b-tooltip :disabled"disabled" target="tooltipButton-disable">
+        Hello <strong>World!</strong>
+      </b-tooltip>
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        disabled: false
+      }
+    }
+  }
+</script>
+
+<!-- tooltip-disable.vue -->
+```
+
+When disabled, the tooltip cannot be opened programmatically (either via the `show` prop,
+methods or events).
+
 
 ## `v-b-tooltip` Directive Usage
 

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -211,6 +211,42 @@ on `<b-tooltip>`:
 <!-- tooltip-show-open.vue -->
 ```
 
+Programmatic control can also be affected by submitting `'open'` and `'close'`
+events to the tooltip by reference.
+ 
+ ```html
+ <template>
+   <div class="d-flex flex-column text-md-center">
+     <div class="p-2">
+       <b-btn id="tooltipButton-showEvent" variant="primary">I have a popover</b-btn>
+     </div>
+     <div class="p-2">
+       <b-btn class="px-1" @click="onOpen">Open</b-btn>
+       <b-btn class="px-1" @click="onClose">Close</b-btn>
+     </div>
+ 
+     <b-tooltip ref="tooltip" target="tooltipButton-showEvent">
+       Hello <strong>World!</strong>
+     </b-tooltip>
+   </div>
+ </template>
+ 
+ <script>
+   export default {
+     methods: {
+       onOpen() {
+         this.$refs.tooltip.$emit('open')
+       },
+       onClose() {
+         this.$refs.tooltip.$emit('close')
+       }
+     }
+   }
+ </script>
+ 
+ <!-- tooltip-show-ref-event.vue -->
+```
+
 You can also use `$root` events to trigger the showing and hiding of tooltip(s).
 See the **Hiding and showing tooltips via $root events** section below for details.
 
@@ -235,10 +271,10 @@ prop modifier.
       </b-btn>
             
       <b-btn @click="disableByRoot">
-        {{ disabled ? 'Enable' : 'Disable' }} Tooltip by $root event
+        {{ disabled ? 'Enable' : 'Disable' }} Tooltip by $ref event
       </b-btn>
 
-      <b-tooltip :disabled.sync="disabled" target="tooltipButton-disable">
+      <b-tooltip :disabled.sync="disabled" ref="tooltip" target="tooltipButton-disable">
         Hello <strong>World!</strong>
       </b-tooltip>
     </div>
@@ -255,9 +291,9 @@ prop modifier.
     methods: {
       disableByRoot () {
         if (this.disabled) {
-          this.$root.$emit('bv::enable::tooltip', 'tooltipButton-disable')
+          this.$refs.tooltip.$emit('enable')
         } else {
-          this.$root.$emit('bv::disable::tooltip', 'tooltipButton-disable')
+          this.$refs.tooltip.$emit('disable')
         }
       } 
     }
@@ -273,7 +309,7 @@ to the toggle button._
 When disabled, the tooltip can be opened programmatically (either via the `show` prop,
 methods or events).
 
-You can also use `$root` events to trigger disabling and enabling of popover(s). See
+You can also emit `$root` events to trigger disabling and enabling of popover(s). See
 the **Disabling and enabling tooltips via $root events** section below for details.
 
 
@@ -315,13 +351,13 @@ You can close (hide) **all open tooltips** by emitting the `bv::hide::tooltip` e
 this.$root.$emit('bv::hide::tooltip');
 ```
 
-To close a **specific tooltip**, pass the trigger element's `id` as the first argument:
+To close a **specific tooltip**, pass the trigger element's `id` as the argument:
 
 ```js
 this.$root.$emit('bv::show::tooltip', 'my-trigger-button-id');
 ```
 
-To open a **specific tooltip**, pass the trigger element's `id` as the first argument when
+To open a **specific tooltip**, pass the trigger element's `id` as the argument when
 emitting the `bv::show::tooltip` $root event:
 
 ```js
@@ -343,13 +379,13 @@ You can disable **all open tooltips** by emitting the `bv::disable::tooltip` eve
 this.$root.$emit('bv::disable::tooltip');
 ```
 
-To disable a **specific tooltip**, pass the trigger element's `id` as the first argument:
+To disable a **specific tooltip**, pass the trigger element's `id` as the argument:
 
 ```js
 this.$root.$emit('bv::disable::tooltip', 'my-trigger-button-id');
 ```
 
-To enable a **specific tooltip**, pass the trigger element's `id` as the first argument when
+To enable a **specific tooltip**, pass the trigger element's `id` as the argument when
 emitting the `bv::enable::tooltip` $root event:
 
 ```js

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -119,6 +119,14 @@ The default position is `top`. Positioning is relative to the trigger element.
   </div>
 </div>
 
+## Triggers
+Tooltips can be triggered (opened/closed) via any combination of `click`, `hover`
+and `focus`. The default trigger is `hover focus`.
+
+If a tooltip has more than one trigger, then all triggers must be cleared before the
+tooltip will close. I.e. if a tooltip has the trigger `focus click`, and it was opened
+by `focus`, and the user then clicks the trigger element, they must click it again
+**and** move focus to close the tooltip.
 
 ## `<b-tooltip>` Component Usage
 

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -229,11 +229,11 @@ prop modifier.
     </div>
     <div class="p-2">
       <b-btn @click="disabled = !disabled">
-              {{ disabled ? 'Enable' : 'Disable' }} Tooltip by prop
+        {{ disabled ? 'Enable' : 'Disable' }} Tooltip by prop
       </b-btn>
             
       <b-btn @click="disableByRoot">
-              {{ disabled ? 'Enable' : 'Disable' }} Tooltip by Root event
+        {{ disabled ? 'Enable' : 'Disable' }} Tooltip by Root event
       </b-btn>
 
       <b-tooltip :disabled.sync="disabled" target="tooltipButton-disable">

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -25,7 +25,7 @@ Things to know when using tooltip component:
 The `<b-tooltip` component inserts a hidden (`display:none`) `<div>` intermediate container
 element at the point in the DOM where the `<b-tooltip>` component is placed. This may
 affect layout and/or styling of components such as `<b-button-group>`, `<b-button-toolbar>`,
-and `<b-input-group>`. To avoid these posible layout issues, place the `<b-tooltip>`
+and `<b-input-group>`. To avoid these possible layout issues, place the `<b-tooltip>`
 component **outside** of these types of components.
 
 The target element **must** exist in the document before `<b-tooltip>` is mounted. If the
@@ -37,7 +37,7 @@ rendered DOM from that slot into the tooltip's markup when shown, and returns
 the content back to the `<b-tooltip>` component when hidden. This may cause some issues
 in rare circumstances, so please test your implementation accordingly! The `title`
 prop does not have this behavior. For simple tooltips, we recommend using the
-`v-b-tooltip` directive and enable the `html` modifer if needed._
+`v-b-tooltip` directive and enable the `html` modifier if needed._
 
 ## Positioning
 Twelve options are available for positioning: `top`, `topleft`, `topright`, `right`, `righttop`,
@@ -229,10 +229,14 @@ prop modifier.
     </div>
     <div class="p-2">
       <b-btn @click="disabled = !disabled">
-        {{ disabled ? 'Enable' : 'Disable' }} Tooltip
+              {{ disabled ? 'Enable' : 'Disable' }} Tooltip by prop
+      </b-btn>
+            
+      <b-btn @click="disableByRoot">
+              {{ disabled ? 'Enable' : 'Disable' }} Tooltip by Root event
       </b-btn>
 
-      <b-tooltip :disabled="disabled" target="tooltipButton-disable">
+      <b-tooltip :disabled.sync="disabled" target="tooltipButton-disable">
         Hello <strong>World!</strong>
       </b-tooltip>
     </div>
@@ -245,13 +249,22 @@ prop modifier.
       return {
         disabled: false
       }
+    },
+    methods: {
+      disableByRoot() {
+        if (this.disabled){
+          this.$root.$emit('bv::enable::popover')
+        }else{
+          this.$root.$emit('bv::disable::popover')
+        }
+      } 
     }
   }
 </script>
 
 <!-- tooltip-disable.vue -->
 ```
-**Note:** _In the above example, since we are using the default tooltip triggers of
+>**Note:** _In the above example, since we are using the default tooltip triggers of
 `focus hover`, the tooltip will close before it is disabled due to loosing focus (and hover)
 to the toggle button._
 
@@ -318,8 +331,7 @@ To open all popovers simultaneously, omit the `id` argument when emitting the
 
 These events work for both the component **and** directive versions of tooltip.
 
-Note the **trigger element** must exist in the DOM and be in a visible state in order
-for the tooltip to show.
+>**Note:** _the **trigger element** must exist in the DOM and be in a visible state in order for the tooltip to show._
 
 
 ## Disabling and enabling tooltips via $root events
@@ -347,8 +359,8 @@ To enable all popovers simultaneously, omit the `id` argument when emitting the
 
 These events work for both the component **and** directive versions of tooltip.
 
-Note the **trigger element** must exist in the DOM in order for the
-tooltip to be enabled or disabled.
+>**Note:** _The **trigger element** must exist in the DOM in order for the
+tooltip to be enabled or disabled._
 
 
 ## Component Reference

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -204,11 +204,14 @@ on `<b-tooltip>`:
 You can also use `$root` events to trigger the showing and hiding of tooltip(s).
 See the **Hiding and showing tooltips via $root events** section below for details.
 
-### Disabling tooltip
+### Programmatically disabling tooltip
 
-You can disable tooltip via the Boolean prop `disabled` (default is `false`)
+You can disable tooltip via the syncable Boolean prop `disabled` (default is `false`)
 Setting it to `true` will disable the tooltip. If the tooltip is currently visible
-when disabled is set to `false`, the tooltip will close.
+when disabled is set to `false`, the tooltip will remain visible until it is enabled
+or programmatically closed. If the tooltip is disabled/enabled via $root events (see
+below), your `disabled` value will be updated as long as you have provided the `.sync`
+prop modifier.
 
 ```html
 <template>
@@ -240,9 +243,15 @@ when disabled is set to `false`, the tooltip will close.
 
 <!-- tooltip-disable.vue -->
 ```
+**Note:** _In the above example, since we are using the default tooltip triggers of
+`focus hover`, the tooltip will close before it is disabled due to loosing focus (and hover)
+to the toggle button._
 
-When disabled, the tooltip cannot be opened programmatically (either via the `show` prop,
+When disabled, the tooltip can be opened programmatically (either via the `show` prop,
 methods or events).
+
+You can also use `$root` events to trigger disabling and enabling of popover(s). See
+the **Disabling and enabling tooltips via $root events** section below for details.
 
 
 ## `v-b-tooltip` Directive Usage
@@ -275,30 +284,63 @@ The `v-b-tooltip` directive makes adding tooltips even easier, without additiona
 Refer to the [`v-b-tooltip` documentation](/docs/directives/tooltip) for more information
 and features of the directive format.
 
+
 ## Hiding and showing tooltips via $root events
-You can close (hide) all open tooltips by emitting the `bv::hide::tooltip` event on $root:
+You can close (hide) **all open tooltips** by emitting the `bv::hide::tooltip` event on $root:
 
 ```js
 this.$root.$emit('bv::hide::tooltip');
 ```
 
-To close a specific tooltip, pass the trigger element's `id` as the first argument:
+To close a **specific tooltip**, pass the trigger element's `id` as the first argument:
 
 ```js
 this.$root.$emit('bv::show::tooltip', 'my-trigger-button-id');
 ```
 
-To open a specific tooltip, pass the trigger element's `id` as the first argument when
+To open a **specific tooltip**, pass the trigger element's `id` as the first argument when
 emitting the `bv::show::tooltip` $root event:
 
 ```js
 this.$root.$emit('bv::show::tooltip', 'my-trigger-button-id');
 ```
 
-These events work for both the component and directive versions of tooltip.
+To open all popovers simultaneously, omit the `id` argument when emitting the
+`bv::show::tooltip` event.
 
-Note the trigger element must exist in the DOM and be in a visible state in order for the
-tooltip to show.
+These events work for both the component **and** directive versions of tooltip.
+
+Note the **trigger element** must exist in the DOM and be in a visible state in order
+for the tooltip to show.
+
+
+## Disabling and enabling tooltips via $root events
+You can disable **all open tooltips** by emitting the `bv::disable::tooltip` event on $root:
+
+```js
+this.$root.$emit('bv::disable::tooltip');
+```
+
+To disable a **specific tooltip**, pass the trigger element's `id` as the first argument:
+
+```js
+this.$root.$emit('bv::disable::tooltip', 'my-trigger-button-id');
+```
+
+To enable a **specific tooltip**, pass the trigger element's `id` as the first argument when
+emitting the `bv::enable::tooltip` $root event:
+
+```js
+this.$root.$emit('bv::enable::tooltip', 'my-trigger-button-id');
+```
+
+To enable all popovers simultaneously, omit the `id` argument when emitting the
+`bv::enable::tooltip` event.
+
+These events work for both the component **and** directive versions of tooltip.
+
+Note the **trigger element** must exist in the DOM in order for the
+tooltip to be enabled or disabled.
 
 
 ## Component Reference

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -119,6 +119,7 @@ The default position is `top`. Positioning is relative to the trigger element.
   </div>
 </div>
 
+
 ## Triggers
 Tooltips can be triggered (opened/closed) via any combination of `click`, `hover`
 and `focus`. The default trigger is `hover focus`.
@@ -127,6 +128,7 @@ If a tooltip has more than one trigger, then all triggers must be cleared before
 tooltip will close. I.e. if a tooltip has the trigger `focus click`, and it was opened
 by `focus`, and the user then clicks the trigger element, they must click it again
 **and** move focus to close the tooltip.
+
 
 ## `<b-tooltip>` Component Usage
 
@@ -233,7 +235,7 @@ prop modifier.
       </b-btn>
             
       <b-btn @click="disableByRoot">
-        {{ disabled ? 'Enable' : 'Disable' }} Tooltip by Root event
+        {{ disabled ? 'Enable' : 'Disable' }} Tooltip by $root event
       </b-btn>
 
       <b-tooltip :disabled.sync="disabled" target="tooltipButton-disable">
@@ -245,17 +247,17 @@ prop modifier.
 
 <script>
   export default {
-    data() {
+    data () {
       return {
         disabled: false
       }
     },
     methods: {
-      disableByRoot() {
-        if (this.disabled){
-          this.$root.$emit('bv::enable::popover')
-        }else{
-          this.$root.$emit('bv::disable::popover')
+      disableByRoot () {
+        if (this.disabled) {
+          this.$root.$emit('bv::enable::tooltip', 'tooltipButton-disable')
+        } else {
+          this.$root.$emit('bv::disable::tooltip', 'tooltipButton-disable')
         }
       } 
     }

--- a/src/components/tooltip/package.json
+++ b/src/components/tooltip/package.json
@@ -7,11 +7,11 @@
         "events": [
             {
                 "event": "show",
-                "description": "Emitted when tooltip is about to be shown. Cancelable",
+                "description": "Emitted when tooltip is about to be shown. Cancelable. Call bvEvent.preventDefault() to cancel show.",
                 "args": [
                     {
                         "arg": "bvEvent",
-                        "description": "bvEvent object. Call bvEvent.preventDefault() to cancel show."
+                        "description": "bvEvent object"
                     }
                 ]
             },
@@ -27,11 +27,11 @@
             },
             {
                 "event": "hide",
-                "description": "Emitted when tooltip is about to be hidden. Cancelable",
+                "description": "Emitted when tooltip is about to be hidden. Cancelable. Call bvEvent.preventDefault() to cancel hide.",
                 "args": [
                     {
                         "arg": "bvEvent",
-                        "description": "bvEvent object. Call bvEvent.preventDefault() to cancel hide."
+                        "description": "bvEvent object"
                     }
                 ]
             },
@@ -55,11 +55,11 @@
             },
             {
                 "event": "bv::tooltip::show",
-                "description": "Emitted on $root when tooltip is about to be shown. Cancelable",
+                "description": "Emitted on $root when tooltip is about to be shown. Cancelable. Call bvEvent.preventDefault() to cancel show.",
                 "args": [
                     {
                         "arg": "bvEvent",
-                        "description": "bvEvent object. Call bvEvent.preventDefault() to cancel show."
+                        "description": "bvEvent object"
                     }
                 ]
             },
@@ -75,11 +75,11 @@
             },
             {
                 "event": "bv::tooltip::hide",
-                "description": "Emitted on $root when tooltip is about to be hidden. Cancelable",
+                "description": "Emitted on $root when tooltip is about to be hidden. Cancelable. Call bvEvent.preventDefault() to cancel hide.",
                 "args": [
                     {
                         "arg": "bvEvent",
-                        "description": "bvEvent object. Call bvEvent.preventDefault() to cancel hide."
+                        "description": "bvEvent object"
                     }
                 ]
             },

--- a/src/components/tooltip/package.json
+++ b/src/components/tooltip/package.json
@@ -7,7 +7,7 @@
         "events": [
             {
                 "event": "show",
-                "description": "When tooltip is about to be shown. Cancelable",
+                "description": "Emitted when tooltip is about to be shown. Cancelable",
                 "args": [
                     {
                         "arg": "bvEvent",
@@ -17,7 +17,7 @@
             },
             {
                 "event": "shown",
-                "description": "When tooltip is shown",
+                "description": "Emitted when tooltip is shown",
                 "args": [
                     {
                         "arg": "bvEvent",
@@ -27,7 +27,7 @@
             },
             {
                 "event": "hide",
-                "description": "When tooltip is about to be hidden. Cancelable",
+                "description": "Emitted when tooltip is about to be hidden. Cancelable",
                 "args": [
                     {
                         "arg": "bvEvent",
@@ -37,13 +37,21 @@
             },
             {
                 "event": "hidden",
-                "description": "When tooltip is hidden",
+                "description": "Emitted when tooltip is hidden",
                 "args": [
                     {
                         "arg": "bvEvent",
                         "description": "bvEvent object."
                     }
                 ]
+            },
+            {
+                "event": "enabled",
+                "description": "Emitted when tooltip becomes enabled"
+            },
+            {
+                "event": "disabled",
+                "description": "Emitted when tooltip becomes disabled"
             },
             {
                 "event": "bv::tooltip::show",
@@ -78,6 +86,26 @@
             {
                 "event": "bv::tooltip::hidden",
                 "description": "Emitted on $root when tooltip is hidden",
+                "args": [
+                    {
+                        "arg": "bvEvent",
+                        "description": "bvEvent object."
+                    }
+                ]
+            },
+            {
+                "event": "bv::tooltip::enabled",
+                "description": "Emitted on $root when tooltip becomes enabled",
+                "args": [
+                    {
+                        "arg": "bvEvent",
+                        "description": "bvEvent object."
+                    }
+                ]
+            },
+            {
+                "event": "bv::tooltip::disabled",
+                "description": "Emitted on $root when tooltip becomes disabled",
                 "args": [
                     {
                         "arg": "bvEvent",

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -378,29 +378,61 @@ v-b-popover.bottom.click.html  => Show on click and place at bottom with HTML co
 ```
 
 ## Hiding and showing popovers via $root events
-You can close (hide) all open popovers by emitting the `bv::hide::popover` event on $root:
+You can close (hide) **all open popovers** by emitting the `bv::hide::popover` event on $root:
 
 ```js
 this.$root.$emit('bv::hide::popover');
 ```
 
-To close a specific popover, pass the trigger element's `id` as the first argument:
+To close a **specific popover**, pass the trigger element's `id` as the first argument:
 
 ```js
 this.$root.$emit('bv::show::popover', 'my-trigger-button-id');
 ```
 
-To open (show) a specific popover, pass the trigger element's `id` as the first argument when
+To open (show) a **specific popover**, pass the trigger element's `id` as the first argument when
 emitting the `bv::show::popover` event:
 
 ```js
 this.$root.$emit('bv::show::popover', 'my-trigger-button-id');
 ```
 
+To open all popovers simultaneously, omit the `id` argument when emitting the
+`bv::show::popover` event.
+
+These events work for both the component **and** directive versions of popover.
+
+Note the **trigger element** must exist in the DOM and be in a visible state in order for the
+popover to instantiate and show.
+
+
+## Disabling and enabling popovers via $root events
+You can disable **all** popovers by emitting the `bv::disable::popover` event on $root:
+
+```js
+this.$root.$emit('bv::disable::popover');
+```
+
+To disable a **specific popover**, pass the trigger element's `id` as the first argument:
+
+```js
+this.$root.$emit('bv::disable::popover', 'my-trigger-button-id');
+```
+
+To enable a **specific popover**, pass the trigger element's `id` as the first argument when
+emitting the `bv::enable::popover` event:
+
+```js
+this.$root.$emit('bv::enable::popover', 'my-trigger-button-id');
+```
+
+To enable all popovers simultaneously, omit the `id` argument when emitting the
+`bv::enable::popover` event.
+
 These events work for both the component and directive versions of popover.
 
-Note the trigger element must exist in the DOM and be in a visible state in order for the
-popover to show.
+Note the **trigger element** must exist in the DOM in order for the popover to be
+enabled or disabled.
 
 
 ## See also

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -305,29 +305,61 @@ v-b-tooltip="{title: 'Title', placement: 'bottom'}"
 
 
 ## Hiding and showing tooltips via $root events
-You can close (hide) all open tooltips by emitting the `bv::hide::tooltip` event on $root:
+You can close (hide) **all open tooltips** by emitting the `bv::hide::tooltip` event on $root:
 
 ```js
 this.$root.$emit('bv::hide::tooltip');
 ```
 
-To close a specific tooltip, pass the trigger element's `id` as the first argument:
+To close a **specific tooltip**, pass the trigger element's `id` as the first argument:
 
 ```js
 this.$root.$emit('bv::show::tooltip', 'my-trigger-button-id');
 ```
 
-To open a specific tooltip, pass the trigger element's `id` as the first argument when
+To open a **specific tooltip**, pass the trigger element's `id` as the first argument when
 emitting the `bv::show::tooltip` $root event:
 
 ```js
 this.$root.$emit('bv::show::tooltip', 'my-trigger-button-id');
 ```
 
-These events work for both the component and directive versions of tooltip.
+To open all popovers simultaneously, omit the `id` argument when emitting the
+`bv::show::tooltip` event.
 
-Note the trigger element must exist in the DOM and be in a visible state in order for the
-tooltip to show.
+These events work for both the component **and** directive versions of tooltip.
+
+Note the **trigger element** must exist in the DOM and be in a visible state in order
+for the tooltip to show.
+
+
+## Disabling and enabling tooltips via $root events
+You can disable **all open tooltips** by emitting the `bv::disable::tooltip` event on $root:
+
+```js
+this.$root.$emit('bv::disable::tooltip');
+```
+
+To disable a **specific tooltip**, pass the trigger element's `id` as the first argument:
+
+```js
+this.$root.$emit('bv::disable::tooltip', 'my-trigger-button-id');
+```
+
+To enable a **specific tooltip**, pass the trigger element's `id` as the first argument when
+emitting the `bv::enable::tooltip` $root event:
+
+```js
+this.$root.$emit('bv::enable::tooltip', 'my-trigger-button-id');
+```
+
+To enable all popovers simultaneously, omit the `id` argument when emitting the
+`bv::enable::tooltip` event.
+
+These events work for both the component **and** directive versions of tooltip.
+
+Note the **trigger element** must exist in the DOM in order for the
+tooltip to be enabled or disabled.
 
 
 ## See also

--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -167,7 +167,9 @@ export default {
           show: this.onShow,
           shown: this.onShown,
           hide: this.onHide,
-          hidden: this.onHidden
+          hidden: this.onHidden,
+          enabled: this.onEnabled,
+          disabled: this.onDisabled
         }
       }
     }
@@ -249,6 +251,14 @@ export default {
       this.bringItBack()
       this.$emit('update:show', false)
       this.$emit('hidden', evt)
+    },
+    onEnabled () {
+      this.$emit('update:disabled', false)
+      this.$emit('disabled')
+    },
+    onDisabled () {
+      this.$emit('update:disabled', true)
+      this.$emit('enabled')
     },
     bringItBack () {
       // bring our content back if needed to keep Vue happy

--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -252,11 +252,19 @@ export default {
       this.$emit('update:show', false)
       this.$emit('hidden', evt)
     },
-    onEnabled () {
+    onEnabled (evt) {
+      if (!evt || evt.type !== 'enabled') {
+        // Prevent possible endless loop if user mistakienly fires enabled instead of enable
+        return
+      }
       this.$emit('update:disabled', false)
       this.$emit('disabled')
     },
-    onDisabled () {
+    onDisabled (evt) {
+      if (!evt || evt.type !== 'disabled') {
+        // Prevent possible endless loop if user mistakienly fires disabled instead of disable
+        return
+      }
       this.$emit('update:disabled', true)
       this.$emit('enabled')
     },

--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -169,7 +169,7 @@ export default {
         callback()
       }
     },
-    disable() {
+    disable () {
       this.$off('close', this.onClose)
       this.setObservers(false)
       // bring our content back if needed
@@ -179,7 +179,7 @@ export default {
         this._toolpop = null
       }
     },
-    enable() {
+    enable () {
       if (this._toolpop) {
         return
       }

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -112,6 +112,7 @@ class ToolTip {
   // Main constructor
   constructor (element, config, $root) {
     // New tooltip object
+    this.$isEnabled = true
     this.$fadeTimeout = null
     this.$hoverTimeout = null
     this.$visibleInterval = null
@@ -196,6 +197,7 @@ class ToolTip {
     this.$tip = null
     // Null out other properties
     this.$id = null
+    this.$isEnabled = null
     this.$root = null
     this.$element = null
     this.$config = null
@@ -206,8 +208,19 @@ class ToolTip {
     this.$doShow = null
   }
 
+  enable() {
+    this.$isEnabled = true
+  }
+
+  disable() {
+    this.$isEnabled = false
+  }
+
   // Click toggler
   toggle (event) {
+    if (!this.$isEnabled) {
+      return
+    }
     if (event) {
       this.$activeTrigger.click = !this.$activeTrigger.click
 
@@ -231,7 +244,9 @@ class ToolTip {
       // If trigger element isn't in the DOM or is not visible
       return
     }
-
+    if (!this.$isEnabled) {
+      return
+    }
     // Build tooltip element (also sets this.$tip)
     const tip = this.getTipElement()
     this.fixTitle()

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -124,10 +124,12 @@ class ToolTip {
     this.$id = generateId(this.constructor.NAME)
     this.$root = $root || null
     this.$routeWatcher = null
-    // We keep a bound copy of the forceHide, doHide and doShow methods for root/modal listeners
+    // We keep a bound version of handlers for root/modal listeners
     this.$forceHide = this.forceHide.bind(this)
     this.$doHide = this.doHide.bind(this)
     this.$doShow = this.doShow.bind(this)
+    this.$doDisable = this.doDisable.bind(this)
+    this.$doEnable = this.doEnable.bind(this)
     // Set the configuration
     this.updateConfig(config)
   }
@@ -206,6 +208,8 @@ class ToolTip {
     this.$forceHide = null
     this.$doHide = null
     this.$doShow = null
+    this.$doDisable = null
+    this.$doEnable = null
   }
 
   enable () {
@@ -242,9 +246,6 @@ class ToolTip {
   show () {
     if (!document.body.contains(this.$element) || !isVisible(this.$element)) {
       // If trigger element isn't in the DOM or is not visible
-      return
-    }
-    if (!this.$isEnabled) {
       return
     }
     // Build tooltip element (also sets this.$tip)
@@ -645,8 +646,8 @@ class ToolTip {
       eventOff(this.$element, evt, this)
     }, this)
 
-    // Stop listening for global show/hide events
-    this.setRootListener(true)
+    // Stop listening for global show/hide/enable/disable events
+    this.setRootListener(false)
   }
 
   handleEvent (e) {
@@ -654,6 +655,10 @@ class ToolTip {
     if (isDisabled(this.$element)) {
       // If disabled, don't do anything. Note: if tip is shown before element gets
       // disabled, then tip not close until no longer disabled or forcefully closed.
+      return
+    }
+    if (!this.$isEnabled) {
+      // If not enable
       return
     }
     const type = e.type
@@ -729,13 +734,15 @@ class ToolTip {
     if (this.$root) {
       this.$root[on ? '$on' : '$off'](`bv::hide::${this.constructor.NAME}`, this.$doHide)
       this.$root[on ? '$on' : '$off'](`bv::show::${this.constructor.NAME}`, this.$doShow)
+      this.$root[on ? '$on' : '$off'](`bv::disable::${this.constructor.NAME}`, this.$doDisable)
+      this.$root[on ? '$on' : '$off'](`bv::enable::${this.constructor.NAME}`, this.$doEnable)
     }
   }
 
   doHide (id) {
-    // Programmatically hide this tooltip or popover
+    // Programmatically hide tooltip or popover
     if (!id) {
-      // Close all tooltip or popovers
+      // Close all tooltips or popovers
       this.forceHide()
     } else if (this.$element && this.$element.id && this.$element.id === id) {
       // Close this specific tooltip or popover
@@ -744,9 +751,35 @@ class ToolTip {
   }
 
   doShow (id) {
-    // Programmatically show this tooltip or popover
-    if (id && this.$element && this.$element.id && this.$element.id === id) {
+    // Programmatically show tooltip or popover
+    if (!id) {
+      // Open all tooltips or popovers
       this.show()
+    } else if (id && this.$element && this.$element.id && this.$element.id === id) {
+      // Show this specific tooltip or popover
+      this.show()
+    }
+  }
+
+  doDisable (id) {
+    // Programmatically disable tooltip or popover
+    if (!id) {
+      // Disable all tooltips or popovers
+      this.disable()
+    } else if (this.$element && this.$element.id && this.$element.id === id) {
+      // Disable this specific tooltip or popover
+      this.disble()
+    }
+  }
+
+  doEnable (id) {
+    // Programmatically enable tooltip or popover
+    if (!id) {
+      // Enable all tooltips or popovers
+      this.enable()
+    } else if (this.$element && this.$element.id && this.$element.id === id) {
+      // Enable this specific tooltip or popover
+      this.enable()
     }
   }
 

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -124,7 +124,7 @@ class ToolTip {
     this.$id = generateId(this.constructor.NAME)
     this.$root = $root || null
     this.$routeWatcher = null
-    // We keep a bound version of handlers for root/modal listeners
+    // We use a bound version of the following handlers for root/modal listeners to maintain the 'this' context
     this.$forceHide = this.forceHide.bind(this)
     this.$doHide = this.doHide.bind(this)
     this.$doShow = this.doShow.bind(this)

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -208,11 +208,11 @@ class ToolTip {
     this.$doShow = null
   }
 
-  enable() {
+  enable () {
     this.$isEnabled = true
   }
 
-  disable() {
+  disable () {
     this.$isEnabled = false
   }
 

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -213,11 +213,25 @@ class ToolTip {
   }
 
   enable () {
+    // Create a non-cancelable BvEvent
+    const enabledEvt = new BvEvent('enabled', {
+      cancelable: false,
+      target: this.$element,
+      relatedTarget: null
+    })
     this.$isEnabled = true
+    this.emitEvent(enabledEvt)
   }
 
   disable () {
+    // Create a non-cancelable BvEvent
+    const disabledEvt = new BvEvent('disabled', {
+      cancelable: false,
+      target: this.$element,
+      relatedTarget: null
+    })
     this.$isEnabled = false
+    this.emitEvent(disabledEvt)
   }
 
   // Click toggler

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -782,7 +782,7 @@ class ToolTip {
       this.disable()
     } else if (this.$element && this.$element.id && this.$element.id === id) {
       // Disable this specific tooltip or popover
-      this.disble()
+      this.disable()
     }
   }
 


### PR DESCRIPTION
Adds a new syncable prop `disabled` to disabled/enable tooltip/popove componentsr. Defaults to `false`

Also introduces new root events for enabling/disabling all/specific tooltips/popovers (components and directives)

Addresses issue #1065 
