### PR TITLE
fix(popover): fixes close emit argument

### DIFF
--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -388,7 +388,7 @@ this.$root.$emit('bv::hide::popover');
 To close a **specific popover**, pass the trigger element's `id` as the first argument:
 
 ```js
-this.$root.$emit('bv::show::popover', 'my-trigger-button-id');
+this.$root.$emit('bv::hide::popover', 'my-trigger-button-id');
 ```
 
 To open (show) a **specific popover**, pass the trigger element's `id` as the first argument when


### PR DESCRIPTION
emit the `bv::hide::popover` event instead of `bv::hide::popover` to close a specific popover