### PR TITLE
fix (docs): Handle state change on validated fields.

### DIFF
--- a/docs/markdown/reference/validation/README.md
+++ b/docs/markdown/reference/validation/README.md
@@ -162,7 +162,7 @@ Same example as above just modified for vee-validate:
         // form submit logic
       },
       validateState(ref) {
-        if (this.veeFields[ref] && this.veeFields[ref].dirty) {
+        if (this.veeFields[ref] && (this.veeFields[ref].dirty || this.veeFields[ref].validated)) {
           return !this.errors.has(ref)
         }
         return null


### PR DESCRIPTION
The state change doesn't get updated when a form is submitted or validated without touching the input (Ex: User clicks submit button but the field is required). Took me hours to figure out this small change to update the state in such cases.

If the field is touched, then it's fine. The issue was when field wasn't touched yet there's an error due to it being required.