### PR TITLE
fix breakpoints on stacked tables to latest bootstrap-values

### DIFF
--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -95,7 +95,7 @@ table.b-table.b-table-stacked > tbody > tr > [data-label]::before {
     font-style: normal;
 }
 
-@media all and (max-width: 575.99px) {
+@media all and (max-width: 575.98px) {
     /* Under SM */
     table.b-table.b-table-stacked-sm {
         width: 100%;
@@ -136,7 +136,7 @@ table.b-table.b-table-stacked > tbody > tr > [data-label]::before {
     }
 }
 
-@media all and (max-width: 767.99px) {
+@media all and (max-width: 767.98px) {
     /* under MD  */
     table.b-table.b-table-stacked-md {
         width: 100%;
@@ -177,7 +177,7 @@ table.b-table.b-table-stacked > tbody > tr > [data-label]::before {
     }
 }
 
-@media all and (max-width: 991.99px) {
+@media all and (max-width: 991.98px) {
     /* under LG  */
     table.b-table.b-table-stacked-lg {
         width: 100%;
@@ -218,7 +218,7 @@ table.b-table.b-table-stacked > tbody > tr > [data-label]::before {
     }
 }
 
-@media all and (max-width: 1199.99px) {
+@media all and (max-width: 1199.98px) {
     /* under XL  */
     table.b-table.b-table-stacked-xl {
         width: 100%;


### PR DESCRIPTION
FIX the breakpoint-max values in the stacked table CSS

Set to 0.02px delta to work around a current rounding bug in Safari.
See https://bugs.webkit.org/show_bug.cgi?id=178261

See also patch on bootstrap v4:
https://github.com/twbs/bootstrap/pull/25177