### PR TITLE
fix(table): Preserve aria-rowcount and aria-describedby if provided. Fixes #1801

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -407,15 +407,20 @@ export default {
         staticClass: 'table b-table',
         class: this.tableClasses,
         attrs: {
+          // We set aria-rowcount before merging in $attrs, in case user has supplied their own
+          'aria-rowcount': (this.filteredItems.length > items.length) ? String(this.filteredItems.length) : null,
+          // Merge in user supplied $attrs if any
           ...this.$attrs,
+          // Now we can override any $attrs here
           id: this.safeId(),
           role: this.isStacked ? 'table' : null,
-          'aria-describedby': captionId,
           'aria-busy': this.computedBusy ? 'true' : 'false',
-          'aria-colcount': String(fields.length),
-          // Only set aria-rowcount if provided in $attrs or if localItems > shown items
-          'aria-rowcount': this.$attrs['aria-rowcount'] ||
-            (this.filteredItems.length > items.length) ? String(this.filteredItems.length) : null
+          'aria-colcount': String(fields.length)
+          'aria-describedby': [
+            // Preserve user supplied aria-describedby, if provided in $attrs
+            (this.$attrs || {})['aria-describedby'],
+            captionId
+          ].filter(a => a).join(' ') || null,
         }
       },
       [caption, colgroup, thead, tfoot, tbody]
@@ -426,6 +431,8 @@ export default {
       ? h('div', { key: 'b-table-responsive', class: this.responsiveClass }, [table])
       : table
   },
+  // Don't place ATTRS on root element automatically, as table could be wrapped in responsive div
+  inheritAttrs: false,
   props: {
     items: {
       type: [Array, Function],

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -415,12 +415,12 @@ export default {
           id: this.safeId(),
           role: this.isStacked ? 'table' : null,
           'aria-busy': this.computedBusy ? 'true' : 'false',
-          'aria-colcount': String(fields.length)
+          'aria-colcount': String(fields.length),
           'aria-describedby': [
             // Preserve user supplied aria-describedby, if provided in $attrs
             (this.$attrs || {})['aria-describedby'],
             captionId
-          ].filter(a => a).join(' ') || null,
+          ].filter(a => a).join(' ') || null
         }
       },
       [caption, colgroup, thead, tfoot, tbody]


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

If user provides `aria-rowcount` and/or `aria-describedby` attributes, preserve their values when rendering. Fixes #1801 where on initial mount `this.$attrs` may be undefined.

Also ensures that any non-prop attributes are rendered on the `<table>` element when table is wrapped in responsive `<div>`.  Sets `inheritAttrs: false` in the `<b-table>` component definition, and merges `this.$attrs` on the `<tbody>`

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [x] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

