### PR TITLE
Accept an HTMLElement as a valid target for tooltips and popovers

### DIFF
--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -35,7 +35,7 @@ export default {
   props: {
     target: {
       // String ID of element, or element/component reference
-      type: [String, Object]
+      type: [String, Object, HTMLElement]
     },
     delay: {
       type: [Number, Object, String],


### PR DESCRIPTION
While it works, passing an `HTMLelement` (e.g. an `HTMLButtonElement`) to a tooltip/popover raises the following warning:
```[Vue warn]: Invalid prop: type check failed for prop "target". Expected String, Object, got HTMLButtonElement. ```