### PR TITLE
perf(dropdowns): use non reactive property to store popper.js instance

### DIFF
--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -249,7 +249,6 @@ export default {
         return
       }
       evt.preventDefault()
-      evt.stopPropagation()
       if (this.disabled) {
         this.visible = false
         return

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -87,6 +87,12 @@ export default {
     // Use new namespaced events
     this.listenOnRoot('bv::link::clicked', listener)
   },
+  deactivated() {
+    // In case we are inside a `<keep-alive>`
+    this.visible = false
+    this.setTouchStart(false)
+    this.removePopper()
+  },
   beforeDestroy () {
     this.visible = false
     this.setTouchStart(false)

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -88,8 +88,9 @@ export default {
     this.listenOnRoot('bv::link::clicked', listener)
   },
   beforeDestroy () {
-    this.removePopper()
+    this.visible = false
     this.setTouchStart(false)
+    this.removePopper()
   },
   watch: {
     visible (state, old) {

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -75,17 +75,12 @@ export default {
     this._popper = null
   },
   mounted () {
-    const listener = vm => {
-      if (vm !== this) {
-        this.visible = false
-      }
-    }
     // To keep one dropdown opened on page
-    this.listenOnRoot('bv::dropdown::shown', listener)
+    this.listenOnRoot('bv::dropdown::shown', this.rootCloseListener)
     // Hide when clicked on links
-    this.listenOnRoot('clicked::link', listener)
+    this.listenOnRoot('clicked::link', this.rootCloseListener)
     // Use new namespaced events
-    this.listenOnRoot('bv::link::clicked', listener)
+    this.listenOnRoot('bv::link::clicked', this.rootCloseListener)
   },
   deactivated () {
     // In case we are inside a `<keep-alive>`
@@ -221,6 +216,11 @@ export default {
     },
     _noop () {
       // Do nothing event handler (used in touchstart event handler)
+    },
+    rootCloseListener (vm) {
+      if (vm !== this) {
+        this.visible = false
+      }
     },
     clickOutListener () {
       this.visible = false

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -87,7 +87,7 @@ export default {
     // Use new namespaced events
     this.listenOnRoot('bv::link::clicked', listener)
   },
-  deactivated() {
+  deactivated () {
     // In case we are inside a `<keep-alive>`
     this.visible = false
     this.setTouchStart(false)


### PR DESCRIPTION
Moving the Popper.js instance to a non-reactive property will prevent Vue from creating reactive getters/setters on the popper instance.

May address issue #1391 