### PR TITLE
Replace `opencollective` dependency with `opencollective-postinstall`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,13 +59,13 @@
     "test": "jest",
     "lint": "eslint src scripts docs tests nuxt",
     "release": "npm run build && npm run test && standard-version",
-    "postinstall": "opencollective postinstall || exit 0"
+    "postinstall": "opencollective-postinstall || exit 0"
   },
   "dependencies": {
     "bootstrap": "^4.1.1",
     "lodash.get": "^4.4.2",
     "lodash.startcase": "^4.4.0",
-    "opencollective": "^1.0.3",
+    "opencollective-postinstall": "^2.0.0",
     "popper.js": "^1.12.9",
     "vue-functional-data-merge": "^2.0.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5786,6 +5786,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+opencollective-postinstall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.0.tgz#5fe062f2706bb84150f7fb1af9f1277e46ec1388"
+
 opencollective@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/opencollective/-/opencollective-1.0.3.tgz#aee6372bc28144583690c3ca8daecfc120dd0ef1"


### PR DESCRIPTION
The [`opencollective`](https://www.npmjs.com/package/opencollective) dependency brings in a lot of unneeded packages into the dependency tree for essentially `console.log` at post install. On a fresh project, where we just habe `bootstrap-vue` as a dependency, it pulls in over 100 dependencies. The open collective project has an alternative dependency which does essentially the same thing without polluting the dependency tree: [`opencollective-postinstall`](https://www.npmjs.com/package/opencollective-postinstall)

Output before:

![screenshot 2018-10-10 at 10 04 29](https://user-images.githubusercontent.com/2906107/46721689-ec25b680-cc73-11e8-9511-f2838c0a68e2.png)


Output after:

![screenshot 2018-10-10 at 10 03 56](https://user-images.githubusercontent.com/2906107/46721683-e9c35c80-cc73-11e8-8e2a-389c563a113b.png)


Dependency tree before/after:
```bash
# before
yarn list | wc -l
# yields 111

#after
yarn list | wc -l
# yields 15
```