### PR TITLE
fix(tab): fix the delay in tab transition

### DIFF
--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -28,8 +28,7 @@ export default {
         props: { mode: 'out-in' },
         on: {
           beforeEnter: this.beforeEnter,
-          afterEnter: this.afterEnter,
-          afterLeave: this.afterLeave
+          beforeLeave: this.beforeLeave
         }
       },
       [content]
@@ -37,12 +36,11 @@ export default {
   },
   methods: {
     beforeEnter () {
-      this.show = false
+      // change opacity 1 frame after display
+      // otherwise css transition won't happen
+      window.requestAnimationFrame(()=>{this.show = true});
     },
-    afterEnter () {
-      this.show = true
-    },
-    afterLeave () {
+    beforeLeave () {
       this.show = false
     }
   },

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -38,7 +38,7 @@ export default {
     beforeEnter () {
       // change opacity 1 frame after display
       // otherwise css transition won't happen
-      window.requestAnimationFrame(()=>{this.show = true});
+      window.requestAnimationFrame(() => { this.show = true });
     },
     beforeLeave () {
       this.show = false


### PR DESCRIPTION
after this change, bootstrap-vue tab transition has the same behavior as original bootstrap.
hide of the previous tab happens instantly, and the new tab have a 0.15s animation. resolves #1806 

