### PR TITLE
Fix typos in Popover docs

### DIFF
--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -225,11 +225,11 @@ a focus change via pressing the <kbd>TAB</kbd> key). Some call this behavior _se
 
 
 ## Heading and content
-There are seveal options for provising the title and content of a popover.
+There are several options for provising the title and content of a popover.
 
-By dfault, popover will ue the `title` attribute of the element as the popover heading,
+By default, popover will ue the `title` attribute of the element as the popover heading,
 and the content is passed as a string to the `v-b-popover` directive.
-The title and content can also be passed as an object to `v-b-popoveer` in the form of
+The title and content can also be passed as an object to `v-b-popover` in the form of
 ```js
 {
    title: 'This is the title',
@@ -237,7 +237,7 @@ The title and content can also be passed as an object to `v-b-popoveer` in the f
 }
 ```
 If your content has basic HTML markup, then you will also need to set the `html`
-property to true, or use the diretive modifier `html`
+property to true, or use the directive modifier `html`
 ```js
 // Object format with HTML:
 {


### PR DESCRIPTION
Here's some typos I found when reading this doc, there may be more, but this is what I found.