### PR TITLE
fix(id): fixed check for _uid in id generator

### DIFF
--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -16,7 +16,7 @@ export default {
     }
   },
   mounted () {
-    if (!this.$isServer && !this.id && this._uid) {
+    if (!this.$isServer && !this.id && typeof this._uid !== 'undefined') {
       this.localId_ = `__BVID__${this._uid}_`
     }
   },


### PR DESCRIPTION
On the first run _uid === 0 and this value fails the check not generating an id for the component.