### PR TITLE
Ignore BV keys when auto-discovering table fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ workbox*.js*
 coverage
 es
 docs/static/sw.js
+*.swp

--- a/src/components/table/fixtures/table.html
+++ b/src/components/table/fixtures/table.html
@@ -19,6 +19,8 @@
     </template>
   </b-table>
 
+  <b-table ref="table_without_fields" :items="secondaryItems"></b-table>
+
     <b-table ref="table_responsive" responsive :items="items" :fields="fields"></b-table>
 
     <h2>Paginated Table</h2>

--- a/src/components/table/fixtures/table.js
+++ b/src/components/table/fixtures/table.js
@@ -25,6 +25,14 @@ window.app = new Vue({
     visibleRecords: [],
     isBusy: false,
     providerType: 'array',
+    secondaryItems: [
+      {
+        isActive: false,
+        age: 26,
+        _rowVariant: 'success',
+        name: 'Mitzi'
+      }
+    ],
     items: [
       {
         isActive: true,

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -759,8 +759,15 @@ export default {
       // If no field provided, take a sample from first record (if exits)
       if (fields.length === 0 && this.computedItems.length > 0) {
         const sample = this.computedItems[0]
+        const ignoredKeys = [
+          "_rowVariant",
+          "_cellVariants",
+          "_showDetails"
+        ]
         keys(sample).forEach(k => {
-          fields.push({ key: k, label: startCase(k) })
+          if (!ignoredKeys.includes(k)) {
+            fields.push({ key: k, label: startCase(k) })
+          }
         })
       }
       // Ensure we have a unique array of fields and that they have String labels

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -760,9 +760,9 @@ export default {
       if (fields.length === 0 && this.computedItems.length > 0) {
         const sample = this.computedItems[0]
         const ignoredKeys = [
-          "_rowVariant",
-          "_cellVariants",
-          "_showDetails"
+          '_rowVariant',
+          '_cellVariants',
+          '_showDetails'
         ]
         keys(sample).forEach(k => {
           if (!ignoredKeys.includes(k)) {

--- a/src/components/table/table.spec.js
+++ b/src/components/table/table.spec.js
@@ -48,6 +48,17 @@ describe('table', async () => {
     expect(table.$el.children[0].tagName).toBe('TABLE')
   })
 
+  it('should generate fields automatically from the first item', async () => {
+    const { app: { $refs } } = window
+    const table = $refs.table_without_fields
+    const thead = $refs.table_without_fields.$el.children[0]
+    const tr = thead.children[0]
+
+    // The row should be equal to the items without any of Bootstrap Vue's
+    // utility fields, like _rowVariant, or _cellVariants
+    expect(tr.children.length).toBe(Object.keys(table.items[0]).length - 1)
+  })
+
   it('table_basic should have thead and tbody', async () => {
     const { app: { $refs } } = window
 


### PR DESCRIPTION
Bootstrap-Vue has some extra keys that can be provided to enhance table
functionality. These should be explicitly ignored when automatically
discovering the fields for a table, when the fields prop is not
provided.

The reason for explicitly ignoring the keys, rather than blanket
ignoring all keys beginning with "_" is to minimise any possible
collisions with user provided data in that field.

Fixes #1635