### PR TITLE
fix(list-group-item): set button type to 'button' when button in mode or tag=button (Fixes #2192)

### DIFF
--- a/src/components/list-group/list-group-item.js
+++ b/src/components/list-group/list-group-item.js
@@ -46,18 +46,22 @@ export default {
       arrayIncludes(actionTags, props.tag)
     )
     const attrs = {}
-    let props = {}
+    let itemProps = {}
     if (tag === 'button') {
-      attrs.type = 'button'
+      if (data.attrs && !data.attrs.type) {
+        // Add a type for button is one not provided in passed attributes
+        attrs.type = 'button'
+      }
       if (props.disabled) {
-        attrs.disabled = true
+        // Set disabled attribute if button and disabled
+        attrs.disabled = props.disabled
       }
     } else {
-      props = pluckProps(linkProps, props)
+      itemProps = pluckProps(linkProps, props)
     }
     const componentData = {
       attrs,
-      props,
+      props: itemProps,
       staticClass: 'list-group-item',
       class: {
         [`list-group-item-${props.variant}`]: Boolean(props.variant),

--- a/src/components/list-group/list-group-item.js
+++ b/src/components/list-group/list-group-item.js
@@ -54,7 +54,7 @@ export default {
       }
       if (props.disabled) {
         // Set disabled attribute if button and disabled
-        attrs.disabled = props.disabled
+        attrs.disabled = true
       }
     } else {
       itemProps = pluckProps(linkProps, props)

--- a/src/components/list-group/list-group-item.js
+++ b/src/components/list-group/list-group-item.js
@@ -48,7 +48,7 @@ export default {
     const attrs = {}
     let itemProps = {}
     if (tag === 'button') {
-      if (data.attrs && !data.attrs.type) {
+      if (!data.attrs || !data.attrs.type) {
         // Add a type for button is one not provided in passed attributes
         attrs.type = 'button'
       }

--- a/src/components/list-group/list-group-item.js
+++ b/src/components/list-group/list-group-item.js
@@ -40,21 +40,31 @@ export default {
       : !props.href && !props.to ? props.tag : Link
     const isAction = Boolean(
       props.href ||
-        props.to ||
-        props.action ||
-        props.button ||
-        arrayIncludes(actionTags, props.tag)
+      props.to ||
+      props.action ||
+      props.button ||
+      arrayIncludes(actionTags, props.tag)
     )
+    const attrs = {}
+    let props = {}
+    if (tag === 'button') {
+      attrs.type = 'button'
+      if (props.disabled) {
+        attrs.disabled = true
+      }
+    } else {
+      props = pluckProps(linkProps, props)
+    }
     const componentData = {
+      attrs,
+      props,
       staticClass: 'list-group-item',
       class: {
         [`list-group-item-${props.variant}`]: Boolean(props.variant),
         'list-group-item-action': isAction,
         active: props.active,
         disabled: props.disabled
-      },
-      attrs: tag === 'button' && props.disabled ? { disabled: true } : {},
-      props: props.button ? {} : pluckProps(linkProps, props)
+      }
     }
 
     return h(tag, mergeData(data, componentData), children)

--- a/src/components/list-group/list-group-item.spec.js
+++ b/src/components/list-group/list-group-item.spec.js
@@ -1,0 +1,162 @@
+import ListGroupItem from './list-group-item'
+import { mount } from '@vue/test-utils'
+
+describe('list-group-item', async () => {
+  it('default should have tag div', async () => {
+    const wrapper = mount(ListGroupItem)
+    expect(wrapper.is('div')).toBe(true)
+  })
+
+  it('default should contain only single class of list-group-item', async () => {
+    const wrapper = mount(ListGroupItem)
+    expect(wrapper.classes().length).toBe(1)
+    expect(wrapper.classes()).toContain('list-group-item')
+  })
+
+  it('default should not have class list-group-item-action', async () => {
+    const wrapper = mount(ListGroupItem)
+    expect(wrapper.classes()).not.toContain('list-group-item-action')
+  })
+
+  it('default should not have class active', async () => {
+    const wrapper = mount(ListGroupItem)
+    expect(wrapper.classes()).not.toContain('active')
+  })
+
+  it('default should not have class disabled', async () => {
+    const wrapper = mount(ListGroupItem)
+    expect(wrapper.classes()).not.toContain('disabled')
+  })
+
+  it('default should not have type attribute', async () => {
+    const wrapper = mount(ListGroupItem)
+    expect(wrapper.attributes('type')).not.toBeDefined()
+  })
+
+  it('default should not have disabled attribute', async () => {
+    const wrapper = mount(ListGroupItem)
+    expect(wrapper.attributes('disabled')).not.toBeDefined()
+  })
+
+  it('should have disabled class when disabled=true', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { disabled: true }
+      }
+    })
+    expect(wrapper.classes()).toContain('disabled')
+  })
+
+  it('should have active class when active=true', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { active: true }
+      }
+    })
+    expect(wrapper.classes()).toContain('active')
+  })
+
+  it('should have variant class and base class when variant set', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { variant: 'danger' }
+      }
+    })
+    expect(wrapper.classes()).toContain('list-group-item')
+    expect(wrapper.classes()).toContain('list-group-item-danger')
+  })
+
+  it('should have tag a when href is set', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { href: '/foobar' }
+      }
+    })
+    expect(wrapper.is('a')).toBe(true)
+  })
+
+  it('should have class list-group-item-action when href is set', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { href: '/foobar' }
+      }
+    })
+    expect(wrapper.classes()).toContain('list-group-item-action')
+  })
+
+  it('should have href attribute when href is set', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { href: '/foobar' }
+      }
+    })
+    expect(wrapper.attributes('href')).toBe('/foobar')
+  })
+
+  it('should have tag button when button=true', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { button: true }
+      }
+    })
+    expect(wrapper.is('button')).toBe(true)
+  })
+
+  it('should have class list-group-item-action when button=true', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { button: true }
+      }
+    })
+    expect(wrapper.classes()).toContain('list-group-item-action')
+  })
+
+  it('should have type=button when button=true', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { button: true }
+      }
+    })
+    expect(wrapper.attributes('type')).toEqual('button')
+  })
+
+  it('should have type=submit when button=true and attr type=submit', async () => {
+    const wrapper = mount(ListGroupItem,{
+      context: {
+        props: { button: true },
+        attrs: { type: 'submit' }
+      }
+    })
+    expect(wrapper.attributes('type')).toEqual('submit')
+  })
+
+  it('should not have attribute disabled when button=true and disabled not set', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { button: true }
+      }
+    })
+    expect(wrapper.attributes('disabled')).not.toBeDefined()
+  })
+
+  it('should have attribute disabled when button=true and disabled=true', async () => {
+    const wrapper = mount(ListGroupItem,{
+      context: {
+        props: {
+          button: true,
+          disabled: 'true'
+        }
+      }
+    })
+    expect(wrapper.attributes('disabled')).toBeDefined()
+  })
+
+  it('should render button when tag=button', async () => {
+    const wrapper = mount(ListGroupItem,{
+      context: {
+        props: { tag: 'button' }
+      }
+    })
+    expect(wrapper.attributes('disabled')).toBeDefined()
+  })
+})

--- a/src/components/list-group/list-group-item.spec.js
+++ b/src/components/list-group/list-group-item.spec.js
@@ -84,6 +84,24 @@ describe('list-group-item', async () => {
     expect(wrapper.classes()).toContain('list-group-item-action')
   })
 
+  it('should have class list-group-item-action when action=true', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { action: true }
+      }
+    })
+    expect(wrapper.classes()).toContain('list-group-item-action')
+  })
+
+  it('should have class list-group-item-action when tag=a', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { tag: 'a' }
+      }
+    })
+    expect(wrapper.classes()).toContain('list-group-item-action')
+  })
+
   it('should have href attribute when href is set', async () => {
     const wrapper = mount(ListGroupItem, {
       context: {
@@ -93,6 +111,24 @@ describe('list-group-item', async () => {
     expect(wrapper.attributes('href')).toBe('/foobar')
   })
 
+  it('should have tag button when tag=button', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { tag: 'button' }
+      }
+    })
+    expect(wrapper.is('button')).toBe(true)
+  })
+
+  it('should have tag a when tag=a', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: { tag: 'a' }
+      }
+    })
+    expect(wrapper.is('a')).toBe(true)
+  })
+
   it('should have tag button when button=true', async () => {
     const wrapper = mount(ListGroupItem, {
       context: {
@@ -100,6 +136,31 @@ describe('list-group-item', async () => {
       }
     })
     expect(wrapper.is('button')).toBe(true)
+  })
+
+  it('should have tag button when button=true and tag=foo', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: {
+          button: true,
+          tag: 'foo'
+        }
+      }
+    })
+    expect(wrapper.is('button')).toBe(true)
+  })
+
+  it('should not have href when button=true and href set', async () => {
+    const wrapper = mount(ListGroupItem, {
+      context: {
+        props: {
+          button: true,
+          href: '/foobar'
+        }
+      }
+    })
+    expect(wrapper.is('button')).toBe(true)
+    expect(wrapper.attributes('href')).not.toBeDefined()
   })
 
   it('should have class list-group-item-action when button=true', async () => {
@@ -121,7 +182,7 @@ describe('list-group-item', async () => {
   })
 
   it('should have type=submit when button=true and attr type=submit', async () => {
-    const wrapper = mount(ListGroupItem,{
+    const wrapper = mount(ListGroupItem, {
       context: {
         props: { button: true },
         attrs: { type: 'submit' }
@@ -140,21 +201,12 @@ describe('list-group-item', async () => {
   })
 
   it('should have attribute disabled when button=true and disabled=true', async () => {
-    const wrapper = mount(ListGroupItem,{
+    const wrapper = mount(ListGroupItem, {
       context: {
         props: {
           button: true,
-          disabled: 'true'
+          disabled: true
         }
-      }
-    })
-    expect(wrapper.attributes('disabled')).toBeDefined()
-  })
-
-  it('should render button when tag=button', async () => {
-    const wrapper = mount(ListGroupItem,{
-      context: {
-        props: { tag: 'button' }
       }
     })
     expect(wrapper.attributes('disabled')).toBeDefined()


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

A `<button>` element without a type specified defaults to type "submit" in some browsers.

This PR explicitly sets the attribute `type="button"` when `<b-list-group-item>` is rendering a `<button>` element, and no `type` attribute is supplied.

Fixes #2192 

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

