### PR TITLE
fix(modal): rounded-top class no longer needed when header variant applied

### DIFF
--- a/src/components/modal/_modal.js
+++ b/src/components/modal/_modal.js
@@ -383,9 +383,7 @@ export default {
     headerClasses () {
       return [
         'modal-header',
-        // Rounding is needed to fix a bug in bootstrap V4.beta.1 CSS
         {
-          'rounded-top': Boolean(this.headerBgVariant),
           [`bg-${this.headerBgVariant}`]: Boolean(this.headerBgVariant),
           [`text-${this.headerTextVariant}`]: Boolean(this.headerTextVariant),
           [`border-${this.headerBorderVariant}`]: Boolean(this.headerBorderVariant)
@@ -404,9 +402,7 @@ export default {
     footerClasses () {
       return [
         'modal-footer',
-        // Rounding is needed to fix a bug in bootstrap V4.beta.1 CSS
         {
-          'rounded-bottom': Boolean(this.footerBgVariant),
           [`bg-${this.footerBgVariant}`]: Boolean(this.footerBgVariant),
           [`text-${this.footerTextVariant}`]: Boolean(this.footerTextVariant),
           [`border-${this.footerBorderVariant}`]: Boolean(this.footerBorderVariant)


### PR DESCRIPTION
The original bug (https://github.com/twbs/bootstrap/issues/23798) was fixed in Bootstrap V4.beta.2: https://github.com/twbs/bootstrap/pull/23799

Fixes #1432 
