### PR TITLE
feat(table): Split computedItems into multiple functions

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -787,7 +787,7 @@ export default {
       // Array copy for sorting, filtering, etc.
       items = items.slice()
       // Apply local filter
-      items = this.filterItems(items)
+      this.filteredItems = items = this.filterItems(items)
       // Apply local sort
       items = this.sortItems(items)
       // Apply local pagination
@@ -803,28 +803,23 @@ export default {
   methods: {
     keys,
     filterItems (items) {
-      const filter = this.filter
-      const localFiltering = this.localFiltering
-      if (filter && localFiltering) {
-        if (filter instanceof Function) {
-          items = items.filter(filter)
-        } else {
-          let regex
-          if (filter instanceof RegExp) {
-            regex = filter
-          } else {
-            regex = new RegExp('.*' + filter + '.*', 'ig')
-          }
-          items = items.filter(item => {
-            const test = regex.test(recToString(item))
-            regex.lastIndex = 0
-            return test
-          })
+      if (this.localFiltering && this.filter) {
+        if (this.filter instanceof Function) {
+          return items.filter(this.filter)
         }
-      }
-      if (localFiltering) {
-        // Make a local copy of filtered items to trigger filtered event
-        this.filteredItems = items.slice()
+
+        let regex
+        if (this.filter instanceof RegExp) {
+          regex = this.filter
+        } else {
+          regex = new RegExp('.*' + this.filter + '.*', 'ig')
+        }
+
+        return items.filter(item => {
+          const test = regex.test(recToString(item))
+          regex.lastIndex = 0
+          return test
+        })
       }
       return items
     },
@@ -834,7 +829,7 @@ export default {
       const sortCompare = this.sortCompare
       const localSorting = this.localSorting
       if (sortBy && localSorting) {
-        items = stableSort(items, (a, b) => {
+        return stableSort(items, (a, b) => {
           let ret = null
           if (typeof sortCompare === 'function') {
             // Call user provided sortCompare routine
@@ -855,9 +850,9 @@ export default {
       const perPage = this.perPage
       const localPaging = this.localPaging
       // Apply local pagination
-      if (Boolean(perPage) && localPaging) {
+      if (!!perPage && localPaging) {
         // Grab the current page of data (which may be past filtered items)
-        items = items.slice((currentPage - 1) * perPage, currentPage * perPage)
+        return items.slice((currentPage - 1) * perPage, currentPage * perPage)
       }
       return items
     },

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -779,16 +779,6 @@ export default {
       })
     },
     computedItems () {
-      // Grab some props/data to ensure reactivity
-      const perPage = this.perPage
-      const currentPage = this.currentPage
-      const filter = this.filter
-      const sortBy = this.localSortBy
-      const sortDesc = this.localSortDesc
-      const sortCompare = this.sortCompare
-      const localFiltering = this.localFiltering
-      const localSorting = this.localSorting
-      const localPaging = this.localPaging
       let items = this.hasProvider ? this.localItems : this.items
       if (!items) {
         this.$nextTick(this._providerUpdate)
@@ -797,6 +787,24 @@ export default {
       // Array copy for sorting, filtering, etc.
       items = items.slice()
       // Apply local filter
+      items = this.filterItems(items)
+      // Apply local sort
+      items = this.sortItems(items)
+      // Apply local pagination
+      items = this.paginateItems(items)
+      // Update the value model with the filtered/sorted/paginated data set
+      this.$emit('input', items)
+      return items
+    },
+    computedBusy () {
+      return this.busy || this.localBusy
+    }
+  },
+  methods: {
+    keys,
+    filterItems (items) {
+      const filter = this.filter
+      const localFiltering = this.localFiltering
       if (filter && localFiltering) {
         if (filter instanceof Function) {
           items = items.filter(filter)
@@ -818,7 +826,13 @@ export default {
         // Make a local copy of filtered items to trigger filtered event
         this.filteredItems = items.slice()
       }
-      // Apply local Sort
+      return items
+    },
+    sortItems (items) {
+      const sortBy = this.localSortBy
+      const sortDesc = this.localSortDesc
+      const sortCompare = this.sortCompare
+      const localSorting = this.localSorting
       if (sortBy && localSorting) {
         items = stableSort(items, (a, b) => {
           let ret = null
@@ -834,21 +848,19 @@ export default {
           return (ret || 0) * (sortDesc ? -1 : 1)
         })
       }
+      return items
+    },
+    paginateItems (items) {
+      const currentPage = this.currentPage
+      const perPage = this.perPage
+      const localPaging = this.localPaging
       // Apply local pagination
       if (Boolean(perPage) && localPaging) {
         // Grab the current page of data (which may be past filtered items)
         items = items.slice((currentPage - 1) * perPage, currentPage * perPage)
       }
-      // Update the value model with the filtered/sorted/paginated data set
-      this.$emit('input', items)
       return items
     },
-    computedBusy () {
-      return this.busy || this.localBusy
-    }
-  },
-  methods: {
-    keys,
     fieldClasses (field) {
       return [
         field.sortable ? 'sorting' : '',


### PR DESCRIPTION
To make it easier to extend the functionality of b-table without feature creep in the b-table itself, a bit more/easier access to the various stages of computedItems is needed.

For example, to implement #225 externally, access is needed to the filtered and sorted, but not yet paginated items. With this change this becomes possible by doing something like this:
    const table = this.$refs.the-table
    let items = table.hasProvider ? table.localItems : table.items
    items = table.sortItems(table.filterItems(items))

This PR incorporates no functional changes and adds no features.