### PR TITLE
Fix #1522: Import button-close in alert with a name matching tag.

### DIFF
--- a/src/components/alert/alert.js
+++ b/src/components/alert/alert.js
@@ -1,7 +1,7 @@
-import bBtnClose from '../button/button-close'
+import bButtonClose from '../button/button-close'
 
 export default {
-  components: {bBtnClose},
+  components: {bButtonClose},
   render (h) {
     if (!this.localShow) {
       // If not showing, render placeholder


### PR DESCRIPTION
bButtonClose component was imported in alert with the shortcut alias
(bBtnClose) but used with the full tag (b-button-close). When importing
b-alert as an individual component b-button-close alias was not set and
vue failed to import the b-button-close component.
Importing bButtonClose component with the fullname fix #1522 .