### PR TITLE
docs(modal): fix a typo

### DIFF
--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -430,7 +430,7 @@ You can disable the **Cancel** and **OK** buttons individually by setting the `c
 and `ok-disabled` props, respectively,  to `true`. Set the prop to `false` to re-enable
 the button.
 
-To disable both **Cancel** and **OK** buttons at teh same time, simply set the `busy`
+To disable both **Cancel** and **OK** buttons at the same time, simply set the `busy`
 prop to `true`. Set it to `false` to re-enable both buttons.
 
 


### PR DESCRIPTION
Change "teh" to "the" in the modal README.md