### PR TITLE
fix(button): allow custom size classes to be passed to the size prop

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -1,5 +1,5 @@
 import { mergeData, pluckProps } from '../../utils'
-import { arrayIncludes, concat } from '../../utils/array'
+import { concat } from '../../utils/array'
 import { assign, keys } from '../../utils/object'
 import { addClass, removeClass } from '../../utils/dom'
 import Link, { propsFactory as linkPropsFactory } from '../link/link'

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -15,8 +15,7 @@ const btnProps = {
   },
   size: {
     type: String,
-    default: null,
-    validator: size => arrayIncludes(['sm', '', 'lg'], size)
+    default: null
   },
   variant: {
     type: String,


### PR DESCRIPTION
Removed the validator for the size prop, so that people can use custom `.btn-{size}` classes