### PR TITLE
feat(table): Add row-unhovered event

### DIFF
--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -60,6 +60,24 @@
                 ]
             },
             {
+                "event": "row-unhovered",
+                "description": "Emitted when a row is unhovered.",
+                "args": [
+                    {
+                        "arg": "item",
+                        "description": "Item data of the row being unhovered."
+                    },
+                    {
+                        "arg": "index",
+                        "description": "Index of the row being unhovered."
+                    },
+                    {
+                        "arg": "event",
+                        "description": "Native event object."
+                    }
+                ]
+            },
+            {
                 "event": "head-clicked",
                 "description": "Emitted when a header or footer cell is clicked.",
                 "args": [

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -254,6 +254,9 @@ export default {
               },
               mouseenter: evt => {
                 this.rowHovered(evt, item, rowIndex)
+              },
+              mouseleave: evt => {
+                this.rowUnHovered(evt, item, rowIndex)
               }
             }
           },
@@ -918,6 +921,13 @@ export default {
         return
       }
       this.$emit('row-hovered', item, index, e)
+    },
+    rowUnHovered (e, item, index) {
+      if (this.stopIfBusy(e)) {
+        // If table is busy (via provider) then don't propagate
+        return
+      }
+      this.$emit('row-unhovered', item, index, e)
     },
     headClicked (e, field) {
       if (this.stopIfBusy(e)) {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -276,7 +276,7 @@ export default {
                 this.rowHovered(evt, item, rowIndex)
               },
               mouseleave: evt => {
-                this.rowUnHovered(evt, item, rowIndex)
+                this.rowUnhovered(evt, item, rowIndex)
               }
             }
           },
@@ -949,7 +949,7 @@ export default {
       }
       this.$emit('row-hovered', item, index, e)
     },
-    rowUnHovered (e, item, index) {
+    rowUnhovered (e, item, index) {
       if (this.stopIfBusy(e)) {
         // If table is busy (via provider) then don't propagate
         return


### PR DESCRIPTION
Some users might want to know not only when the mouse is hovering a row,
but also when the mouse leaves the row.

For example for dynamically showing (and hiding) some row content based
on mouse hovering.