### PR TITLE
Always pass selectSize to selects

### DIFF
--- a/src/components/form-select/form-select.js
+++ b/src/components/form-select/form-select.js
@@ -42,7 +42,7 @@ export default {
           id: t.safeId(),
           name: t.name,
           multiple: t.multiple || null,
-          size: t.isMultiple ? t.selectSize : null,
+          size: t.selectSize,
           disabled: t.disabled,
           required: t.required,
           'aria-required': t.required ? 'true' : null,


### PR DESCRIPTION
The size attribute is not specific to multiple-select fields: it can be
used on single selects on both Bootstrap and raw HTML. We could probably
pass the value straight through instead of renaming it "selectSize",
but I'd like to avoid making a breaking API change at this stage.

Fixes #1639