### PR TITLE
fix(typescript): Fixed the typescript export

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,11 +3,9 @@
 // Definitions by: Nicola Bosco <https://github.com/nicolabosco87>
 
 declare module 'bootstrap-vue' {
-    import Vue from 'vue';
+    import Vue, {PluginObject} from 'vue';
 
-    const VuePlugin = {
-        install: function(Vue: any): any;
-    }
+    const VuePlugin : PluginObject<void>
 
     export default VuePlugin;
 


### PR DESCRIPTION
Changed the default export from the TypeScript definition files to use Vue's PluginObject interface. This fixes issue #1741