### PR TITLE
Call removeEventListener on the right element

### DIFF
--- a/src/mixins/clickout.js
+++ b/src/mixins/clickout.js
@@ -6,7 +6,7 @@ export default {
   },
   beforeDestroy () {
     if (typeof document !== 'undefined') {
-      document.removeEventListener('click', this._clickOutListener)
+      document.documentElement.removeEventListener('click', this._clickOutListener)
     }
   },
   methods: {


### PR DESCRIPTION
When removing the click listener, we were calling `removeEventListener` on the wrong element, and this was causing a memory leak.
fixes #1391 