### PR TITLE
[WIP] Feat/beta 3 input groups

### DIFF
--- a/src/components/input-group/README.md
+++ b/src/components/input-group/README.md
@@ -3,8 +3,10 @@
 
 ```html
 <div>
-  <b-input-group left="$" right=".00">
+  <b-input-group>
+    <b-input-group-prepend>$</b-input-group-prepend>
     <b-form-input></b-form-input>
+    <b-input-group-append>.00</b-input-group-append>
   </b-input-group>
 
   <br>

--- a/src/components/input-group/fixtures/input-group.html
+++ b/src/components/input-group/fixtures/input-group.html
@@ -1,6 +1,8 @@
 <div id="app">
-    <b-input-group ref="basic" left="$" right=".00">
+    <b-input-group ref="basic">
+        <input-group-prepend>$</input-group-prepend>
         <b-input></b-input>
+        <input-group-append>$</input-group-append>
     </b-input-group>
 
     <b-input-group ref="components">

--- a/src/components/input-group/index.js
+++ b/src/components/input-group/index.js
@@ -1,5 +1,8 @@
 import bInputGroup from './input-group'
 import bInputGroupAddon from './input-group-addon'
+import bInputGroupPrepend from './input-group-prepend'
+import bInputGroupAppend from './input-group-append'
+import bInputGroupText from './input-group-text'
 import bInputGroupButton from './input-group-button'
 import { registerComponents, vueUse } from '../../utils'
 
@@ -8,7 +11,10 @@ import { registerComponents, vueUse } from '../../utils'
 const components = {
   bInputGroup,
   bInputGroupAddon,
+  bInputGroupPrepend,
+  bInputGroupAppend,
   bInputGroupButton,
+  bInputGroupText,
   bInputGroupBtn: bInputGroupButton
 }
 

--- a/src/components/input-group/input-group-append.js
+++ b/src/components/input-group/input-group-append.js
@@ -1,5 +1,6 @@
 import { mergeData } from '../../utils'
 import InputGroupText from './input-group-text'
+
 export const props = {
   id: {
     type: String,
@@ -12,16 +13,18 @@ export const props = {
 }
 
 export default {
-  functional: true,
   props,
-  render (h, { props, data, children }) {
+  functional: true,
+  render (h, {props, data, children}) {
     return h(
       props.tag,
       mergeData(data, {
-        staticClass: `input-group-${data.slot === 'left' ? 'prepend' : 'append'}`,
-        attrs: { id: props.id }
+        staticClass: 'input-group-append',
+        attrs: {
+          id: props.id
+        }
       }),
-      [h(InputGroupText, { }, children)]
+      [h(InputGroupText, { }, children )]
     )
   }
 }

--- a/src/components/input-group/input-group-prepend.js
+++ b/src/components/input-group/input-group-prepend.js
@@ -1,5 +1,6 @@
-import { mergeData } from '../../utils'
 import InputGroupText from './input-group-text'
+import { mergeData } from '../../utils'
+
 export const props = {
   id: {
     type: String,
@@ -12,16 +13,18 @@ export const props = {
 }
 
 export default {
-  functional: true,
   props,
-  render (h, { props, data, children }) {
+  functional: true,
+  render (h, {props, data, children}) {
     return h(
       props.tag,
       mergeData(data, {
-        staticClass: `input-group-${data.slot === 'left' ? 'prepend' : 'append'}`,
-        attrs: { id: props.id }
+        staticClass: 'input-group-prepend',
+        attrs: {
+          id: props.id
+        }
       }),
-      [h(InputGroupText, { }, children)]
+      [h(InputGroupText, { domProps: { innerHTML: '' } }, children)]
     )
   }
 }

--- a/src/components/input-group/input-group-text.js
+++ b/src/components/input-group/input-group-text.js
@@ -1,0 +1,16 @@
+import { mergeData } from '../../utils'
+
+export const props = {
+  tag: {
+    type: String,
+    default: 'div'
+  }
+}
+
+export default {
+  props,
+  functional: true,
+  render (h, { props, data }) {
+    return h(props.tag, mergeData(data, { staticClass: 'input-group-text' }))
+  }
+}

--- a/src/components/input-group/input-group.spec.js
+++ b/src/components/input-group/input-group.spec.js
@@ -24,12 +24,12 @@ describe('input-group', async () => {
     })
   })
 
-  it('basic should have `.input-group-append` as first child', async () => {
+  it('basic should have `div.input-group-prepend` as first child', async () => {
     const { app: { $refs } } = window
 
     const left = $refs.basic.children[0]
     expect(left).toBeDefined()
-    expect(left).toHaveClass('input-group-append')
+    expect(left).toHaveClass('input-group-prepend')
   })
 
   it('basic should have content in left `.input-group-prepend`', async () => {


### PR DESCRIPTION
@pi0 @tmorehouse This is what I got through today. It is **not** working code, but I wanted to get some eyes on it for a little help. Vue is new to me and so I'm using this to learn some internals. I think we can easily migrate from input-addon to the two new components @tmorehouse suggested in #1505 just by swapping it out in input-group.js. I laid out these goals to support this change:

* Support the current way of doing it with left and right properties, but surface some messaging to update the HTML to use `b-input-group-prepend|append`.
* Support for child nodes inside `b-input-group-prepend|append`
* Created a `b-input-group-text` component for handling the child div of `b-input-group-prepend|append`
* Add tests for new components
* Update the docs