### PR TITLE
feat(dropdown): Add `dropright` and `dropleft` direction support

### DIFF
--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -136,7 +136,7 @@ Turn your dropdown menu into a drop-up menu by setting the `dropup` prop.
 
 ```html
 <div>
-  <b-dropdown id="ddown-dropup" dropup text="Drop-Up" variant="info" class="m-2">
+  <b-dropdown id="ddown-dropup" dropup text="Drop-Up" variant="primary" class="m-2">
     <b-dropdown-item href="#">Action</b-dropdown-item>
     <b-dropdown-item href="#">Another action</b-dropdown-item>
     <b-dropdown-item href="#">Something else here</b-dropdown-item>
@@ -144,6 +144,36 @@ Turn your dropdown menu into a drop-up menu by setting the `dropup` prop.
 </div>
 
 <!-- dropdown-dropup.vue -->
+```
+
+### Dropright
+Turn your dropdown menu into a drop-right menu by setting the `dropright` prop.
+
+```html
+<div>
+  <b-dropdown id="ddown-dropright" dropright text="Drop-Right" variant="primary" class="m-2">
+    <b-dropdown-item href="#">Action</b-dropdown-item>
+    <b-dropdown-item href="#">Another action</b-dropdown-item>
+    <b-dropdown-item href="#">Something else here</b-dropdown-item>
+  </b-dropdown>
+</div>
+
+<!-- dropdown-dropright.vue -->
+```
+
+### Dropleft
+Turn your dropdown menu into a drop-right menu by setting the `dropleft` prop.
+
+```html
+<div>
+  <b-dropdown id="ddown-dropleft" dropleft text="Drop-Left" variant="primary" class="m-2">
+    <b-dropdown-item href="#">Action</b-dropdown-item>
+    <b-dropdown-item href="#">Another action</b-dropdown-item>
+    <b-dropdown-item href="#">Something else here</b-dropdown-item>
+  </b-dropdown>
+</div>
+
+<!-- dropdown-dropleft.vue -->
 ```
 
 ### Auto "flipping"

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -124,20 +124,29 @@ export default {
   },
   computed: {
     dropdownClasses () {
-      let position = ''
       // Position `static` is needed to allow menu to "breakout" of the scrollParent boundaries
       // when boundary is anything other than `scrollParent`
       // See https://github.com/twbs/bootstrap/issues/24251#issuecomment-341413786
-      if (this.boundary !== 'scrollParent' || !this.boundary) {
-        position = 'position-static'
+      const positionStatic = this.boundary !== 'scrollParent' || !this.boundary
+
+      let direction = ''
+      if (this.dropup) {
+        direction = 'dropup'
+      } else if (this.dropright) {
+        direction = 'dropright'
+      } else if (this.dropleft) {
+        direction = 'dropleft'
       }
+
       return [
         'btn-group',
         'b-dropdown',
         'dropdown',
-        this.dropup ? 'dropup' : '',
-        this.visible ? 'show' : '',
-        position
+        direction,
+        {
+          show: this.visible,
+          'position-static': positionStatic
+        }
       ]
     },
     menuClasses () {

--- a/src/components/dropdown/fixtures/dropdown.html
+++ b/src/components/dropdown/fixtures/dropdown.html
@@ -97,4 +97,28 @@
         <b-dropdown-item href="#">Action</b-dropdown-item>
         <b-dropdown-item href="#">Another action</b-dropdown-item>
     </b-dropdown>
+
+    <br><br>
+
+    <b-dropdown ref="dd_11"
+                text="Drop-Right"
+                dropright
+                variant="primary"
+                class="m-md-2">
+        <b-dropdown-item href="#">Action</b-dropdown-item>
+        <b-dropdown-item href="#">Another action</b-dropdown-item>
+        <b-dropdown-item href="#">Something else here</b-dropdown-item>
+    </b-dropdown>
+
+    <br><br>
+
+    <b-dropdown ref="dd_12"
+                text="Drop-Left"
+                dropleft
+                variant="primary"
+                class="m-md-2">
+        <b-dropdown-item href="#">Action</b-dropdown-item>
+        <b-dropdown-item href="#">Another action</b-dropdown-item>
+        <b-dropdown-item href="#">Something else here</b-dropdown-item>
+    </b-dropdown>
 </div>

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -46,6 +46,16 @@ export default {
       type: Boolean,
       default: false
     },
+    dropright: {
+      // place right if possible
+      type: Boolean,
+      default: false
+    },
+    dropleft: {
+      // place left if possible
+      type: Boolean,
+      default: false
+    },
     right: {
       // Right align menu (default is left align)
       type: Boolean,
@@ -198,14 +208,13 @@ export default {
     },
     getPopperConfig /* istanbul ignore next: can't test popper in JSDOM */ () {
       let placement = AttachmentMap.BOTTOM
-      if (this.dropup && this.right) {
-        // dropup + right
-        placement = AttachmentMap.TOPEND
-      } else if (this.dropup) {
-        // dropup + left
-        placement = AttachmentMap.TOP
+      if (this.dropup) {
+        placement = this.right ? AttachmentMap.TOPEND : AttachmentMap.TOP
+      } else if (this.dropright) {
+        placement = AttachmentMap.RIGHT
+      } else if (this.dropleft) {
+        placement = AttachmentMap.LEFT
       } else if (this.right) {
-        // dropdown + right
         placement = AttachmentMap.BOTTOMEND
       }
       const popperConfig = {


### PR DESCRIPTION
This commit adds support for `dropright` and `dropleft` directions for the dropdown component.

Closes #2108.