### PR TITLE
fix(table): Fix Table aria-rowcount

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -358,10 +358,8 @@ export default {
           role: this.isStacked ? 'table' : null,
           'aria-busy': this.computedBusy ? 'true' : 'false',
           'aria-colcount': String(fields.length),
-          'aria-rowcount':
-            this.$attrs['aria-rowcount'] || (this.perPage && this.perPage > 0)
-              ? '-1'
-              : null
+          'aria-rowcount': this.$attrs['aria-rowcount'] ||
+            this.items.length > this.perPage ? this.items.length : null
         }
       },
       [caption, colgroup, thead, tfoot, tbody]


### PR DESCRIPTION
Currently the table component uses this code to set the `aria-rowcount` property:
```javascript
'aria-rowcount': this.$attrs['aria-rowcount'] || (this.perPage && this.perPage > 0)
    ? '-1'  
    : null
```

> https://www.w3.org/TR/wai-aria-1.1/#aria-rowcount
> If all of the rows are present in the DOM, it is not necessary to set this attribute as the user agent can automatically calculate the total number of rows. However, if only a portion of the rows is present in the DOM at a given moment, this attribute is needed to provide an explicit indication of the number of rows in the full table.

> Authors MUST set the value of aria-rowcount to an integer equal to the number of rows in the full table. If the total number of rows is unknown, authors MUST set the value of aria-rowcount to -1 to indicate that the value should not be calculated by the user agent.

According to the WAI-ARIA spec, `aria-rowcount` should only be set to -1 if the total number of rows is unknown. The current code has -1 set as the default for any paged tables.
Furthermore, if all of items are currently displayed on the table, we do not need to set `aria-rowcount` as accessibility readers will automatically count these.

I propose the following code change:
```javascript
'aria-rowcount': this.$attrs['aria-rowcount'] ||
    this.items.length > this.perPage ? this.items.length : null
```