### PR TITLE
fix(table): import lodash.get from "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "bootstrap": "^4.0.0",
+    "lodash.get": "^4.4.2",
     "lodash.startcase": "^4.4.0",
     "opencollective": "^1.0.3",
     "popper.js": "^1.12.9",

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1,5 +1,5 @@
 import startCase from 'lodash.startcase'
-import get from 'lodash/get'
+import get from 'lodash.get'
 import looseEqual from '../../utils/loose-equal'
 import stableSort from '../../utils/stable-sort'
 import KeyCodes from '../../utils/key-codes'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5126,6 +5126,10 @@ lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"


### PR DESCRIPTION
This fixes a breaking bug in the latest update, where `table` can't compile because `lodash/get` is not in `node_modules`. Here's the error message I'm getting:
```
ERROR in ./node_modules/bootstrap-vue/es/components/table/table.js
Module not found: Error: Can't resolve 'lodash/get' in '/home/rjmill/Development/build-chain/node_modules/bootstrap-vue/es/
components/table'
 @ ./node_modules/bootstrap-vue/es/components/table/table.js 4:0-29
 @ ./node_modules/bootstrap-vue/es/components/table/index.js
 @ ./node_modules/bootstrap-vue/es/components/index.js
 @ ./node_modules/bootstrap-vue/es/index.js
 @ ./src/main.js
 @ multi (webpack)-dev-server/client?http://localhost:8080 webpack/hot/dev-server babel-polyfill ./src/main.js
```

`lodash.get` was being imported from `lodash/get`, even though the `lodash` package is not in `dependencies`. (`lodash` *is* in `devDependencies`, however, which is why the tests are still passing.)

This PR adds `lodash.get` to `dependencies` and changes the import statement to pull in `get` from `lodash.get` instead of `lodash/get`

This fixes an issue that looks like #1670. I can open a new issue with more details if need be. Opening a PR with a fix just seemed quicker than describing the problem in an issue :)

Let me know if you need me to change/add anything for this PR. The latest release of bootstrap-vue is unusable in my project until this issue is resolved.