### PR TITLE
fix(readonly): allow readonly to be forced to false when plaintext is enabled

### DIFF
--- a/src/components/form-input/form-input.js
+++ b/src/components/form-input/form-input.js
@@ -39,7 +39,7 @@ export default {
         type: this.localType,
         disabled: this.disabled,
         required: this.required,
-        readonly: this.readonly || this.plaintext,
+        readonly: this.readonly || this.plaintext && this.readonly === null,
         placeholder: this.placeholder,
         autocomplete: this.autocomplete || null,
         'aria-required': this.required ? 'true' : null,
@@ -71,7 +71,7 @@ export default {
     },
     readonly: {
       type: Boolean,
-      default: false
+      default: null
     },
     plaintext: {
       type: Boolean,

--- a/src/components/form-input/form-input.js
+++ b/src/components/form-input/form-input.js
@@ -39,7 +39,7 @@ export default {
         type: this.localType,
         disabled: this.disabled,
         required: this.required,
-        readonly: this.readonly || this.plaintext && this.readonly === null,
+        readonly: this.readonly || (this.plaintext && this.readonly === null),
         placeholder: this.placeholder,
         autocomplete: this.autocomplete || null,
         'aria-required': this.required ? 'true' : null,
@@ -133,7 +133,7 @@ export default {
   methods: {
     format (value, e) {
       if (this.formatter) {
-          return this.formatter(value, e)
+        return this.formatter(value, e)
       }
       return value
     },


### PR DESCRIPTION
plaintext could be convenient to customize `b-input` styling (for example when you need to wrap it into a div), but readonly is currently forced to true, when plaintext is enabled.

this PR introduces an indeterminate state for readonly, and hence allows it to be forced to false even with plaintext enabled.