### PR TITLE
feat(form): emit blur event on form controls

### DIFF
--- a/docs/markdown/reference/validation/README.md
+++ b/docs/markdown/reference/validation/README.md
@@ -86,3 +86,84 @@ This is a verbose example designed to show how Bootstrap-Vue and Vuelidate inter
 
 <!-- form-validation-1.vue -->
 ```
+
+## VeeValidate
+
+VeeValidate provides a simple, flexible and configurable fields validation, without needing a model. Installation instructions and other documentation can be found at https://baianat.github.io/vee-validate.
+
+### Example
+
+This example shows how to add different validation and feedback to two form fields, as well as dynamically disable the submit button based on the form validity. You can test it out live at https://codepen.io/uriannrima/pen/aGPvYm
+
+```html
+<template>
+  <b-form @submit="onSubmit">
+    <b-form-group id="exampleInputGroup1"
+                  label="Name"
+                  label-for="exampleInput1">
+      <b-form-input id="exampleInput1"
+                    type="text"
+                    name="name"
+                    v-model="form.name"
+                    :state="getState('name')"
+                    aria-describedby="input1LiveFeedback"
+                    placeholder="Enter name"
+                    v-validate="{ required: true, min: 3 }" />
+      <b-form-invalid-feedback id="input1LiveFeedback">
+        This is a required field and must be at least 3 characters
+      </b-form-invalid-feedback>
+    </b-form-group>
+    <b-form-group id="exampleInputGroup2"
+                  label="Food"
+                  label-for="exampleInput2">
+      <b-form-select id="exampleInput2"
+                     :options="foods"
+                     name="food"
+                     :state="getState('food')"
+                     v-model="form.food" 
+                     v-validate="{ required: true }"/>
+      <b-form-invalid-feedback id="input2LiveFeedback">
+        This is a required field
+      </b-form-invalid-feedback>
+    </b-form-group>
+    <b-button type="submit"
+              variant="primary"
+              :disabled="errors.any()">
+      Submit
+    </b-button>
+  </b-form>  
+</template>
+
+<script>
+  export default {
+    name: "myForm",
+    data() {
+      return {
+        foods: [
+          "apple",
+          "orange"
+        ],
+        form: {}
+      }
+    },
+    methods: {
+      /** Required to return a null state, since VeeValidate erros only only true or false. */
+      getState(fieldName) {
+        const field = this.$validator.fields.find({
+          name: fieldName
+        });
+        if (field && field.flags.touched) {
+          return field.flags.valid;
+        }
+        return null;
+      },
+      onSubmit() {
+        // form submit logic
+        console.log('Submited');
+      }
+    }
+  }
+</script>
+
+<!-- form-validation-2.vue -->
+```

--- a/src/components/form-checkbox/form-checkbox.js
+++ b/src/components/form-checkbox/form-checkbox.js
@@ -47,7 +47,7 @@ export default {
       domProps: { value: this.value, checked: this.is_Checked },
       on: {
         focus: this.handleFocus,
-        blur: this.handleFocus,
+        blur: this.onBlur,
         change: this.emitChange,
         __c: evt => {
           const $$a = this.computedLocalChecked
@@ -180,6 +180,10 @@ export default {
       this.$refs.check.indeterminate = state
       // Emit update event to prop
       this.$emit('update:indeterminate', this.$refs.check.indeterminate)
+    },
+    onBlur (evt) {
+      this.handleFocus(evt)
+      this.$emit('blur', evt)
     }
   },
   mounted () {

--- a/src/components/form-input/form-input.js
+++ b/src/components/form-input/form-input.js
@@ -47,7 +47,8 @@ export default {
       },
       on: {
         input: this.onInput,
-        change: this.onChange
+        change: this.onChange,
+        blur: this.onBlur
       }
     })
   },
@@ -133,7 +134,7 @@ export default {
   methods: {
     format (value, e) {
       if (this.formatter) {
-          return this.formatter(value, e)
+        return this.formatter(value, e)
       }
       return value
     },
@@ -154,6 +155,9 @@ export default {
       if (!this.disabled) {
         this.$el.focus()
       }
+    },
+    onBlur (evt) {
+      this.$emit('blur', evt)
     }
   }
 }

--- a/src/components/form-radio/form-radio-group.js
+++ b/src/components/form-radio/form-radio-group.js
@@ -30,6 +30,9 @@ export default {
             value: option.value,
             required: Boolean(this.name && this.required),
             disabled: option.disabled
+          },
+          on: {
+            blur: this.onBlur
           }
         },
         [h('span', { domProps: { innerHTML: option.text } })]
@@ -127,6 +130,11 @@ export default {
     get_State () {
       // Required by child radios
       return this.computedState
+    }
+  },
+  methods: {
+    onBlur (evt) {
+      this.$emit('blur', evt)
     }
   }
 }

--- a/src/components/form-radio/form-radio.js
+++ b/src/components/form-radio/form-radio.js
@@ -37,7 +37,7 @@ export default {
       },
       on: {
         focus: this.handleFocus,
-        blur: this.handleFocus,
+        blur: this.onBlur,
         change: this.emitChange,
         __c: evt => {
           this.computedLocalChecked = this.value
@@ -103,6 +103,10 @@ export default {
       if (this.is_Child) {
         this.$parent.$emit('change', this.computedLocalChecked)
       }
+    },
+    onBlur (evt) {
+      this.handleFocus(evt)
+      this.$emit('blur', evt)
     }
   }
 }

--- a/src/components/form-select/form-select.js
+++ b/src/components/form-select/form-select.js
@@ -55,7 +55,8 @@ export default {
               .map(o => ('_value' in o ? o._value : o.value))
             this.localValue = target.multiple ? selectedVal : selectedVal[0]
             this.$emit('change', this.localValue)
-          }
+          },
+          blur: this.onBlur
         }
       },
       [$slots.first, options, $slots.default]
@@ -112,6 +113,11 @@ export default {
         return 'true'
       }
       return this.stateClass === 'is-invalid' ? 'true' : null
+    }
+  },
+  methods: {
+    onBlur (evt) {
+      this.$emit('blur', evt)
     }
   }
 }

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -35,7 +35,8 @@ export default {
       on: {
         input: (evt) => {
           this.localValue = evt.target.value
-        }
+        },
+        blur: this.onBlur
       }
     })
   },
@@ -146,6 +147,9 @@ export default {
       if (!this.disabled) {
         this.$el.focus()
       }
+    },
+    onBlur (evt) {
+      this.$emit('blur', evt)
     }
   }
 }


### PR DESCRIPTION
Required to some framework, like VeeValidate, to update its flags.

Tested. Linted. Documentation updated to have a VeeValidate example.

Without it, is impossible to update VeeValidate flags (touched & untouched), since they're updated on blur.
Still, some work is required to make it work with Radio Buttons.