### PR TITLE
fix(fom-input): revert changes from PR #1841

### DIFF
--- a/src/components/form-input/form-input.js
+++ b/src/components/form-input/form-input.js
@@ -48,7 +48,7 @@ export default {
         type: self.localType,
         disabled: self.disabled,
         required: self.required,
-        readonly: self.readonly || (self.plaintext && self.readonly === null),
+        readonly: self.readonly || self.plaintext,
         placeholder: self.placeholder,
         autocomplete: self.autocomplete || null,
         min: self.min,
@@ -94,7 +94,7 @@ export default {
     },
     readonly: {
       type: Boolean,
-      default: null
+      default: false
     },
     plaintext: {
       type: Boolean,


### PR DESCRIPTION
reverts changes from #1841, as it breaks the readonly plaintext requirements (plus documentatijn was not properly updated to reflect changes)
