### PR TITLE
feat(tabs/noNavStyle): added related prop and check

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -102,8 +102,8 @@ export default {
       {
         class: [
           'nav',
-          `nav-${this.navStyle}`,
           {
+            [`nav-${this.navStyle}`]: !this.noNavStyle,
             [`card-header-${this.navStyle}`]: this.card && !this.vertical,
             'card-header': this.card && this.vertical,
             'h-100': this.card && this.vertical,
@@ -218,6 +218,10 @@ export default {
       default: false
     },
     noFade: {
+      type: Boolean,
+      default: false
+    },
+    noNavStyle: {
       type: Boolean,
       default: false
     },


### PR DESCRIPTION
`b-tabs` is very convenient to handle content, but its style is currently limited to `nav-tabs` and `nav-pills`. 

`no-nav-style` gets rid of the mandatory `nav-${navStyle}` allowing more customization without the overhead of deflecting `nav-tabs` and `nav-pills` effects. Here's a sample:
![2018-04-08_14-53-41](https://user-images.githubusercontent.com/4192037/38467721-b2847380-3b3c-11e8-9e73-2402b724ccf9.gif)

I'd have introduced a `nav-style` or `nav-variant` prop instead, but it'd have lacked constitency with `pills` prop to remain backward compatible.

cheers