### PR TITLE
feat(tooltip+popover): add boundary element config option (position constraint)

### DIFF
--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -237,6 +237,7 @@ export default {
 | `delay` | `0` | Delay showing and hiding of popover by specified number of milliseconds. Can also be defined as an object in the form of `{ show: 100, hide: 400 }` allowing different show and hide delays | `0` and up, integers only.
 | `offset` | `0` | Shift the center of the popover by specified number of pixels. Also affects the position of the popover arrow. | Any negative or positive integer
 | `container` | `null` | Element string ID to append rendered popover into. If `null` or element not found, popover is appended to `<body>` (default) | Any valid in-document unique  element ID.
+| `boundary` | `'scrollParent'` | The container that the popover will be constrained visually. The default should suffice in most cases, but you may need to chagne this if your target element is in a small container with overflow scroll | `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.
 
 
 ### Programmatically show and hide popover

--- a/src/components/popover/fixtures/popover.html
+++ b/src/components/popover/fixtures/popover.html
@@ -3,9 +3,13 @@
     <div class="row">
         <div v-for="placement in ['top', 'left', 'right', 'bottom']" :key="placement">
             <b-btn :id="placement" variant="primary">{{ placement }}</b-btn>
-            <b-popover :target="placement" :placement="placement" :title="placement">
+            <b-popover :target="placement" triggers="click" :placement="placement" :title="placement">
                 {{ placement }}
             </b-popover>
         </div>
+    </div>
+    <h4 class="mt-sm-4 ms-sm-4 text-muted">Directive</h4>
+    <div class="row">
+      <b-btn id="directive1" v-b-popover.top.click.viewport="'content'" title="popover" variant="primary">Directive 1</b-btn>
     </div>
 </div>

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -167,6 +167,7 @@ by `focus`, and the user then clicks the trigger element, they must click it aga
 | `delay` | `0` | Delay showing and hiding of tooltip by specified number of milliseconds. Can also be specified as an object in the form of `{ show: 100, hide: 400 }` allowing different show and hide delays | `0` and up, integers only.
 | `offset` | `0` | Shift the center of the tooltip by specified number of pixels | Any negative or positive integer
 | `container` | `null` | Element string ID to append rendered tooltip into. If `null` or element not found, tooltip is appended to `<body>` (default) | Any valid in-document unique element ID.
+| `boundary` | `'scrollParent'` | The container that the tooltip will be constrained visually. The default should suffice in most cases, but you may need to chagne this if your target element is in a small container with overflow scroll | `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.
 
 
 ### Programmatically show and hide tooltip

--- a/src/components/tooltip/fixtures/tooltip.html
+++ b/src/components/tooltip/fixtures/tooltip.html
@@ -1,4 +1,16 @@
 <div id="app">
-    <b-btn id="button" variant="outline-success">Live chat</b-btn>
-    <b-tooltip target="button">Online</b-tooltip>
+  <b-btn id="button1">Button 1</b-btn>
+  <b-tooltip target="button1">Tooltip 1</b-tooltip>
+  <br>
+  <b-btn id="button2">Button 2</b-btn>
+  <b-tooltip target="button2" title="Tooltip 2"></b-tooltip>
+  <br>
+  <b-btn id="button3">Button 3</b-btn>
+  <b-tooltip target="button3" boundary="viewport">Tooltip 3</b-tooltip>
+  <br>
+  <b-btn id="button4">Button 4</b-btn>
+  <b-tooltip target="button4" placement="bottom">Tooltip 4</b-tooltip>
+  <br>
+  <b-btn id="button5">Button 4</b-btn>
+  <b-tooltip target="button5" trigger="click">Tooltip 4</b-tooltip>
 </div>

--- a/src/components/tooltip/fixtures/tooltip.html
+++ b/src/components/tooltip/fixtures/tooltip.html
@@ -11,6 +11,12 @@
   <b-btn id="button4">Button 4</b-btn>
   <b-tooltip target="button4" placement="bottom">Tooltip 4</b-tooltip>
   <br>
-  <b-btn id="button5">Button 4</b-btn>
-  <b-tooltip target="button5" trigger="click">Tooltip 4</b-tooltip>
+  <b-btn id="button5">Button 5</b-btn>
+  <b-tooltip target="button5" trigger="click">Tooltip 5</b-tooltip>
+  <br>
+  <h5>Directive</h5>
+  <br>
+  <b-btn id="button6" v-b-tooltip.top.click title="Tooltip 6">Button 6</b-btn>
+  <br>
+  <b-btn id="button7" v-b-tooltip.right.focus="'Tooltip 7'">Button 7</b-btn>
 </div>

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -334,6 +334,7 @@ Where `[mod]` can be (all optional):
  - `html` to enable rendering raw HTML. by default HTML is escaped and converted to text.
  - A delay value in the format of `d###` (where `###` is in ms, defaults to 0).
  - An offset value in pixels in the format of `o###` (where `###` is the number of pixels, defaults to 0. Negative values are allowed). Note if an offset is supplied, then the alignment positions will fallback to one of `top`, `bottom`, `left`, or `right`.
+ - A boundary setting of `window` or `viewport`.  The element to constrain the visual placement of the popover. If not specified, the boundary defaults to the trigger element's scroll parent (in most cases this will suffice).
 
 Where `[container]` can be (optional):
  - An element ID (minus the #) to place the popover markup in when visible

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -53,7 +53,7 @@ function parseBindings (bindings) {
       config.placement = mod
     } else if (/^(window|viewport)$/.test(mod)) {
       // bounday of popover
-      config.boundariesElement = mod
+      config.boundary = mod
     } else if (/^d\d+$/.test(mod)) {
       // delay value
       const delay = parseInt(mod.slice(1), 10) || 0

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -18,6 +18,7 @@ const validTriggers = {
 
 // Build a PopOver config based on bindings (if any)
 // Arguments and modifiers take precedence over pased value config object
+/* istanbul ignore next: not easy to test */
 function parseBindings (bindings) {
   // We start out with a blank config
   let config = {}
@@ -104,6 +105,7 @@ function parseBindings (bindings) {
 //
 // Add or Update popover on our element
 //
+/* istanbul ignore next: not easy to test */
 function applyBVPO (el, bindings, vnode) {
   if (!inBrowser) {
     return
@@ -138,6 +140,7 @@ function removeBVPO (el) {
 /*
  * Export our directive
  */
+/* istanbul ignore next: not easy to test */
 export default {
   bind (el, bindings, vnode) {
     applyBVPO(el, bindings, vnode)
@@ -155,7 +158,6 @@ export default {
       applyBVPO(el, bindings, vnode)
     }
   },
-  /* istanbul ignore next */
   unbind (el) {
     removeBVPO(el)
   }

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -51,6 +51,9 @@ function parseBindings (bindings) {
     } else if (/^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom)?|right(top|bottom)?)$/.test(mod)) {
       // placement of popover
       config.placement = mod
+    } else if (/^(window|viewport)$/.test(mod)) {
+      // bounday of popover
+      config.boundariesElement = mod
     } else if (/^d\d+$/.test(mod)) {
       // delay value
       const delay = parseInt(mod.slice(1), 10) || 0

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -8,7 +8,7 @@ const inBrowser = typeof window !== 'undefined' && typeof document !== 'undefine
 // Key which we use to store tooltip object on element
 const BVPO = '__BV_PopOver__'
 
-// Vlid event triggers
+// Valid event triggers
 const validTriggers = {
   'focus': true,
   'hover': true,
@@ -123,6 +123,7 @@ function applyBVPO (el, bindings, vnode) {
 //
 // Remove popover on our element
 //
+/* istanbul ignore next */
 function removeBVPO (el) {
   if (!inBrowser) {
     return
@@ -154,6 +155,7 @@ export default {
       applyBVPO(el, bindings, vnode)
     }
   },
+  /* istanbul ignore next */
   unbind (el) {
     removeBVPO(el)
   }

--- a/src/directives/scrollspy/scrollspy.js
+++ b/src/directives/scrollspy/scrollspy.js
@@ -63,6 +63,7 @@ function addBVSS (el, binding, vnode) {
   return el[BVSS]
 }
 
+/* istanbul ignore next */
 function removeBVSS (el) {
   if (el[BVSS]) {
     el[BVSS].dispose()
@@ -87,6 +88,7 @@ export default {
   componentUpdated (el, binding, vnode) {
     addBVSS(el, binding, vnode)
   },
+  /* istanbul ignore next */
   unbind (el) {
     if (isServer) {
       return

--- a/src/directives/scrollspy/scrollspy.js
+++ b/src/directives/scrollspy/scrollspy.js
@@ -63,7 +63,6 @@ function addBVSS (el, binding, vnode) {
   return el[BVSS]
 }
 
-/* istanbul ignore next */
 function removeBVSS (el) {
   if (el[BVSS]) {
     el[BVSS].dispose()
@@ -88,7 +87,6 @@ export default {
   componentUpdated (el, binding, vnode) {
     addBVSS(el, binding, vnode)
   },
-  /* istanbul ignore next */
   unbind (el) {
     if (isServer) {
       return

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -247,6 +247,7 @@ Where [modX] can be (all optional):
  - `html` to enable rendering raw HTML. by default HTML is escaped and converted to text
  - A delay value in the format of `d###` (where `###` is in ms, defaults to 0);
  - An offset value in pixels in the format of `o###` (where `###` is the number of pixels, defaults to 0. Negative values allowed)
+ - A boundary setting of `window` or `viewport`.  The element to constrain the visual placement of the tooltip. If not specified, the boundary defaults to the trigger element's scroll parent (in most cases this will suffice).
 
 Where `<value>` can be (optional):
  - A string containing the title of the tooltip
@@ -268,6 +269,7 @@ Where `<value>` can be (optional):
 | `trigger` | String | `'hover focus'` | How tooltip is triggered: `click`, `hover`, `focus`. You may pass multiple triggers; separate them with a space.
 | `offset` | Number or String | `0` | Offset of the tooltip relative to its target. For more information refer to Popper.js's offset docs.
 | `fallbackPlacement` | String or Array | `'flip'` | Allow to specify which position Popper will use on fallback. For more information refer to Popper.js's behavior docs
+| `boundary` | String or HTMLElement reference |`'scrollParent'` | The container that the tooltip will be constrained visually. The default should suffice in most cases, but you may need to chagne this if your target element is in a small container with overflow scroll. Supported values: `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.
 
 
 ### Usage

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -123,6 +123,7 @@ function applyBVTT (el, bindings, vnode) {
 //
 // Remove tooltip on our element
 //
+/* istanbul ignore next */
 function removeBVTT (el) {
   if (!inBrowser) {
     return
@@ -154,6 +155,7 @@ export default {
       applyBVTT(el, bindings, vnode)
     }
   },
+  /* istanbul ignore next */
   unbind (el) {
     removeBVTT(el)
   }

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -53,7 +53,7 @@ function parseBindings (bindings) {
       config.placement = mod
     } else if (/^(window|viewport)$/.test(mod)) {
       // bounday of tooltip
-      config.boundariesElement = mod
+      config.boundary = mod
     } else if (/^d\d+$/.test(mod)) {
       // delay value
       const delay = parseInt(mod.slice(1), 10) || 0

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -18,6 +18,7 @@ const validTriggers = {
 
 // Build a ToolTip config based on bindings (if any)
 // Arguments and modifiers take precedence over passed value config object
+/* istanbul ignore next: not easy to test */
 function parseBindings (bindings) {
   // We start out with a blank config
   let config = {}
@@ -104,6 +105,7 @@ function parseBindings (bindings) {
 //
 // Add or Update tooltip on our element
 //
+/* istanbul ignore next: not easy to test */
 function applyBVTT (el, bindings, vnode) {
   if (!inBrowser) {
     return
@@ -123,7 +125,7 @@ function applyBVTT (el, bindings, vnode) {
 //
 // Remove tooltip on our element
 //
-/* istanbul ignore next */
+/* istanbul ignore next: not easy to test */
 function removeBVTT (el) {
   if (!inBrowser) {
     return
@@ -138,6 +140,7 @@ function removeBVTT (el) {
 /*
  * Export our directive
  */
+/* istanbul ignore next: not easy to test */
 export default {
   bind (el, bindings, vnode) {
     applyBVTT(el, bindings, vnode)
@@ -155,7 +158,6 @@ export default {
       applyBVTT(el, bindings, vnode)
     }
   },
-  /* istanbul ignore next */
   unbind (el) {
     removeBVTT(el)
   }

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -51,6 +51,9 @@ function parseBindings (bindings) {
     } else if (/^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom)?|right(top|bottom)?)$/.test(mod)) {
       // placement of tooltip
       config.placement = mod
+    } else if (/^(window|viewport)$/.test(mod)) {
+      // bounday of tooltip
+      config.boundariesElement = mod
     } else if (/^d\d+$/.test(mod)) {
       // delay value
       const delay = parseInt(mod.slice(1), 10) || 0

--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -161,7 +161,7 @@ export default {
         // Container curently needs to be an ID with '#' prepended, if null then body is used
         container: cont ? (/^#/.test(cont) ? cont : `#${cont}`) : false,
         // boundariesElement passed to popper
-        boundariesElement: this.boundary,
+        boundary: this.boundary,
         // Show/Hide delay
         delay: delay || 0,
         // Offset can be css distance. if no units, pixels are assumed

--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -54,6 +54,12 @@ export default {
       type: String,
       default: null
     },
+    boundary: {
+      // String: scrollParent, window, or viewport
+      // Element: element reference
+      type: [String, Object],
+      default: 'scrollParent'
+    },
     show: {
       type: Boolean,
       default: false
@@ -154,6 +160,8 @@ export default {
         placement: PLACEMENTS[this.placement] || 'auto',
         // Container curently needs to be an ID with '#' prepended, if null then body is used
         container: cont ? (/^#/.test(cont) ? cont : `#${cont}`) : false,
+        // boundariesElement passed to popper
+        boundariesElement: this.boundary,
         // Show/Hide delay
         delay: delay || 0,
         // Offset can be css distance. if no units, pixels are assumed

--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -122,10 +122,12 @@ export default {
       this._toolpop.updateConfig(this.getConfig())
     }
   },
+  /* istanbul ignore next: not easy to test */
   activated () {
     // Called when component is inside a <keep-alive> and component brought offline
     this.setObservers(true)
   },
+  /* istanbul ignore next: not easy to test */
   deactivated () {
     // Called when component is inside a <keep-alive> and component taken offline
     if (this._toolpop) {
@@ -133,6 +135,7 @@ export default {
       this._toolpop.hide()
     }
   },
+  /* istanbul ignore next: not easy to test */
   beforeDestroy () {
     // Shutdown our local event listeners
     this.$off('open', this.onOpen)
@@ -285,6 +288,7 @@ export default {
         this.$el.appendChild(this.$refs.content)
       }
     },
+    /* istanbul ignore next: not easy to test */
     setObservers (on) {
       if (on) {
         if (this.$refs.title) {

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -409,6 +409,7 @@ class ToolTip {
     }
 
     // Transitionend Callback
+    /* istanbul ignore next */
     const complete = () => {
       if (this.$hoverState !== HoverState.SHOW && tip.parentNode) {
         // Remove tip from dom, and force recompile on next show
@@ -494,6 +495,7 @@ class ToolTip {
     this.$popper = null
   }
 
+  /* istanbul ignore next */
   transitionOnce (tip, complete) {
     const transEvents = this.getTransitionEndEvents()
     let called = false
@@ -711,6 +713,7 @@ class ToolTip {
     }
   }
 
+  /* istanbul ignore next */
   setRouteWatcher (on) {
     if (on) {
       this.setRouteWatcher(false)
@@ -732,6 +735,7 @@ class ToolTip {
     }
   }
 
+  /* istanbul ignore next */
   setModalListener (on) {
     const modal = closest(MODAL_CLASS, this.$element)
     if (!modal) {
@@ -744,6 +748,7 @@ class ToolTip {
     }
   }
 
+  /* istanbul ignore next */
   setRootListener (on) {
     // Listen for global 'bv::{hide|show}::{tooltip|popover}' hide request event
     if (this.$root) {
@@ -798,6 +803,7 @@ class ToolTip {
     }
   }
 
+  /* istanbul ignore next */
   setOnTouchStartListener (on) {
     // if this is a touch-enabled device we add extra
     // empty mouseover listeners to the body's immediate children;
@@ -814,6 +820,7 @@ class ToolTip {
     }
   }
 
+  /* istanbul ignore next */
   _noop () {
     // Empty noop handler for ontouchstart devices
   }
@@ -828,6 +835,7 @@ class ToolTip {
   }
 
   // Enter handler
+  /* istanbul ignore next */
   enter (e) {
     if (e) {
       this.$activeTrigger[e.type === 'focusin' ? 'focus' : 'hover'] = true
@@ -850,6 +858,7 @@ class ToolTip {
   }
 
   // Leave handler
+  /* istanbul ignore next */
   leave (e) {
     if (e) {
       this.$activeTrigger[e.type === 'focusout' ? 'focus' : 'hover'] = false

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -86,7 +86,8 @@ const Defaults = {
   arrowPadding: 6,
   container: false,
   fallbackPlacement: 'flip',
-  callbacks: {}
+  callbacks: {},
+  boundariesElement: 'scrollParent'
 }
 
 // Transition Event names
@@ -880,7 +881,8 @@ class ToolTip {
       modifiers: {
         offset: { offset: this.getOffset(placement, tip) },
         flip: { behavior: this.$config.fallbackPlacement },
-        arrow: { element: '.arrow' }
+        arrow: { element: '.arrow' },
+        preventOverflow: { boundariesElement: this.$config.boundariesElement }
       },
       onCreate: data => {
         // Handle flipping arrow classes

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -87,7 +87,7 @@ const Defaults = {
   container: false,
   fallbackPlacement: 'flip',
   callbacks: {},
-  boundariesElement: 'scrollParent'
+  boundary: 'scrollParent'
 }
 
 // Transition Event names
@@ -882,7 +882,7 @@ class ToolTip {
         offset: { offset: this.getOffset(placement, tip) },
         flip: { behavior: this.$config.fallbackPlacement },
         arrow: { element: '.arrow' },
-        preventOverflow: { boundariesElement: this.$config.boundariesElement }
+        preventOverflow: { boundariesElement: this.$config.boundary }
       },
       onCreate: data => {
         // Handle flipping arrow classes


### PR DESCRIPTION
Adds new prop `boundary` to component versions - can be either `scrollParent` (Popper default), `window`, `viewport`, or an element reference

Adds modifiers `window` and `viewport` to directive versions (if not present defaults to scrollParent)

Addresses #1434 

A similar issue (#1163 and https://github.com/twbs/bootstrap/issues/24251) applies to dropdowns, which will be addressed in a separate PR #1440  PR https://github.com/twbs/bootstrap/pull/24979 addresses the issue in Bootstrap V4 official.