### PR TITLE
Feat/table multi sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lodash.startcase": "^4.4.0",
     "opencollective": "^1.0.3",
     "popper.js": "^1.12.9",
+    "thenby": "^1.2.3",
     "vue-functional-data-merge": "^2.0.3"
   },
   "devDependencies": {

--- a/src/components/table/fixtures/table.js
+++ b/src/components/table/fixtures/table.js
@@ -9,7 +9,8 @@ window.app = new Vue({
       age: {
         label: 'Person age',
         sortable: true,
-        formatter: 'formatAge'
+        formatter: 'formatAge',
+        sortCompare: sortBy => (a, b) => b[sortBy] - a[sortBy] // Inverted
       },
       isActive: {
         label: 'is Active'

--- a/src/components/table/table.spec.js
+++ b/src/components/table/table.spec.js
@@ -421,7 +421,7 @@ describe('table', async () => {
             expect(vm.context.sortBy).toContainEqual({
               key,
               compare,
-              desc: false,
+              desc: false
             })
             sortBy = vm.context.sortBy
           } else {
@@ -468,7 +468,7 @@ describe('table', async () => {
             expect(vm.context.sortBy).toContainEqual({
               key,
               compare,
-              desc: false,
+              desc: false
             })
             sortBy = vm.context.sortBy
           } else {

--- a/src/components/table/table.spec.js
+++ b/src/components/table/table.spec.js
@@ -200,7 +200,7 @@ describe('table', async () => {
   it('sortable columns should have ARIA labels in thead', async () => {
     const { app: { $refs } } = window
     const vm = $refs.table_paginated
-    const ariaLabel = vm.labelSortDesc
+    const ariaLabel = vm.labelSortAsc
 
     const thead = [...vm.$el.children].find(el => el && el.tagName === 'THEAD')
     expect(thead).toBeDefined()
@@ -219,7 +219,7 @@ describe('table', async () => {
   it('sortable columns should have ARIA labels in tfoot', async () => {
     const { app: { $refs } } = window
     const vm = $refs.table_paginated
-    const ariaLabel = vm.labelSortDesc
+    const ariaLabel = vm.labelSortAsc
 
     const tfoot = [...vm.$el.children].find(el => el && el.tagName === 'THEAD')
     expect(tfoot).toBeDefined()
@@ -398,6 +398,7 @@ describe('table', async () => {
     const vm = $refs.table_paginated
     const spy = jest.fn()
     const fieldKeys = Object.keys(vm.fields)
+    const fieldValues = Object.values(vm.fields)
 
     vm.$on('sort-changed', spy)
     const thead = [...vm.$el.children].find(el => el && el.tagName === 'THEAD')
@@ -406,23 +407,31 @@ describe('table', async () => {
       const tr = [...thead.children].find(el => el && el.tagName === 'TR')
       expect(tr).toBeDefined()
       if (tr) {
-        let sortBy = null
+        let sortBy = []
         const ths = [...tr.children]
         expect(ths.length).toBe(fieldKeys.length)
         ths.forEach((th, idx) => {
           th.click()
-          if (vm.fields[fieldKeys[idx]].sortable) {
+
+          const key = fieldKeys[idx]
+          const compare = fieldValues[idx].sortCompare ? fieldValues[idx].sortCompare : null
+
+          if (fieldValues[idx].sortable) {
             expect(spy).toHaveBeenCalledWith(vm.context)
-            expect(vm.context.sortBy).toBe(fieldKeys[idx])
+            expect(vm.context.sortBy).toContainEqual({
+              key,
+              compare,
+              desc: false,
+            })
             sortBy = vm.context.sortBy
           } else {
             if (sortBy) {
               expect(spy).toHaveBeenCalledWith(vm.context)
-              expect(vm.context.sortBy).toBe(null)
-              sortBy = null
+              expect(vm.context.sortBy).toEqual([])
+              sortBy = []
             } else {
               expect(spy).not.toHaveBeenCalled()
-              expect(vm.context.sortBy).toBe(null)
+              expect(vm.context.sortBy).toEqual([])
             }
           }
           spy.mockClear()
@@ -436,6 +445,7 @@ describe('table', async () => {
     const vm = $refs.table_paginated
     const spy = jest.fn()
     const fieldKeys = Object.keys(vm.fields)
+    const fieldValues = Object.values(vm.fields)
 
     vm.$on('sort-changed', spy)
     const tfoot = [...vm.$el.children].find(el => el && el.tagName === 'TFOOT')
@@ -444,23 +454,31 @@ describe('table', async () => {
       const tr = [...tfoot.children].find(el => el && el.tagName === 'TR')
       expect(tr).toBeDefined()
       if (tr) {
-        let sortBy = null
+        let sortBy = []
         const ths = [...tr.children]
         expect(ths.length).toBe(fieldKeys.length)
         ths.forEach((th, idx) => {
           th.click()
-          if (vm.fields[fieldKeys[idx]].sortable) {
+
+          const key = fieldKeys[idx]
+          const compare = fieldValues[idx].sortCompare ? fieldValues[idx].sortCompare : null
+
+          if (fieldValues[idx].sortable) {
             expect(spy).toHaveBeenCalledWith(vm.context)
-            expect(vm.context.sortBy).toBe(fieldKeys[idx])
+            expect(vm.context.sortBy).toContainEqual({
+              key,
+              compare,
+              desc: false,
+            })
             sortBy = vm.context.sortBy
           } else {
             if (sortBy) {
               expect(spy).toHaveBeenCalledWith(vm.context)
-              expect(vm.context.sortBy).toBe(null)
-              sortBy = null
+              expect(vm.context.sortBy).toEqual([])
+              sortBy = []
             } else {
               expect(spy).not.toHaveBeenCalled()
-              expect(vm.context.sortBy).toBe(null)
+              expect(vm.context.sortBy).toEqual([])
             }
           }
           spy.mockClear()

--- a/yarn.lock
+++ b/yarn.lock
@@ -8042,6 +8042,10 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
+thenby@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/thenby/-/thenby-1.2.3.tgz#62465b07e3d8b9466f01026df837f738e0faaa69"
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"


### PR DESCRIPTION
Breaking change to table sorting to support multi-column sorting.

The sortBy property changes from a string to an array of objects describing the current sorted columns. Move the sortCompare function to the array of field objects to provide column specific sortCompare functions, and use the default sortCompare when the field doesn't provide its own.

This is a feature I found a need for in the current project I'm working on. I tried to go around the table internal sorting mechanisms at first, but it wasn't great and it took a lot away from the greatness that is bootstrap-vue. In the end I made this modification and maybe there is interest in this specific functionality?

Hope we can make it even better.