### PR TITLE
fix(form-group+progress-bar): fix misspellings in component props

### DIFF
--- a/src/components/form-group/form-group.js
+++ b/src/components/form-group/form-group.js
@@ -213,7 +213,7 @@ export default {
     },
     validated: {
       type: Boolean,
-      value: false
+      default: false
     }
   },
   computed: {

--- a/src/components/progress/progress-bar.js
+++ b/src/components/progress/progress-bar.js
@@ -80,7 +80,7 @@ export default {
     },
     label: {
       type: String,
-      value: null
+      default: null
     },
     // $parent prop values take precedence over the following props
     // Which is why they are defaulted to null


### PR DESCRIPTION
This commit fixes two misspellings im component props that break Vue.js v2.5.11 compatibility.

Closes #1469