### PR TITLE
fix: Accept not only integer but other texts like as POPPER.JS (#1728)

### DIFF
--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -922,7 +922,7 @@ class ToolTip {
           return 0
       }
     }
-    return parseFloat(this.$config.offset)
+    return this.$config.offset
   }
 
   getPlacement () {


### PR DESCRIPTION
Hi.

I think that #1728 is the spec now.
But if use the offsets function of POPPER.JS, it can be resolved.
https://popper.js.org/popper-documentation.html#modifiers..offset

Please check it when you have a time.

Keiko