### PR TITLE
fix(table): only call provider once DOM is fully updated (#1904)

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -997,7 +997,7 @@ export default {
       this.localBusy = true
 
       // Call provider function with context and optional callback after DOM is fully updated
-      this.$nextTick(function(){
+      this.$nextTick(function () {
         const data = this.items(this.context, this._providerSetLocal)
         if (data && data.then && typeof data.then === 'function') {
           // Provider returned Promise

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -995,17 +995,20 @@ export default {
       }
       // Set internal busy state
       this.localBusy = true
-      // Call provider function with context and optional callback
-      const data = this.items(this.context, this._providerSetLocal)
-      if (data && data.then && typeof data.then === 'function') {
-        // Provider returned Promise
-        data.then(items => {
-          this._providerSetLocal(items)
-        })
-      } else {
-        // Provider returned Array data
-        this._providerSetLocal(data)
-      }
+
+      // Call provider function with context and optional callback after DOM is fully updated
+      this.$nextTick(function(){
+        const data = this.items(this.context, this._providerSetLocal)
+        if (data && data.then && typeof data.then === 'function') {
+          // Provider returned Promise
+          data.then(items => {
+            this._providerSetLocal(items)
+          })
+        } else {
+          // Provider returned Array data
+          this._providerSetLocal(data)
+        }
+      })
     },
     getTdValues (item, key, tdValue, defValue) {
       const parent = this.$parent


### PR DESCRIPTION
The provider function was called with state values that were only partially updated after a user action as this function is called as soon as an event is emitted. This meant that the provider was called with potentially an invalid context as in the case I encountered and subsequent calls for subsequent data changes from the event processing were ignored as the table was set as busy.

With this change, waiting for the $nextTick before calling the provider, the DOM has time to update and it is called with the proper context. The provider is also only called once per user event as opposed to every state changes stemming from the event if the busy state had been removed; so this is the proper solution considering that the provider may be reaching out a remote database.