### PR TITLE
update input group addon changes from bootstrap beta 3

### DIFF
--- a/src/components/input-group/input-group-addon.js
+++ b/src/components/input-group/input-group-addon.js
@@ -18,7 +18,7 @@ export default {
     return h(
       props.tag,
       mergeData(data, {
-        staticClass: 'input-group-addon',
+        staticClass: `input-group-${data.slot === 'left' ? 'prepend' : 'append'}`,
         attrs: { id: props.id }
       }),
       children

--- a/src/components/input-group/input-group-button.js
+++ b/src/components/input-group/input-group-button.js
@@ -1,3 +1,9 @@
+/**
+* This is deprecated as of Bootstrap 4 beta 3
+* Previously class was input-group-btn but is now dropped for append/prepend
+* depending on slot='left' or slot='right' property.
+* See https://github.com/twbs/bootstrap/pull/25020
+ */
 import { mergeData } from '../../utils'
 
 export const props = {
@@ -18,7 +24,7 @@ export default {
     return h(
       props.tag,
       mergeData(data, {
-        staticClass: 'input-group-btn',
+        staticClass: `input-group-${data.slot === 'left' ? 'prepend' : 'append'}`,
         attrs: {
           id: props.id
         }

--- a/src/components/input-group/input-group.spec.js
+++ b/src/components/input-group/input-group.spec.js
@@ -24,15 +24,15 @@ describe('input-group', async () => {
     })
   })
 
-  it('basic should have left `.input-group-addon` as first child', async () => {
+  it('basic should have `.input-group-append` as first child', async () => {
     const { app: { $refs } } = window
 
     const left = $refs.basic.children[0]
     expect(left).toBeDefined()
-    expect(left).toHaveClass('input-group-addon')
+    expect(left).toHaveClass('input-group-append')
   })
 
-  it('basic should have content in left `.input-group-addon`', async () => {
+  it('basic should have content in left `.input-group-prepend`', async () => {
     const { app: { $refs } } = window
 
     const left = $refs.basic.children[0]
@@ -40,15 +40,15 @@ describe('input-group', async () => {
     expect(left.textContent).toContain('$')
   })
 
-  it('basic should have right `.input-group-addon` as last child', async () => {
+  it('basic should have right `.input-group-append` as last child', async () => {
     const { app: { $refs } } = window
 
     const right = $refs.basic.children[2]
     expect(right).toBeDefined()
-    expect(right).toHaveClass('input-group-addon')
+    expect(right).toHaveClass('input-group-append')
   })
 
-  it('basic should have content in right `.input-group-addon`', async () => {
+  it('basic should have content in right `.input-group-append`', async () => {
     const { app: { $refs } } = window
 
     const right = $refs.basic.children[2]
@@ -64,15 +64,15 @@ describe('input-group', async () => {
     expect(input.tagName).toBe('INPUT')
   })
 
-  it('components should have left `.input-group-addon` as first child', async () => {
+  it('components should have left `.input-group-prepend` as first child', async () => {
     const { app: { $refs } } = window
 
     const left = $refs.components.children[0]
     expect(left).toBeDefined()
-    expect(left).toHaveClass('input-group-addon')
+    expect(left).toHaveClass('input-group-prepend')
   })
 
-  it('components should have content in left `.input-group-addon`', async () => {
+  it('components should have content in left `.input-group-prepend`', async () => {
     const { app: { $refs } } = window
 
     const left = $refs.components.children[0]
@@ -80,15 +80,15 @@ describe('input-group', async () => {
     expect(left.textContent).toContain('$')
   })
 
-  it('components should have right `.input-group-btn` as last child', async () => {
+  it('components should have right `.input-group-append` as last child', async () => {
     const { app: { $refs } } = window
 
     const right = $refs.components.children[2]
     expect(right).toBeDefined()
-    expect(right).toHaveClass('input-group-btn')
+    expect(right).toHaveClass('input-group-append')
   })
 
-  it('components should have button in right `.input-group-btn`', async () => {
+  it('components should have button in right `.input-group-append`', async () => {
     const { app: { $refs } } = window
 
     const right = $refs.components.children[2]


### PR DESCRIPTION
This addresses changes introduced in https://github.com/twbs/bootstrap/pull/25020

* drops the `.input-group-addon` class and replaces it with `.input-group-prepend` and `.input-group-append` depending on the value of the slot
* deprecates the `.input-group-btn` class and uses the classes above
* defaults component to `input-group-append` if no slot value provided
* updates specs