### PR TITLE
fix(select): Fix issues with form-select

### DIFF
--- a/src/components/form-select/form-select.js
+++ b/src/components/form-select/form-select.js
@@ -42,7 +42,7 @@ export default {
           id: t.safeId(),
           name: t.name,
           multiple: t.multiple || null,
-          size: t.selectSize,
+          size: t.computedSelectSize,
           disabled: t.disabled,
           required: t.required,
           'aria-required': t.required ? 'true' : null,
@@ -93,21 +93,20 @@ export default {
     }
   },
   computed: {
+    computedSelectSize () {
+      // Custom selects with a size of zero causes the arrows to be hidden,
+      // so dont render the size attribute in this case
+      return !this.plain && this.selectSize === 0 ? null : this.selectSize
+    },
     inputClass () {
       return [
         'form-control',
         this.stateClass,
         this.sizeFormClass,
         // Awaiting for https://github.com/twbs/bootstrap/issues/23058
-        this.isPlain ? null : 'custom-select',
-        this.isPlain || !this.size ? null : 'custom-select-' + this.size
+        this.plain ? null : 'custom-select',
+        this.plain || !this.size ? null : 'custom-select-' + this.size
       ]
-    },
-    isPlain () {
-      return this.plain || this.isMultiple
-    },
-    isMultiple () {
-      return Boolean(this.multiple && this.selectSize > 1)
     },
     computedAriaInvalid () {
       if (this.ariaInvalid === true || this.ariaInvalid === 'true') {


### PR DESCRIPTION
The form-input component currently has some arbitary restrictions around
the combinations of multiple, custom-select and selectSize that will be
applied. Previously I tried to address this by passing through the
selectSize, but this caused an issue (hiding the arrows) in custom
selects when the size was set to 0.

This patch cleans up the internal computed state of form-select to be
more relaxed about what user input is rendered in the final component

Fixes: #1658