### PR TITLE
fix(safeId): trigger id creation/update after mount (fixes #1978)

### DIFF
--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -36,7 +36,7 @@ export default {
         if (!id) {
           return null
         }
-        suffix = String(suffix || '').replace(\/s+/g, '_')
+        suffix = String(suffix || '').replace(/\/s+/g, '_')
         return suffix ? id + '_' + suffix : id
       }
       return fn

--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -18,16 +18,28 @@ export default {
   },
   mounted () {
     // mounted only occurs client side
-    this.localId_ = `__BVID__${this._uid}`
+    this.$nextTick(() => {
+      // Update dom with auto ID after dom loaded to prevent
+      // SSR hydration errors.
+      this.localId_ = `__BVID__${this._uid}`
+    })
   },
-  methods: {
-    safeId (suffix = '') {
-      const id = this.id || this.localId_ || null
-      if (!id) {
-        return null
+  computed: {
+    safeId () {
+      // Computed property that returns a dynamic function for creating the ID.
+      // Reacts to changes in both .id and .localId_ And regens a new function  
+      const id = this.id || this.localId_
+
+      // We return a function that accepts an optional suffix string
+      // So this computed prop looks and works like a method!!!
+      const fn = (suffix) => {
+        if (!id) {
+          return null
+        }
+        suffix = String(suffix || '').replace(\/s+/g, '_')
+        return suffix ? id + '_' + suffix : id
       }
-      suffix = String(suffix).replace(/\s+/g, '_')
-      return suffix ? id + '_' + suffix : id
+      return fn
     }
   }
 }

--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -12,11 +12,11 @@ export default {
     }
   },
   data () {
-    locaId_: null
+    localId_: null
   },
   mounted () {
     // mounted only occurs client side
-    this.localUid_ = `__BVID__${this._uid}`
+    this.localId_ = `__BVID__${this._uid}`
   },
   methods: {
     safeId (suffix = '') {

--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -12,7 +12,9 @@ export default {
     }
   },
   data () {
-    localId_: null
+    return {
+      localId_: null
+    }
   },
   mounted () {
     // mounted only occurs client side

--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -1,6 +1,7 @@
 /*
  * SSR Safe Client Side ID attribute generation
- *
+ * id's can only be generated client side, after mount.
+ * this._uid is not synched between server and client.
  */
 
 export default {
@@ -10,6 +11,13 @@ export default {
       default: null
     }
   },
+  data () {
+    locaId_: null
+  },
+  mounted () {
+    // mounted only occurs client side
+    this.localUid_ = `__BVID__${this._uid}`
+  },
   methods: {
     safeId (suffix = '') {
       const id = this.id || this.localId_ || null
@@ -18,13 +26,6 @@ export default {
       }
       suffix = String(suffix).replace(/\s+/g, '_')
       return suffix ? id + '_' + suffix : id
-    }
-  },
-  computed: {
-    localId_ () {
-      if (!this.$isServer && !this.id && typeof this._uid !== 'undefined') {
-        return '__BVID__' + this._uid
-      }
     }
   }
 }

--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -27,7 +27,7 @@ export default {
   computed: {
     safeId () {
       // Computed property that returns a dynamic function for creating the ID.
-      // Reacts to changes in both .id and .localId_ And regens a new function  
+      // Reacts to changes in both .id and .localId_ And regens a new function
       const id = this.id || this.localId_
 
       // We return a function that accepts an optional suffix string

--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -36,7 +36,7 @@ export default {
         if (!id) {
           return null
         }
-        suffix = String(suffix || '').replace(/\/s+/g, '_')
+        suffix = String(suffix || '').replace(/\s+/g, '_')
         return suffix ? id + '_' + suffix : id
       }
       return fn


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

safe ID's must be created on mount() of the component, and only client side. This was the original way it was intended, but was inadvertently changed over time to lose its reactive nature (there is no reactivity to this._uid)

this addresses this issue by storing the bv safe ID in data on mount, of which computed properties and methods can rely on it.

The computed prop `safeId` replaces the method `safeId(...)`, and returns a cached method reference which mimics the old method `safeId(...)`, and accepts the same optional suffix parameter.

fixes #1978 

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [x] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

