### PR TITLE
fix(tab): typo aria-lablelledby

### DIFF
--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -16,7 +16,7 @@ export default {
             id: this.safeId(),
             'aria-hidden': this.localActive ? 'false' : 'true',
             'aria-expanded': this.localActive ? 'true' : 'false',
-            'aria-lablelledby': this.controlledBy || null
+            'aria-labelledby': this.controlledBy || null
           }
         },
         [this.$slots.default]


### PR DESCRIPTION
This was fixed in #954 , but apparently somewhere along the way `lib/` was changed to `src/` and the fix was lost.
Found the issue because it was affecting my Lighthouse accessibility scores.