### PR TITLE
feat(dropdowns): add boundary prop for controlling placement constraint

### DIFF
--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -180,10 +180,10 @@ you can sepcify a boundary element via the `boundary` prop.  Supported values ar
 is passed directly to Popper.js's `boundariesElement` configurtion option.
 
 **Note:** when `boundary` is any value other than the default of `'scrollParent'`, the style
-`position: static` is applied to to the dropdown's root element in order to allow the
-menu to "break-out" of its scroll container. This may affect layout if you are _floating_
-your dropdown to the left or right. In these cases you will need to place the dropdown _inside_
-a floated element instead of floating the dropdown directly.
+`position: static` is applied to to the dropdown component's root element in order to allow the
+menu to "break-out" of its scroll container. In some situations this may affect your layout or
+positioning of the dropdown trigger button. In these cases you may need to wrap your
+dropdown inside another element.
 
 ## Split button support
 Create a split dropdown button, where the left button provides standard

--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -171,6 +171,13 @@ the toggle button:
 <!-- dropdown-offset.vue -->
 ```
 
+### Boundary constraint
+By default, dropdowns are visually constrained to its scroll parent, which will suffice
+in most situations.  However, if you place a dropdown inside an element that has `overflow: scroll`
+(or similar) set, the drodpwon menu may - in some situations - get cut off.  To get around this,
+you can sepcify a boundary element via the `boundary` prop.  Supported values are `'scrollParent'`
+(the default), `'viewport'`, `'window'` or a reference to an HTML element. The boundary value
+is passed directly to Popper.js's `boundariesElement` configurtion option.
 
 ## Split button support
 Create a split dropdown button, where the left button provides standard

--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -180,7 +180,7 @@ you can sepcify a boundary element via the `boundary` prop.  Supported values ar
 is passed directly to Popper.js's `boundariesElement` configurtion option.
 
 **Note:** when `boundary` is any value other than the default of `'scrollParent'`, the style
-`position: fixed` is applied to to the dropdown's root element in order to allow the
+`position: static` is applied to to the dropdown's root element in order to allow the
 menu to "break-out" of its scroll container. This may affect layout if you are _floating_
 your dropdown to the left or right. In these cases you will need to place the dropdown _inside_
 a floated element instead of floating the dropdown directly.

--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -179,6 +179,12 @@ you can sepcify a boundary element via the `boundary` prop.  Supported values ar
 (the default), `'viewport'`, `'window'` or a reference to an HTML element. The boundary value
 is passed directly to Popper.js's `boundariesElement` configurtion option.
 
+**Note:** when `boundary` is any value other than the default of `'scrollParent'`, the style
+`position: fixed` is applied to to the dropdown's root element in order to allow the
+menu to "break-out" of its scroll container. This may affect layout if you are _floating_
+your dropdown to the left or right. In these cases you will need to place the dropdown _inside_
+a floated element instead of floating the dropdown directly.
+
 ## Split button support
 Create a split dropdown button, where the left button provides standard
 `click` event support, while the right hand side is the dropdown menu toggle button.

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -97,6 +97,12 @@ export default {
     role: {
       type: String,
       default: 'menu'
+    },
+    boundary: {
+      // String: `scrollParent`, `window` or `viewport`
+      // Object: HTML Element reference
+      type: [String, Object],
+      default: 'scrollParent'
     }
   },
   computed: {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -71,7 +71,16 @@ export default {
       },
       [ this.$slots.default ]
     )
-    return h('div', { attrs: { id: t.safeId() }, class: t.dropdownClasses }, [split, toggle, menu])
+    return h(
+      'div',
+      {
+        attrs: { id: t.safeId() },
+        class: t.dropdownClasses,
+        // Position `static` is needed to allow menu to "breakout" of the scrollParent boundaries
+        style: (t.boundary === 'scrollParent' || !t.boundary) ? {} : { position: 'static' }
+      },
+      [split, toggle, menu]
+    )
   },
   props: {
     split: {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -73,13 +73,8 @@ export default {
     )
     return h(
       'div',
-      {
-        attrs: { id: t.safeId() },
-        class: t.dropdownClasses,
-        // Position `static` is needed to allow menu to "breakout" of the scrollParent boundaries
-        style: (t.boundary === 'scrollParent' || !t.boundary) ? {} : { position: 'static' }
-      },
-      [split, toggle, menu]
+      { attrs: { id: t.safeId() }, class: t.dropdownClasses, style: t.dropdownStyles },
+      [ split, toggle, menu ]
     )
   },
   props: {
@@ -123,6 +118,16 @@ export default {
         this.dropup ? 'dropup' : '',
         this.visible ? 'show' : ''
       ]
+    },
+    dropdownStyles () {
+      // Position `static` is needed to allow menu to "breakout" of the scrollParent boundaries
+      // See https://github.com/twbs/bootstrap/issues/24251#issuecomment-341413786
+      if (this.boundary === 'scrollParent' || !this.boundary) {
+        return {}
+      }
+      // We enable this feature only when the user supplies a boundary other than `scrollParent`
+      // to preserve default functionality
+      return { position: 'static' }
     },
     menuClasses () {
       return [

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -59,10 +59,6 @@ export default {
       type: Boolean,
       default: false
     },
-    boundary: {
-      type: [String, Object],
-      default: 'scrollParent'
-    },
     popperOpts: {
       type: Object,
       default: () => {}
@@ -195,10 +191,12 @@ export default {
           },
           flip: {
             enabled: !this.noFlip
-          },
-          preventOverflow: {
-            boundariesElement: this.boundary
           }
+        }
+      }
+      if (this.boundary) {
+        popperConfig.preventOverflow = {
+          boundariesElement: this.boundary
         }
       }
       return assign(popperConfig, this.popperOpts || {})

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -59,6 +59,10 @@ export default {
       type: Boolean,
       default: false
     },
+    boundary: {
+      type: [String, Object],
+      default: 'scrollParent'
+    },
     popperOpts: {
       type: Object,
       default: () => {}
@@ -191,6 +195,9 @@ export default {
           },
           flip: {
             enabled: !this.noFlip
+          },
+          preventOverflow: {
+            boundariesElement: this.boundary
           }
         }
       }

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -82,12 +82,14 @@ export default {
     // Use new namespaced events
     this.listenOnRoot('bv::link::clicked', this.rootCloseListener)
   },
+  /* istanbul ignore next: not easy to test */
   deactivated () {
     // In case we are inside a `<keep-alive>`
     this.visible = false
     this.setTouchStart(false)
     this.removePopper()
   },
+  /* istanbul ignore next: not easy to test */
   beforeDestroy () {
     this.visible = false
     this.setTouchStart(false)
@@ -219,6 +221,7 @@ export default {
         })
       }
     },
+    /* istanbul ignore next: not easy to test */
     _noop () {
       // Do nothing event handler (used in touchstart event handler)
     },
@@ -269,6 +272,7 @@ export default {
       }
       this.$emit('click', evt)
     },
+    /* istanbul ignore next: not easy to test */
     onKeydown (evt) {
       // Called from dropdown menu context
       const key = evt.keyCode
@@ -286,6 +290,7 @@ export default {
         this.focusNext(evt, true)
       }
     },
+    /* istanbul ignore next: not easy to test */
     onEsc (evt) {
       if (this.visible) {
         this.visible = false
@@ -295,6 +300,7 @@ export default {
         this.$nextTick(this.focusToggler)
       }
     },
+    /* istanbul ignore next: not easy to test */
     onTab (evt) {
       if (this.visible) {
         // TODO: Need special handler for dealing with form inputs
@@ -309,6 +315,7 @@ export default {
       }
       this.visible = false
     },
+    /* istanbul ignore next: not easy to test */
     onMouseOver (evt) {
       // Focus the item on hover
       // TODO: Special handling for inputs? Inputs are in a special .dropdown-form container

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -195,7 +195,7 @@ export default {
         }
       }
       if (this.boundary) {
-        popperConfig.preventOverflow = {
+        popperConfig.modifiers.preventOverflow = {
           boundariesElement: this.boundary
         }
       }


### PR DESCRIPTION
New prop `boundary` which can be `scrollParent` (Popper default), `viewport`, `window` or a reference to an HTML element.

Controls how the placement is constrained visually.

Addresses issue #1163 and https://github.com/twbs/bootstrap/issues/24251

Without `boundary` set (default):
> ![image](https://user-images.githubusercontent.com/2781561/33746081-27f2ad6e-db91-11e7-8ae8-c65be9390cfe.png)

Now (with `boundary` set to `window` or `viewport`):
> ![image](https://user-images.githubusercontent.com/2781561/33746040-e1510aa4-db90-11e7-976e-3a7c14ff8bc5.png)

PR https://github.com/twbs/bootstrap/pull/24976 has been opened at Bootstrap Official to address this issue as well.