### PR TITLE
fix(dropdown): Use custom CSS for `no-caret` option #1473

### DIFF
--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -1,0 +1,5 @@
+/* See: https://github.com/bootstrap-vue/bootstrap-vue/issues/1473 */
+/* See: https://github.com/twbs/bootstrap/issues/23724 */
+.dropdown-toggle.dropdown-toggle-no-caret:after {
+  display: none !important;
+}

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -167,7 +167,7 @@ export default {
         'dropdown-toggle',
         {
           'dropdown-toggle-split': this.split,
-          'dropdown-toggle-no-caret': this.noCaret
+          'dropdown-toggle-no-caret': this.noCaret && !this.split
         },
         this.toggleClass
       ]

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -3,6 +3,7 @@ import dropdownMixin from '../../mixins/dropdown'
 import stripScripts from '../../utils/strip-scripts'
 import bButton from '../button/button'
 
+import './dropdown.css'
 // Needed when dropdowns are inside an input group
 import '../input-group/input-group.css'
 
@@ -163,9 +164,10 @@ export default {
     },
     toggleClasses () {
       return [
+        'dropdown-toggle',
         {
-          'dropdown-toggle': !this.noCaret || this.split,
-          'dropdown-toggle-split': this.split
+          'dropdown-toggle-split': this.split,
+          'dropdown-toggle-no-caret': this.noCaret
         },
         this.toggleClass
       ]

--- a/src/components/dropdown/dropdown.spec.js
+++ b/src/components/dropdown/dropdown.spec.js
@@ -41,22 +41,22 @@ describe('dropdown', async () => {
     });
 */
 
-  it('should not have a toggle caret when no-caret is true', async () => {
+  it('should have "dropdown-toggle-no-caret" class when no-caret is true', async () => {
     const { app: { $refs } } = window
     const { dd_7 } = $refs // eslint-disable-line camelcase
 
     const toggle = Array.from(dd_7.$el.children)
       .find(node => node.tagName === 'BUTTON' && node.id === `${dd_7.safeId('_BV_toggle_')}`)
-    expect(toggle).not.toHaveClass('dropdown-toggle')
+    expect(toggle).toHaveClass('dropdown-toggle-no-caret')
   })
 
-  it('should have a toggle caret when no-caret and split are true', async () => {
+  it('should not have "dropdown-toggle-no-caret" class when no-caret and split are true', async () => {
     const { app: { $refs } } = window
     const { dd_8 } = $refs // eslint-disable-line camelcase
 
     const toggle = Array.from(dd_8.$el.children)
       .find(node => node.tagName === 'BUTTON' && node.id === `${dd_8.safeId('_BV_toggle_')}`)
-    expect(toggle).toHaveClass('dropdown-toggle')
+    expect(toggle).not.toHaveClass('dropdown-toggle-no-caret')
   })
   /*
   it('boundary set to viewport should have class position-static', async () => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of PR:
This PR use custom CSS for the `no-caret` option on the `<b-dropdown>`component instead of removing the `dropdown-toggle` class from the toggle itself which can cause minor styling issues.

Closes #1473

---------------------------------------------------
### PR checklist:
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)

If new features/enhancement/fixes are added or changed:
- [ ] Includes documentation updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users?)

If adding a **new feature**, or changing the functionality of an existing feature, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

_PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention_

