### PR TITLE
fix(modal): fixes modal with long content on click backdrop scroll to .modal-content top

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -657,7 +657,7 @@ export default {
         content &&
         !content.contains(evt.relatedTarget)
       ) {
-        content.focus()
+        content.focus({preventScroll: true})
       }
     },
     // Resize Listener


### PR DESCRIPTION
fix for #1748 