### PR TITLE
[WIP] feat(modal): Support multiple modals open at once

### DIFF
--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -176,8 +176,9 @@ methods: {
 ### Prevent Closing
 
 To prevent `<b-modal>` from closing (for example when validation fails). you can call
-the `preventDefault()` method of the event object passed to your `ok` (**OK** button),
-`cancel` (**Cancel** button) and `hide` event handlers.
+the `.preventDefault()` method of the event object passed to your `ok` (**OK** button),
+`cancel` (**Cancel** button) and `hide` event handlers. Note that `.preventDevault()`, when used,
+must be called synchronously, as async is not supported.
 
 ```html
 <template>
@@ -434,6 +435,32 @@ the button.
 To disable both **Cancel** and **OK** buttons at the same time, simply set the `busy`
 prop to `true`. Set it to `false` to re-enable both buttons.
 
+
+## Multiple modal support
+Unlike native Bootstrap V4, Bootstrap-Vue supports multiple modals opened at the same time.
+
+```html
+<div>
+  <b-button v-b-modal.modal-multi-1>Open First Modal</b-button>
+  <b-modal id="modal-multi-1" size="lg"title="First Modal" ok-only>
+    <p class="my-5">First Modal</p>
+    <b-button v-b-modal.modal-multi-2>Open Second Modal</b-button>
+  </b-modal>
+  <b-modal id="modal-multi-2" title="Second Modal" ok-only>
+    <p class="my-2">Second Modal</p>
+    <b-button v-b-modal.modal-multi-3 size="sm">Open Third Modal</b-button>
+  </b-modal>
+  <b-modal id="modal-multi-3" size="sm" title="Third Modal" ok-only>
+    <p class="my-1">Third Modal</p>
+  </b-modal>
+</div>
+
+<!-- modal-multiple.vue -->
+```
+
+**Notes:**
+- Do not nest `b-modal` _inside_ another `b-modal`, as it will get "constrained" to the boundaries of the containing modal dialog.
+- The opaque backdrop will appear progressively darker for each modal that is opened. This is expected behaviour as each backdrop is opened over top the other backdrops.
 
 ## Accessibility
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -628,7 +628,7 @@ export default {
       this.is_block = false
       this.resetDialogAdjustments()
       this.is_transitioning = false
-      const count = decrementModalOpenCCount()
+      const count = decrementModalOpenCount()
       if (count === 0) {
         this.resetScrollbar()
         removeClass(document.body, 'modal-open')

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -781,15 +781,15 @@ export default {
         const body = document.body
         const computedStyle = window.getComputedStyle
         const scrollbarWidth = this.scrollbarWidth
-        body._paddingChangedForScroll = []
-        body._marginChangedForScroll = []
+        body._paddingChangedForModal = []
+        body._marginChangedForModal = []
         // Adjust fixed content padding
         selectAll(Selector.FIXED_CONTENT).forEach(el => {
           const actualPadding = el.style.paddingRight
           const calculatedPadding = computedStyle(el).paddingRight || 0
           setAttr(el, 'data-padding-right', actualPadding)
           el.style.paddingRight = `${parseFloat(calculatedPadding) + scrollbarWidth}px`
-          body._paddingChangedForScroll.push(el)
+          body._paddingChangedForModal.push(el)
         })
         // Adjust sticky content margin
         selectAll(Selector.STICKY_CONTENT).forEach(el => {
@@ -797,7 +797,7 @@ export default {
           const calculatedMargin = computedStyle(el).marginRight || 0
           setAttr(el, 'data-margin-right', actualMargin)
           el.style.marginRight = `${parseFloat(calculatedMargin) - scrollbarWidth}px`
-          body._marginChangedForScroll.push(el)
+          body._marginChangedForModal.push(el)
         })
         // Adjust navbar-toggler margin
         selectAll(Selector.NAVBAR_TOGGLER).forEach(el => {
@@ -805,7 +805,7 @@ export default {
           const calculatedMargin = computedStyle(el).marginRight || 0
           setAttr(el, 'data-margin-right', actualMargin)
           el.style.marginRight = `${parseFloat(calculatedMargin) + scrollbarWidth}px`
-          body._marginChangedForScroll.push(el)
+          body._marginChangedForModal.push(el)
         })
         // Adjust body padding
         const actualPadding = body.style.paddingRight
@@ -816,28 +816,30 @@ export default {
     },
     resetScrollbar () {
       const body = document.body
-      if (body._marginChangedForScroll && body._paddingChangedForScroll) {
+      if (body._paddingChangedForModal) {
         // Restore fixed content padding
-        body._paddingChangedForScroll.forEach(el => {
+        body._paddingChangedForModal.forEach(el => {
           if (hasAttr(el, 'data-padding-right')) {
             el.style.paddingRight = getAttr(el, 'data-padding-right') || ''
             removeAttr(el, 'data-padding-right')
           }
         })
+      }
+      if (body._marginChangedForModal) {
         // Restore sticky content and navbar-toggler margin
-        body._marginChangedForScroll.forEach(el => {
+        body._marginChangedForModal.forEach(el => {
           if (hasAttr(el, 'data-margin-right')) {
             el.style.marginRight = getAttr(el, 'data-margin-right') || ''
             removeAttr(el, 'data-margin-right')
           }
         })
-        body._paddingChangedForScroll = null
-        body._marginChangedForScroll = null
-        // Restore body padding
-        if (hasAttr(body, 'data-padding-right')) {
-          body.style.paddingRight = getAttr(body, 'data-padding-right') || ''
-          removeAttr(body, 'data-padding-right')
-        }
+      }
+      body._paddingChangedForModal = null
+      body._marginChangedForModal = null
+      // Restore body padding
+      if (hasAttr(body, 'data-padding-right')) {
+        body.style.paddingRight = getAttr(body, 'data-padding-right') || ''
+        removeAttr(body, 'data-padding-right')
       }
     }
   },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -80,6 +80,7 @@ export default {
         'header',
         {
           ref: 'header',
+          staticClass: 'modal-header',
           class: this.headerClasses,
           attrs: { id: this.safeId('__BV_modal_header_') }
         },
@@ -91,6 +92,7 @@ export default {
       'div',
       {
         ref: 'body',
+        staticClass: 'modal-body',
         class: this.bodyClasses,
         attrs: { id: this.safeId('__BV_modal_body_') }
       },
@@ -142,6 +144,7 @@ export default {
         'footer',
         {
           ref: 'footer',
+          staticClass: 'modal-footer',
           class: this.footerClasses,
           attrs: { id: this.safeId('__BV_modal_footer_') }
         },
@@ -174,12 +177,20 @@ export default {
       [header, body, footer]
     )
     // Modal Dialog wrapper
-    const modalDialog = h('div', { class: this.dialogClasses }, [modalContent])
+    const modalDialog = h(
+      'div',
+      {
+        staticClass: 'modal-dialog',
+        class: this.dialogClasses
+      },
+      [modalContent]
+    )
     // Modal
     let modal = h(
       'div',
       {
         ref: 'modal',
+        staticClass: 'modal',
         class: this.modalClasses,
         directives: [
           {
@@ -228,6 +239,7 @@ export default {
     let backdrop = h(false)
     if (!this.hideBackdrop && (this.is_visible || this.is_transitioning)) {
       backdrop = h('div', {
+        staticClass: 'modal-backdrop',
         class: this.backdropClasses,
         attrs: { id: this.safeId('__BV_modal_backdrop_') }
       })
@@ -421,7 +433,6 @@ export default {
     },
     modalClasses () {
       return [
-        'modal',
         {
           fade: !this.noFade,
           show: this.is_show,
@@ -431,26 +442,19 @@ export default {
       ]
     },
     dialogClasses () {
-      return [
-        'modal-dialog',
-        {
-          [`modal-${this.size}`]: Boolean(this.size),
-          'modal-dialog-centered': this.centered
-        }
-      ]
+      return {
+        [`modal-${this.size}`]: Boolean(this.size),
+        'modal-dialog-centered': this.centered
+      }
     },
     backdropClasses () {
-      return [
-        'modal-backdrop',
-        {
-          fade: !this.noFade,
-          show: this.is_show || this.noFade
-        }
-      ]
+      return {
+        fade: !this.noFade,
+        show: this.is_show || this.noFade
+      }
     },
     headerClasses () {
       return [
-        'modal-header',
         {
           [`bg-${this.headerBgVariant}`]: Boolean(this.headerBgVariant),
           [`text-${this.headerTextVariant}`]: Boolean(this.headerTextVariant),
@@ -463,7 +467,6 @@ export default {
     },
     bodyClasses () {
       return [
-        'modal-body',
         {
           [`bg-${this.bodyBgVariant}`]: Boolean(this.bodyBgVariant),
           [`text-${this.bodyTextVariant}`]: Boolean(this.bodyTextVariant)
@@ -473,7 +476,6 @@ export default {
     },
     footerClasses () {
       return [
-        'modal-footer',
         {
           [`bg-${this.footerBgVariant}`]: Boolean(this.footerBgVariant),
           [`text-${this.footerTextVariant}`]: Boolean(this.footerTextVariant),

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -524,8 +524,9 @@ export default {
     },
     modalOuterStyle () {
       return {
-        position: 'relative', /* needed for stacking to work */
-        zIndex: this.zIndex
+        // We only set these styles on the stacked modals (ones with next z-index > 0).
+        position: this.zIndex ? 'static' : '',
+        zIndex: this.zIndex || ''
       }
     }
   },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -39,6 +39,9 @@ const OBSERVER_CONFIG = {
   attributeFilter: ['style', 'class']
 }
 
+// modal wrapper ZINDEX offset incrememnt
+const ZINDEX_OFFSET = 2000;
+
 // Modal open count helpers
 function getModalOpenCount () {
   return parseInt(getAttr(document.body, 'data-modal-open-count') || 0, 10)
@@ -64,8 +67,8 @@ function getModalNextZIndex () {
     .filter(isVisible) /* filter only visible ones */
     .map(m => m.parentElement) /* select the outer div */
     .reduce((max, el) => { /* compute the next z-index */
-      return Math.max(max, parseInt(el.style.zIndex || 0, 10) + 2000)
-    }, 0)
+      return Math.max(max, parseInt(el.style.zIndex || 0, 10))
+    }, 0) + ZINDEX_OFFSET
 }
 
 export default {
@@ -298,7 +301,7 @@ export default {
       is_show: false, // Used for style control
       is_block: false, // Used for style control
       scrollbarWidth: 0,
-      zIndex: 0, // z-index for modal stacking
+      zIndex: ZINDEX_OFFSET, // z-index for modal stacking
       isBodyOverflowing: false,
       return_focus: this.returnFocus || null
     }
@@ -525,8 +528,8 @@ export default {
     modalOuterStyle () {
       return {
         // We only set these styles on the stacked modals (ones with next z-index > 0).
-        position: this.zIndex ? 'static' : '',
-        zIndex: this.zIndex || ''
+        position: 'relative',
+        zIndex: this.zIndex
       }
     }
   },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -276,9 +276,9 @@ export default {
     return {
       is_hidden: this.lazy || false,
       is_visible: false,
-      is_transitioning: false,
-      is_show: false,
-      is_block: false,
+      is_transitioning: false, // Used for style control
+      is_show: false, // Used for style control
+      is_block: false, // Used for style control
       scrollbarWidth: 0,
       isBodyOverflowing: false,
       return_focus: this.returnFocus || null
@@ -627,12 +627,10 @@ export default {
     onAfterLeave () {
       this.is_block = false
       this.resetDialogAdjustments()
-      const count = decrementModalOpen()
+      this.is_transitioning = false
+      const count = decrementModalOpenCCount()
       if (count === 0) {
         this.resetScrollbar()
-      }
-      this.is_transitioning = false
-      if (count === 0) {
         removeClass(document.body, 'modal-open')
       }
       this.$nextTick(() => {
@@ -790,8 +788,7 @@ export default {
           const actualPadding = el.style.paddingRight
           const calculatedPadding = computedStyle(el).paddingRight || 0
           setAttr(el, 'data-padding-right', actualPadding)
-          el.style.paddingRight = `${parseFloat(calculatedPadding) +
-            scrollbarWidth}px`
+          el.style.paddingRight = `${parseFloat(calculatedPadding) + scrollbarWidth}px`
           body._paddingChangedForScroll.push(el)
         })
         // Adjust sticky content margin
@@ -799,8 +796,7 @@ export default {
           const actualMargin = el.style.marginRight
           const calculatedMargin = computedStyle(el).marginRight || 0
           setAttr(el, 'data-margin-right', actualMargin)
-          el.style.marginRight = `${parseFloat(calculatedMargin) -
-            scrollbarWidth}px`
+          el.style.marginRight = `${parseFloat(calculatedMargin) - scrollbarWidth}px`
           body._marginChangedForScroll.push(el)
         })
         // Adjust navbar-toggler margin
@@ -808,16 +804,14 @@ export default {
           const actualMargin = el.style.marginRight
           const calculatedMargin = computedStyle(el).marginRight || 0
           setAttr(el, 'data-margin-right', actualMargin)
-          el.style.marginRight = `${parseFloat(calculatedMargin) +
-            scrollbarWidth}px`
+          el.style.marginRight = `${parseFloat(calculatedMargin) + scrollbarWidth}px`
           body._marginChangedForScroll.push(el)
         })
         // Adjust body padding
         const actualPadding = body.style.paddingRight
         const calculatedPadding = computedStyle(body).paddingRight
         setAttr(body, 'data-padding-right', actualPadding)
-        body.style.paddingRight = `${parseFloat(calculatedPadding) +
-          scrollbarWidth}px`
+        body.style.paddingRight = `${parseFloat(calculatedPadding) + scrollbarWidth}px`
       }
     },
     resetScrollbar () {
@@ -840,7 +834,6 @@ export default {
         body._paddingChangedForScroll = null
         body._marginChangedForScroll = null
         // Restore body padding
-        const body = document.body
         if (hasAttr(body, 'data-padding-right')) {
           body.style.paddingRight = getAttr(body, 'data-padding-right') || ''
           removeAttr(body, 'data-padding-right')

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -15,7 +15,6 @@ import {
   getBCR,
   addClass,
   removeClass,
-  hasClass,
   setAttr,
   removeAttr,
   getAttr,
@@ -41,20 +40,20 @@ const OBSERVER_CONFIG = {
 }
 
 // Modal open count helpers
-function getModalOpenCount() {
+function getModalOpenCount () {
   return parseInt(getAttr(document.body, 'data-modal-open-count') || 0, 10)
 }
 
-function setModalOpenCount(count) {
+function setModalOpenCount (count) {
   setAttr(document.body, 'data-modal-open-count', String('count'))
   return count
 }
 
-function incrementModalOpenCount() {
+function incrementModalOpenCount () {
   return setModalOpenCount(getModalOpenCount() + 1)
 }
 
-function decrementModalOpenCount() {
+function decrementModalOpenCount () {
   return setModalOpenCount(Math.max(getModalOpenCount() - 1, 0))
 }
 
@@ -628,7 +627,7 @@ export default {
     onAfterLeave () {
       this.is_block = false
       this.resetDialogAdjustments()
-      const count = decrememntModalOpen()
+      const count = decrementModalOpen()
       if (count === 0) {
         this.resetScrollbar()
       }
@@ -781,8 +780,8 @@ export default {
       if (this.isBodyOverflowing) {
         // Note: DOMNode.style.paddingRight returns the actual value or '' if not set
         //   while $(DOMNode).css('padding-right') returns the calculated value or 0 if not set
-        const computedStyle = window.getComputedStyle
         const body = document.body
+        const computedStyle = window.getComputedStyle
         const scrollbarWidth = this.scrollbarWidth
         body._paddingChangedForScroll = []
         body._marginChangedForScroll = []

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -46,15 +46,15 @@ function getModalOpenCount() {
 }
 
 function setModalOpenCount(count) {
-  setAttr(document.body, 'data-modal-open-count'), String('count'))
+  setAttr(document.body, 'data-modal-open-count', String('count'))
   return count
 }
 
-function incrememntModalOpen() {
+function incrementModalOpenCount() {
   return setModalOpenCount(getModalOpenCount() + 1)
 }
 
-function decrementModalOpen() {
+function decrementModalOpenCount() {
   return setModalOpenCount(Math.max(getModalOpenCount() - 1, 0))
 }
 
@@ -591,7 +591,7 @@ export default {
     onBeforeEnter () {
       this.is_transitioning = true
       this.checkScrollbar()
-      const count = incrementModalOpen()
+      const count = incrementModalOpenCount()
       if (count === 1) {
         this.setScrollbar()
       }
@@ -875,7 +875,7 @@ export default {
       this.is_visible = false
       this.is_show = false
       this.is_transitioning = false
-      const count = decrementModalOpen()
+      const count = decrementModalOpenCount()
       if (count === 0) {
         // Re-adjust body/navbar/fixed padding/margins (if needed)
         removeClass(document.body, 'modal-open')

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -525,7 +525,7 @@ export default {
     modalOuterStyle () {
       return {
         position: 'relative', /* needed for stacking to work */
-        zIndex: this.zIndex || null
+        zIndex: this.zIndex
       }
     }
   },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -42,7 +42,7 @@ const OBSERVER_CONFIG = {
 
 // Modal open count helpers
 function getModalOpenCount() {
-  return parseInt(getAttr(document.body, 'data-modal-open-count') || 0), 10)
+  return parseInt(getAttr(document.body, 'data-modal-open-count') || 0, 10)
 }
 
 function setModalOpenCount(count) {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -40,7 +40,7 @@ const OBSERVER_CONFIG = {
 }
 
 // modal wrapper ZINDEX offset incrememnt
-const ZINDEX_OFFSET = 2000;
+const ZINDEX_OFFSET = 2000
 
 // Modal open count helpers
 function getModalOpenCount () {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -12,7 +12,6 @@ import {
   isVisible,
   selectAll,
   select,
-  closest,
   getBCR,
   addClass,
   removeClass,
@@ -60,13 +59,13 @@ function decrementModalOpenCount () {
 
 // Returns the next z-index to be used by a modal to ensure proper stacking
 // regardless of document order. Increments by 2000
-function getNextModalZIndex () {
+function getModalNextZIndex () {
   return selectAll('div.modal') /* find all modals that are in document */
-  .filter(isVisible) /* filter only visible ones */
-  .map(m => m.parentElement) /* select the outer div */
-  .reduce((max, el) => {  /* Compute the next z-index */
-    return Math.max(max, parseInt(el.style.zIndex || 0, 10) + 2000)
-  }, 0)
+    .filter(isVisible) /* filter only visible ones */
+    .map(m => m.parentElement) /* select the outer div */
+    .reduce((max, el) => { /* compute the next z-index */
+      return Math.max(max, parseInt(el.style.zIndex || 0, 10) + 2000)
+    }, 0)
 }
 
 export default {
@@ -794,7 +793,7 @@ export default {
       }
     },
     checkScrollbar () {
-      const {left, right, height}  = getBCR(document.body)
+      const {left, right, height} = getBCR(document.body)
       // Extra check for body.height needed for stacked modals
       this.isBodyOverflowing = (left + right) < window.innerWidth || height > window.innerHeight
     },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -524,8 +524,8 @@ export default {
     },
     modalOuterStyle () {
       return {
-        positon: 'relative',
-        zIndex: this.zIndex
+        position: 'relative', /* needed for stacking to work */
+        zIndex: this.zIndex || null
       }
     }
   },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -45,7 +45,7 @@ function getModalOpenCount () {
 }
 
 function setModalOpenCount (count) {
-  setAttr(document.body, 'data-modal-open-count', String('count'))
+  setAttr(document.body, 'data-modal-open-count', String(count))
   return count
 }
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -279,8 +279,8 @@ export default {
         'div',
         {
           key: 'modal-outer',
+          style: this.modalOuterStyle,
           attrs: {
-            style: this.modalOuterStyle,
             id: this.safeId('__BV_modal_outer_')
           }
         },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -765,8 +765,7 @@ export default {
       const scrollDiv = document.createElement('div')
       scrollDiv.className = 'modal-scrollbar-measure'
       document.body.appendChild(scrollDiv)
-      this.scrollbarWidth =
-        scrollDiv.getBoundingClientRect().width - scrollDiv.clientWidth
+      this.scrollbarWidth = getBCR(scrollDiv).width - scrollDiv.clientWidth
       document.body.removeChild(scrollDiv)
     },
     adjustDialog () {
@@ -795,7 +794,7 @@ export default {
       }
     },
     checkScrollbar () {
-      const (left, right, height}  = getBCR(document.body)
+      const {left, right, height}  = getBCR(document.body)
       // Extra check for body.height needed for stacked modals
       this.isBodyOverflowing = (left + right) < window.innerWidth || height > window.innerHeight
     },

--- a/src/components/modal/modal.spec.js
+++ b/src/components/modal/modal.spec.js
@@ -21,17 +21,18 @@ describe('modal', async () => {
   it('Should show hide modal', async () => {
     const { app: { $refs } } = window
     const { modalButton2, modal2 } = $refs
+    const body = document.body
 
     // show the modal
     modalButton2.click()
     await nextTick()
-    expect(Array.isArray(modal2._marginChangedForScroll)).toBe(true)
+    expect(Array.isArray(body._marginChangedForModal)).toBe(true)
 
     // hide the modal
     modal2.hide()
     await nextTick()
     // manually run resetScrollbar because JSDOM doesn't support it
     modal2.resetScrollbar()
-    expect(modal2._marginChangedForScroll).toBe(null)
+    expect(body._marginChangedForModal).toBe(null)
   })
 })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Support multiple modals being opened onscreen at the same time.

Keeps track of the number of modals currently opened to determine if scrollBar adjustments need to be done.

Fixes #1997
Fixes #1869
Fixes #1842
Fixes #1513

_While not officially supported in Bootstrap V4 native_, it has been a popular feature request for Bootstrap-Vue

It requires that the outer div container (containing .modal and .modal-backdrop) have CSS `position: relative` and a z-index of multiples of 2000 (starting at 2000) to ensure proper stacking of the opened modals. This may cause weird layout issues depending on the overflow and positioning settings of the parent container (which is similar to current behaviour).  It is always best to place your `b-modal` outside of constrained elements/components.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)
