### PR TITLE
feat(form-file): reset file input when value  set to null or empty string

### DIFF
--- a/src/components/form-file/README.md
+++ b/src/components/form-file/README.md
@@ -160,6 +160,7 @@ to the `<b-form-file>` component.
     <b-form-file v-model="file" ref="fileinput" class="mb-2"></b-form-file>
     <b-button @click="clearFiles" class="mr-2">Reset via method</b-button>
     <b-button @click="file = null">Reset via v-model</b-button>
+    <p class="mt-2">Selected file: <b>{{ file ? file.name : ''}}</b><p>
   </div>
 </template>
 

--- a/src/components/form-file/README.md
+++ b/src/components/form-file/README.md
@@ -147,12 +147,12 @@ assitive technologies.
 ## Clearing the file selection
 With inputs of type file, normally the `v-model` is uni-directional (meaning
 you cannot pre-set the selected files). However, you can clear the file input's 
-selected files by setting the `v-model` to either `null` or an empty string.
-Alternatively,  `<b-form-file>` provides a `reset()` method that can be
-called to clear the file input.
+selected files by setting the `v-model` to either `null`, an empty string, or an
+empty array).
 
-To take advantage of the `reset()` method, you will need to obtain a reference
-to the `<b-form-file>` component.
+Alternatively,  `<b-form-file>` provides a `reset()` method that can be called to
+clear the file input. To take advantage of the `reset()` method, you will need
+to obtain a reference to the `<b-form-file>` component.
 
 ```html
 <template>
@@ -181,6 +181,11 @@ export default {
 
 <!-- form-file-reset.vue -->
 ```
+
+**Implementation note:** As not all browsers allow setting a value of a file
+input (even to null or an empty string), `b-form-input` employs a technique that
+works cross-browser that involves changing the input type to null and then back
+to type file.
 
 
 <!-- Component reference added automatically from component package.json -->

--- a/src/components/form-file/README.md
+++ b/src/components/form-file/README.md
@@ -155,16 +155,16 @@ To take advantage of the `reset()` method, you will need to obtain a reference
 to the `<b-form-file>` component.
 
 ```html
-<div id="#app">
-  <b-form-file v-model="file" ref="fileinput"></b-form-file>
-  <b-button @click="clearFiles" class="mr-2">Reset via method</b-button>
-  <b-button @click="file = null">Reset via v-model</b-button>
-</div>
-```
+<template>
+  <div>
+    <b-form-file v-model="file" ref="fileinput"></b-form-file>
+    <b-button @click="clearFiles" class="mr-2">Reset via method</b-button>
+    <b-button @click="file = null">Reset via v-model</b-button>
+  </div>
+</template>
 
-```js
-window.app = new Vue({
-  el: '#app',
+<script>
+export default {
   data () {
     return {
       file: null
@@ -175,7 +175,10 @@ window.app = new Vue({
       this.$refs.fileinput.reset();
     }
   }
-})
+}
+</script>
+
+<!-- form-file-reset.vue -->
 ```
 
 

--- a/src/components/form-file/README.md
+++ b/src/components/form-file/README.md
@@ -145,18 +145,20 @@ assitive technologies.
 
 
 ## Clearing the file selection
-Because of limitations in the value binding with `<input type="file">` elements, `v-model`
-for `<b-form-file>` is unidirectional, and cannot be used to set or clear the file(s) selection.
-To get around this limitation, `<b-form-file>` provides a `reset()` method that can be
+With inputs of type file, normally the `v-model` is uni-directional (meaning
+you cannot pre-set the selected files). However, you can clear the file input's 
+selected files by setting the `v-model` to either `null` or an empty string.
+Alternatively,  `<b-form-file>` provides a `reset()` method that can be
 called to clear the file input.
 
 To take advantage of the `reset()` method, you will need to obtain a reference
-to the `<b-form-file>` component:
+to the `<b-form-file>` component.
 
 ```html
 <div id="#app">
-    <b-form-file v-model="file" ref="fileinput"></b-form-file>
-    <b-button @click="clearFiles">Reset</b-button>
+  <b-form-file v-model="file" ref="fileinput"></b-form-file>
+  <b-button @click="clearFiles" class="mr-2">Reset via method</b-button>
+  <b-button @click="file = null">Reset via v-model</b-button>
 </div>
 ```
 

--- a/src/components/form-file/README.md
+++ b/src/components/form-file/README.md
@@ -157,7 +157,7 @@ to the `<b-form-file>` component.
 ```html
 <template>
   <div>
-    <b-form-file v-model="file" ref="fileinput"></b-form-file>
+    <b-form-file v-model="file" ref="fileinput" class="mb-2"></b-form-file>
     <b-button @click="clearFiles" class="mr-2">Reset via method</b-button>
     <b-button @click="file = null">Reset via v-model</b-button>
   </div>

--- a/src/components/form-file/form-file.js
+++ b/src/components/form-file/form-file.js
@@ -80,6 +80,9 @@ export default {
     }
   },
   props: {
+    value: {
+      default: null
+    },
     accept: {
       type: String,
       default: ''
@@ -151,6 +154,11 @@ export default {
         this.$emit('input', [])
       } else {
         this.$emit('input', newVal)
+      }
+    },
+    value (newVal) {
+      if (newVal === null || newVal === '') {
+        this.reset()
       }
     }
   },

--- a/src/components/form-file/form-file.js
+++ b/src/components/form-file/form-file.js
@@ -36,7 +36,8 @@ export default {
       on: {
         change: this.onFileChange,
         focusin: this.focusHandler,
-        focusout: this.focusHandler
+        focusout: this.focusHandler,
+        reset: this.onReset
       }
     })
 
@@ -223,6 +224,10 @@ export default {
         // Return single file object
         this.selectedFile = files[0]
       }
+    },
+    onReset () {
+      // Triggered when the parent form (if any) is reset
+      this.selectedFile = this.multiple ? [] : null
     },
     onDragover (evt) {
       evt.preventDefault()

--- a/src/components/form-file/form-file.js
+++ b/src/components/form-file/form-file.js
@@ -2,7 +2,7 @@ import idMixin from '../../mixins/id'
 import formMixin from '../../mixins/form'
 import formStateMixin from '../../mixins/form-state'
 import formCustomMixin from '../../mixins/form-custom'
-import { from as arrayFrom } from '../../utils/array'
+import { from as arrayFrom, isArray } from '../../utils/array'
 
 // temporary css until Bootstrap V4.2 is released
 import './form-file.css'
@@ -158,7 +158,7 @@ export default {
       }
     },
     value (newVal) {
-      if (newVal === null || newVal === '') {
+      if (!newVal || (isArray(newVal) && newVal.length === 0)) {
         this.reset()
       }
     }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

As an alternative to calling the `reset()` method, users can now clear the form file input by setting the v-model to null or an empty string.

The watcher checks for null and empty string and internally calls reset().

Also listens for reset events triggered by the parent form and clears the v-model

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

