### PR TITLE
perf(modal): Get scrollbar width just before modal opens rather than on mount (fixes #1800)

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -574,6 +574,7 @@ export default {
     },
     // Transition Handlers
     onBeforeEnter () {
+      this.getScrollbarWidth()
       this.is_transitioning = true
       this.checkScrollbar()
       this.setScrollbar()
@@ -836,8 +837,6 @@ export default {
     this._observer = null
   },
   mounted () {
-    // Measure scrollbar
-    this.getScrollbarWidth()
     // Listen for events from others to either open or close ourselves
     this.listenOnRoot('bv::show::modal', this.showHandler)
     this.listenOnRoot('bv::hide::modal', this.hideHandler)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Moves the scroll bar measurement to just before the modal opens, rather than during mount().

Prevents the page from reflowing until modal opens

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)
