### PR TITLE
fix(docs): vue-loader v15 changes

### DIFF
--- a/docs/markdown/reference/images/README.md
+++ b/docs/markdown/reference/images/README.md
@@ -1,20 +1,22 @@
 # Project relative image URLs for Bootstrap Vue custom components
 
 > vue-loader automatically converts project relative `src` attributes
-on `<img>` tags, but doesn't automatically for Bootrap-Vue custom
+on `<img>` tags, but doesn't automatically for Bootstrap-Vue custom
 components that accept image src url tags.
 
-## Vue-loader `transformToRequire` to resolve img paths
+## Vue-loader `transformAssetUrls` to resolve img paths
 To have your project convert these custom component image URLs for you, you will need to
-customize the [`transformToRequire`](https://vue-loader.vuejs.org/en/options.html#transformtorequire)
+customize the [`transformAssetUrls`](https://vue-loader.vuejs.org/options.html#transformasseturls)
 `option` for `vue-loader` in your webpack config.
 
-The default value for `transformToRequire` is:
+The default value for `transformAssetUrls` is:
 
 ```js
-transformToRequire: {
-  'img': 'src',
-  'image': 'xlink:href'
+transformAssetUrls: {
+  video: ['src', 'poster'],
+  source: 'src',
+  img: 'src',
+  image: 'xlink:href'
 }
 ```
 
@@ -22,15 +24,17 @@ To allow Bootstrap-Vue components to use project relative URLs,
 use the following configuration:
 
 ```js
-transformToRequire: {
-  'img': 'src',
-  'image': 'xlink:href',
-  'b-img': 'src',
-  'b-img-lazy': ['src', 'blank-src'],
-  'b-card': 'img-src',
-  'b-card-img': 'img-src',
-  'b-carousel-slide': 'img-src',
-  'b-embed': 'src'
+transformAssetUrls: {
+    video: ['src', 'poster'],
+    source: 'src',
+    img: 'src',
+    image: 'xlink:href',
+    'b-img': 'src',
+    'b-img-lazy': ['src', 'blank-src'],
+    'b-card': 'img-src',
+    'b-card-img': 'img-src',
+    'b-carousel-slide': 'img-src',
+    'b-embed': 'src'
 }
 ```
 
@@ -42,7 +46,7 @@ This will allow you to use the following format in your `.vue` files:
 <b-card-img img-src="~/static/picture.jpg" />
 ```
 
-### Configuring `transformToRequire` in Nuxt
+### Configuring `transformAssetUrls` in Nuxt
 
 In your `nuxt.config.js` file, add the following to your build section:
 
@@ -50,9 +54,11 @@ In your `nuxt.config.js` file, add the following to your build section:
 build: {   
   extend (config, ctx) {
     const vueLoader = config.module.rules.find((rule) => rule.loader === 'vue-loader')
-    vueLoader.options.transformToRequire = {
-      'img': 'src',
-      'image': 'xlink:href',
+    vueLoader.options.transformAssetUrls = {
+      video: ['src', 'poster'],
+      source: 'src',
+      img: 'src',
+      image: 'xlink:href',
       'b-img': 'src',
       'b-img-lazy': ['src', 'blank-src'],
       'b-card': 'img-src',
@@ -65,7 +71,7 @@ build: {
 ```
 
 ## Using `require` to resolve image paths
-If you cannot set the `transforToRequire` in your view-loader config, you
+If you cannot set the `transformAssetUrls` in your view-loader config, you
 can alternatively use the `require` method:
 
 ```html


### PR DESCRIPTION
`transformToRequire` (now renamed to `transformAssetUrls`)