### PR TITLE
fix(form-group): add missing disabled prop

### DIFF
--- a/src/components/form-group/README.md
+++ b/src/components/form-group/README.md
@@ -189,6 +189,11 @@ semantic grouping of related form controls:
 <!-- form-group-nested.vue -->
 ```
 
+## Disabled form-group
+Setting the `disabled` prop will disable the rendered `<fieldset>` and, on most
+browsers, will disable all the input elements contained within the fieldset.
+
+`disabled` has no effect when `label-for` is set (as a `fieldset` element is not rendered).
 
 ## Validation state feedback
 Bootstrap includes validation styles for `valid` and `invalid` states

--- a/src/components/form-group/form-group.js
+++ b/src/components/form-group/form-group.js
@@ -140,7 +140,7 @@ export default {
         class: this.groupClasses,
         attrs: {
           id: this.safeId(),
-          disabled: this.disabled,
+          disabled: this.labelFor ? null : this.disabled,
           role: 'group',
           'aria-invalid': this.computedState === false ? 'true' : null,
           'aria-labelledby': this.labelId,
@@ -212,6 +212,10 @@ export default {
       default: null
     },
     validated: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
Adds in the missing `disabled` prop.

Disabled state is only applicable when the a `fieldset` is rendered (i..e when no `label-for` is specified

Note that not all browsers will disable the inputs inside of a disabled fieldset.

Fixes #1920