### PR TITLE
feat(table): Add table-busy slot for loading status. Closes #1859

### DIFF
--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -609,6 +609,73 @@ elements are limited. Refer to [MDN](https://developer.mozilla.org/en-US/docs/We
 for details and usage of `<colgroup>`
 
 
+## Table busy state
+`<b-table>` provides a `busy` prop that will flag the table as busy, which you can
+set to `true` just before you update your items, and then set it to `false` once you have
+your items. When in hte busy state, the tabe will have the attribute `aria-busy="true"`.
+
+During the busy state, the table will be rendered in a "muted" look (`opacity: 0.6`), using the
+following custom CSS:
+
+```css
+/* Busy table styling */
+table.b-table[aria-busy='false'] {
+    opacity: 1;
+}
+table.b-table[aria-busy='true'] {
+    opacity: 0.6;
+}
+```
+
+You can override this styling using your own CSS.
+
+You may optionally provide a `table-busy` slot to show a custom loading message or spinner
+whenever the table's busy state is `true`.  The slot will be placed in a `<tr>` element with
+class `b-table-busy-slot`, which has one single `<td>` with a `colspan` set to the number of fields.
+
+**Example of `table-busy` slot usage:**
+```html
+<template>
+  <div>
+    <b-button @click="toggleBusy">Toggle Busy State</b-button>
+    <b-table :items="items" :busy="isBusy" class="mt-3" outlined>
+      <div slot="table-busy" class="text-center text-danger">
+        <br><strong>Loading...</strong><br><br>
+      </div>
+    </b-table>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      isBusy: false,
+      items: [
+        { first_name: 'Dickerson', last_name: 'MacDonald', age: 40 },
+        { first_name: 'Larsen', last_name: 'Shaw', age: 21 },
+        { first_name: 'Geneva', last_name: 'Wilson', age: 89 },
+        { first_name: 'Jami', last_name: 'Carney',age: 38 }
+      ]
+    }
+  },
+  methods: {
+    toggleBusy() {
+      this.isBusy = !this.isBusy
+    }
+  }
+}
+</script>
+
+<!-- table-busy-slot.vue -->
+```
+
+Also see the [**Using Items Provider Functions**](#using-items-provider-functions) below for additional
+informaton on the `busy` state.
+
+**Note:** All click related and hover events, and sort-changed events will __not__ be
+ emitted when the table is in the `busy` state.
+
+
 ## Custom Data Rendering
 Custom rendering for each data field in a row is possible using either
 [scoped slots](http://vuejs.org/v2/guide/components.html#Scoped-Slots)
@@ -1226,22 +1293,23 @@ function myProvider (ctx) {
 }
 ```
 
-`<b-table>` automatically tracks/controls it's `busy` state, however it provides
-a `busy` prop that can be used either to override inner `busy`state, or to monitor
-`<b-table>`'s current busy state in your application using the 2-way `.sync` modifier.
+### Automated table busy state
+`<b-table>` automatically tracks/controls it's `busy` state when items provider functions are
+used, however it also provides a `busy` prop that can be used either to override the inner `busy`
+state, or to monitor `<b-table>`'s current busy state in your application using the 2-way `.sync` modifier.
 
-**Note:** in order to allow `<b-table>` fully track it's `busy` state, custom items
+**Note:** in order to allow `<b-table>` fully track it's `busy` state, the custom items
 provider function should handle errors from data sources and return an empty
 array to `<b-table>`.
 
-`<b-table>` provides a `busy` prop that will flag the table as busy, which you can
-set to `true` just before your async fetch, and then set it to `false` once you have
-your data, and just before you send it to the table for display. Example:
-
+**Example: usage of busy state**
 ```html
-<b-table id="my-table" :busy.sync="isBusy" :items="myProvider" :fields="fields" ...></b-table>
+<b-table id="my-table"
+         :busy.sync="isBusy"
+         :items="myProvider"
+         :fields="fields" ...>
+</b-table>
 ```
-
 ```js
 data () {
   return {
@@ -1250,8 +1318,8 @@ data () {
 }
 methods: {
   myProvider (ctx) {
-      // Here we don't set isBusy prop, so busy state will be handled by table itself
-      // this.isBusy = true
+    // Here we don't set isBusy prop, so busy state will be handled by table itself
+    // this.isBusy = true
     let promise = axios.get('/some/url')
 
     return promise.then((data) => {
@@ -1275,6 +1343,7 @@ __not__ be called/refreshed until the `busy` state has been set to `false`.
 - All click related and hover events, and sort-changed events will __not__ be
  emitted when in the `busy` state (either set automatically during provider update,
  or when manually set).
+
 
 ### Provider Paging, Filtering, and Sorting
 By default, the items provider function is responsible for **all paging, filtering, and sorting**

--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -158,6 +158,10 @@
                 "description": "Slot to place custom colgroup and col elements"
             },
             {
+                "name": "table-busy",
+                "description": "Optional slot to place loading message when table is in the busy state"
+            },
+            {
                 "name": "[field]",
                 "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
             },

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -44,9 +44,6 @@ describe('b-table busy state', async () => {
     const wrapper = mount(Table, {
       propsData: {
         items: testItems
-      },
-      listeners: {
-        busy
       }
     })
     expect(wrapper.attributes('aria-busy')).toBeDefined()

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -2,9 +2,9 @@ import Table from './table'
 import { mount } from '@vue/test-utils'
 
 const testItems = [
-  {a: 1, b: 2, c: 3 },
-  {a: 1, b: 2, c: 3 },
-  {a: 1, b: 2, c: 3 }
+  { a: 1, b: 2, c: 3 },
+  { a: 5, b: 5, c: 6 },
+  { a: 7, b: 8, c: 9 }
 ]
 
 describe('b-table busy state', async () => {

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -1,5 +1,5 @@
 import Table from './table'
-import { mount, shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 const testItems = [
   { a: 1, b: 2, c: 3 },
@@ -74,7 +74,7 @@ describe('b-table busy state', async () => {
   })
 
   it('should render table-busy slot when busy=true and slot provided', async () => {
-    const wrapper = shallowMount(Table, {
+    const wrapper = mount(Table, {
       propsData: {
         busy: false,
         items: testItems
@@ -117,21 +117,30 @@ describe('b-table busy state', async () => {
 
   it('table-busy slot works with async provider function', async () => {
     let callback = null
+    let called = false
     const providerFn = (ctx, cb) => {
       // Simulate async function by letting us call calback manually
       callback = cb
+      called = true
     }
-    const wrapper = shallowMount(Table, {
+    const wrapper = mount(Table, {
       propsData: {
         fields: Object.keys(testItems[0]),
-        items: providerFn
+        items: providerFn,
+        busy: false
       },
       slots: {
         'table-busy': '<span>busy slot content</span>'
       }
     })
 
-    // WHen items is a provider function, localBusy is immediately set to true
+    expect(callback).toBe(null)
+    expect(called).toBe(false)
+    expect(typeof wrapper.props('items')).toBe('function')
+    expect(wrapper.vm.localBusy).toBe(true)
+    expect(wrapper.vm.computedBusy).toBe(true)
+
+    // When items is a provider function, localBusy is immediately set to true
     expect(wrapper.attributes('aria-busy')).toBeDefined()
     expect(wrapper.attributes('aria-busy')).toEqual('true')
     expect(wrapper.find('tbody').exists()).toBe(true)

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -18,7 +18,7 @@ describe('b-table busy state', async () => {
     expect(wrapper.attributes('aria-busy')).toEqual('false')
   })
 
-  it('default should have rows rendered', async () => {
+  it('default should have item rows rendered', async () => {
     const wrapper = mount(Table, {
       propsData: {
         items: testItems
@@ -29,7 +29,7 @@ describe('b-table busy state', async () => {
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
   })
 
-  it('should have attribute aria-busy=true when busy=true', async () => {
+  it('should have attribute aria-busy=true when prop busy=true', async () => {
     const wrapper = mount(Table, {
       propsData: {
         busy: true,
@@ -57,7 +57,7 @@ describe('b-table busy state', async () => {
     expect(wrapper.attributes('aria-busy')).toEqual('true')
   })
 
-  it('should emit update:busy event when data localBusy is set to true', async () => {
+  it('should emit update:busy event when data localBusy is toggled', async () => {
     const wrapper = mount(Table, {
       propsData: {
         items: testItems
@@ -73,7 +73,7 @@ describe('b-table busy state', async () => {
     expect(wrapper.emitted('update:busy')[0][0]).toEqual(true)
   })
 
-  it('should render table-busy slot when busy=true and slot provided', async () => {
+  it('should render table-busy slot when prop busy=true and slot provided', async () => {
     const wrapper = mount(Table, {
       propsData: {
         busy: false,
@@ -113,62 +113,5 @@ describe('b-table busy state', async () => {
     expect(wrapper.find('tbody').exists()).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
-  })
-
-  it('table-busy slot works with async provider function', async () => {
-    let callback = null
-    let called = false
-    const providerFn = (ctx, cb) => {
-      // Simulate async function by letting us call calback manually
-      callback = cb
-      called = true
-    }
-    const wrapper = mount(Table, {
-      propsData: {
-        fields: Object.keys(testItems[0]),
-        items: providerFn,
-        busy: false
-      },
-      slots: {
-        'table-busy': '<span>busy slot content</span>'
-      }
-    })
-
-    expect(callback).toBe(null)
-    expect(called).toBe(false)
-    expect(typeof wrapper.props('items')).toBe('function')
-    expect(wrapper.vm.localBusy).toBe(true)
-    expect(wrapper.vm.computedBusy).toBe(true)
-
-    // When items is a provider function, localBusy is immediately set to true
-    expect(wrapper.attributes('aria-busy')).toBeDefined()
-    expect(wrapper.attributes('aria-busy')).toEqual('true')
-    expect(wrapper.find('tbody').exists()).toBe(true)
-    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
-    expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
-    expect(wrapper.find('tbody').text()).toContain('busy slot content')
-    expect(wrapper.emitted('update:busy')).toBeDefined()
-    expect(wrapper.emitted('update:busy').length).toBe(1)
-    expect(wrapper.emitted('update:busy')[0][0]).toEqual(true)
-
-    // Provider function is called after nextTick on mount, so we wait and call the callback
-    return wrapper.vm.$nextTick(() => {
-      // callback should now be set
-      expect(typeof callback).toBe('function')
-
-      // Send the items array to b-table
-      callback(testItems)
-
-      // b-table should immediately clear busy state and populate items
-      expect(wrapper.attributes('aria-busy')).toBeDefined()
-      expect(wrapper.attributes('aria-busy')).toEqual('false')
-      expect(wrapper.find('tbody').exists()).toBe(true)
-      expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
-      expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
-      expect(wrapper.emitted('update:busy').length).toBe(2)
-      expect(wrapper.emitted('update:busy')[1][0]).toEqual(false)
-      expect(wrapper.emitted('refreshed')).toBeDefined()
-      expect(wrapper.emitted('refreshed').length).toBe(1)
-    })
   })
 })

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -1,0 +1,95 @@
+import Table from './table'
+import { mount } from '@vue/test-utils'
+
+const testItems = [
+  {a: 1, b: 2, c: 3 },
+  {a: 1, b: 2, c: 3 },
+  {a: 1, b: 2, c: 3 }
+]
+
+describe('b-table busy state', async () => {
+  it('default should have attribute aria-busy=false', async () => {
+    const wrapper = mount(Table, {
+      propsData: {
+        items: testItems
+      }
+    })
+    expect(wrapper.attributes('aria-busy')).toBeDefined()
+    expect(wrapper.attributes('aria-busy')).toEqual('false')
+  })
+
+  it('default should have rows rendered', async () => {
+    const wrapper = mount(Table, {
+      propsData: {
+        items: testItems
+      }
+    })
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+  })
+
+  it('should have attribute aria-busy=true when busy=true', async () => {
+    const wrapper = mount(Table, {
+      propsData: {
+        busy: true,
+        items: testItems
+      }
+    })
+    expect(wrapper.attributes('aria-busy')).toBeDefined()
+    expect(wrapper.attributes('aria-busy')).toEqual('true')
+  })
+
+  it('should render table-busy slot when busy=true and slot provided', async () => {
+    const wrapper = mount(Table, {
+      propsData: {
+        busy: true
+        items: testItems
+      },
+      slots: {
+        'table-busy': 'busy slot content'
+      }
+    })
+    expect(wrapper.attributes('aria-busy')).toBeDefined()
+    expect(wrapper.attributes('aria-busy')).toEqual('true')
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
+    expect(wrapper.find('tbody').text()).toContain('busy slot content')
+  })
+
+  it('should not render table-busy slot when busy=false and slot provided', async () => {
+    const wrapper = mount(Table, {
+      propsData: {
+        busy: false
+        items: testItems
+      },
+      slots: {
+        'table-busy': 'busy slot content'
+      }
+    })
+    expect(wrapper.attributes('aria-busy')).toBeDefined()
+    expect(wrapper.attributes('aria-busy')).toEqual('true')
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+    expect(wrapper.find('tbody').text()).not.toContain('busy slot content')
+  })
+
+  it('should set class b-table-busy-slot on tbody>tr when busy=true and slot provided', async () => {
+    const wrapper = mount(Table, {
+      propsData: {
+        busy: true
+        items: testItems
+      },
+      slots: {
+        'table-busy': 'busy slot content'
+      }
+    })
+    expect(wrapper.attributes('aria-busy')).toBeDefined()
+    expect(wrapper.attributes('aria-busy')).toEqual('true')
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').find('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').find('tr').classes()).toContain('b-table-busy-slot')
+  })
+})

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -1,5 +1,5 @@
 import Table from './table'
-import { mount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 
 const testItems = [
   { a: 1, b: 2, c: 3 },
@@ -58,13 +58,16 @@ describe('b-table busy state', async () => {
   })
 
   it('should render table-busy slot when busy=true and slot provided', async () => {
-    const wrapper = mount(Table, {
+    const wrapper = shallowMount(Table, {
       propsData: {
         busy: false,
         items: testItems
       },
       slots: {
-        'table-busy': 'busy slot content'
+        // Note slot data needs to be wrapped in an element.
+        // https://github.com/vue/vue-test-utils/issues:992
+        // Will be fixed in v1.0.0-beta.26
+        'table-busy': '<span>busy slot content</span>'
       }
     })
     expect(wrapper.attributes('aria-busy')).toBeDefined()
@@ -77,15 +80,22 @@ describe('b-table busy state', async () => {
       busy: true
     })
 
-    // Await until next tick to check rendered DOM
-    return wrapper.vm.$nextTick().then(function () {
-      expect(wrapper.attributes('aria-busy')).toBeDefined()
-      expect(wrapper.attributes('aria-busy')).toEqual('true')
-      expect(wrapper.find('tbody').exists()).toBe(true)
-      expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
-      expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
-      expect(wrapper.find('tbody').text()).toContain('busy slot content')
-      expect(wrapper.find('tbody').find('tr').classes()).toContain('b-table-busy-slot')
+    expect(wrapper.attributes('aria-busy')).toBeDefined()
+    expect(wrapper.attributes('aria-busy')).toEqual('true')
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
+    expect(wrapper.find('tbody').text()).toContain('busy slot content')
+    expect(wrapper.find('tbody').find('tr').classes()).toContain('b-table-busy-slot')
+
+    wrapper.setProps({
+      busy: false
     })
+
+    expect(wrapper.attributes('aria-busy')).toBeDefined()
+    expect(wrapper.attributes('aria-busy')).toEqual('false')
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
   })
 })

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -40,25 +40,24 @@ describe('b-table busy state', async () => {
     expect(wrapper.attributes('aria-busy')).toEqual('true')
   })
 
-  it('should render table-busy slot when busy=true and slot provided', async () => {
+  it('should have attribute aria-busy=true when data localBusy=true', async () => {
     const wrapper = mount(Table, {
       propsData: {
-        busy: true,
         items: testItems
-      },
-      slots: {
-        'table-busy': 'busy slot content'
       }
     })
     expect(wrapper.attributes('aria-busy')).toBeDefined()
+    expect(wrapper.attributes('aria-busy')).toEqual('false')
+
+    wrapper.setData({
+      localBusy: true
+    })
+
+    expect(wrapper.attributes('aria-busy')).toBeDefined()
     expect(wrapper.attributes('aria-busy')).toEqual('true')
-    expect(wrapper.find('tbody').exists()).toBe(true)
-    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
-    expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
-    expect(wrapper.find('tbody').text()).toContain('busy slot content')
   })
 
-  it('should not render table-busy slot when busy=false and slot provided', async () => {
+  it('should render table-busy slot when busy=true and slot provided', async () => {
     const wrapper = mount(Table, {
       propsData: {
         busy: false,
@@ -69,27 +68,21 @@ describe('b-table busy state', async () => {
       }
     })
     expect(wrapper.attributes('aria-busy')).toBeDefined()
-    expect(wrapper.attributes('aria-busy')).toEqual('true')
+    expect(wrapper.attributes('aria-busy')).toEqual('false')
     expect(wrapper.find('tbody').exists()).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
-    expect(wrapper.find('tbody').text()).not.toContain('busy slot content')
-  })
 
-  it('should set class b-table-busy-slot on tbody>tr when busy=true and slot provided', async () => {
-    const wrapper = mount(Table, {
-      propsData: {
-        busy: true,
-        items: testItems
-      },
-      slots: {
-        'table-busy': 'busy slot content'
-      }
+    wrapper.setProps({
+      busy: true
     })
+
     expect(wrapper.attributes('aria-busy')).toBeDefined()
     expect(wrapper.attributes('aria-busy')).toEqual('true')
     expect(wrapper.find('tbody').exists()).toBe(true)
-    expect(wrapper.find('tbody').find('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
+    expect(wrapper.find('tbody').text()).toContain('busy slot content')
     expect(wrapper.find('tbody').find('tr').classes()).toContain('b-table-busy-slot')
   })
 })

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -77,12 +77,15 @@ describe('b-table busy state', async () => {
       busy: true
     })
 
-    expect(wrapper.attributes('aria-busy')).toBeDefined()
-    expect(wrapper.attributes('aria-busy')).toEqual('true')
-    expect(wrapper.find('tbody').exists()).toBe(true)
-    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
-    expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
-    expect(wrapper.find('tbody').text()).toContain('busy slot content')
-    expect(wrapper.find('tbody').find('tr').classes()).toContain('b-table-busy-slot')
+    // Await until next tick to check rendered DOM
+    return Vue.nextTick().then(function() {
+      expect(wrapper.attributes('aria-busy')).toBeDefined()
+      expect(wrapper.attributes('aria-busy')).toEqual('true')
+      expect(wrapper.find('tbody').exists()).toBe(true)
+      expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+      expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
+      expect(wrapper.find('tbody').text()).toContain('busy slot content')
+      expect(wrapper.find('tbody').find('tr').classes()).toContain('b-table-busy-slot')
+    })
   })
 })

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -78,7 +78,7 @@ describe('b-table busy state', async () => {
     })
 
     // Await until next tick to check rendered DOM
-    return Vue.nextTick().then(function() {
+    return wrapper.vm.nextTick().then(function () {
       expect(wrapper.attributes('aria-busy')).toBeDefined()
       expect(wrapper.attributes('aria-busy')).toEqual('true')
       expect(wrapper.find('tbody').exists()).toBe(true)

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -78,7 +78,7 @@ describe('b-table busy state', async () => {
     })
 
     // Await until next tick to check rendered DOM
-    return wrapper.vm.nextTick().then(function () {
+    return wrapper.vm.$nextTick().then(function () {
       expect(wrapper.attributes('aria-busy')).toBeDefined()
       expect(wrapper.attributes('aria-busy')).toEqual('true')
       expect(wrapper.find('tbody').exists()).toBe(true)

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -43,7 +43,7 @@ describe('b-table busy state', async () => {
   it('should render table-busy slot when busy=true and slot provided', async () => {
     const wrapper = mount(Table, {
       propsData: {
-        busy: true
+        busy: true,
         items: testItems
       },
       slots: {
@@ -61,7 +61,7 @@ describe('b-table busy state', async () => {
   it('should not render table-busy slot when busy=false and slot provided', async () => {
     const wrapper = mount(Table, {
       propsData: {
-        busy: false
+        busy: false,
         items: testItems
       },
       slots: {
@@ -79,7 +79,7 @@ describe('b-table busy state', async () => {
   it('should set class b-table-busy-slot on tbody>tr when busy=true and slot provided', async () => {
     const wrapper = mount(Table, {
       propsData: {
-        busy: true
+        busy: true,
         items: testItems
       },
       slots: {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -222,122 +222,146 @@ export default {
       rows.push(h(false))
     }
 
-    // Add the item data rows
-    items.forEach((item, rowIndex) => {
-      const detailsSlot = $scoped['row-details']
-      const rowShowDetails = Boolean(item._showDetails && detailsSlot)
-      // Details ID needed for aria-describedby when details showing
-      const detailsId = rowShowDetails
-        ? this.safeId(`_details_${rowIndex}_`)
-        : null
-      const toggleDetailsFn = () => {
-        if (detailsSlot) {
-          this.$set(item, '_showDetails', !item._showDetails)
-        }
+    // Add the item data rows or the busy slot
+    if (this.computedBusy && $slots['table-busy']) {
+      // show the busy slot
+      const tdAttrs = { colspan: String(fields.length) }
+      const trAttrs = { }
+      if (this.isStacked) {
+        tdAttrs['role'] = 'cell'
+        trAttrs['role'] = 'row'
       }
-      // For each item data field in row
-      const tds = fields.map((field, colIndex) => {
-        const formatted = this.getFormattedValue(item, field)
-        const data = {
-          key: `row-${rowIndex}-cell-${colIndex}`,
-          class: this.tdClasses(field, item),
-          attrs: this.tdAttrs(field, item, colIndex),
-          domProps: {}
-        }
-        let childNodes
-        if ($scoped[field.key]) {
-          childNodes = [
-            $scoped[field.key]({
-              item: item,
-              index: rowIndex,
-              field: field,
-              unformatted: _get(item, field.key, ''),
-              value: formatted,
-              toggleDetails: toggleDetailsFn,
-              detailsShowing: Boolean(item._showDetails)
-            })
-          ]
-          if (this.isStacked) {
-            // We wrap in a DIV to ensure rendered as a single cell when visually stacked!
-            childNodes = [h('div', {}, [childNodes])]
-          }
-        } else {
-          if (this.isStacked) {
-            // We wrap in a DIV to ensure rendered as a single cell when visually stacked!
-            childNodes = [h('div', formatted)]
-          } else {
-            // Non stacked
-            childNodes = formatted
-          }
-        }
-        // Render either a td or th cell
-        return h(field.isRowHeader ? 'th' : 'td', data, childNodes)
-      })
-      // Calculate the row number in the dataset (indexed from 1)
-      let ariaRowIndex = null
-      if (this.currentPage && this.perPage && this.perPage > 0) {
-        ariaRowIndex = String((this.currentPage - 1) * this.perPage + rowIndex + 1)
-      }
-      // Assemble and add the row
+      const busyContent = h('td', { attrs: tdAttrs }, $slots['table-busy'])
       rows.push(
         h(
           'tr',
           {
-            key: `row-${rowIndex}`,
-            class: [
-              this.rowClasses(item),
-              { 'b-table-has-details': rowShowDetails }
-            ],
-            attrs: {
-              'aria-describedby': detailsId,
-              'aria-owns': detailsId,
-              'aria-rowindex': ariaRowIndex,
-              role: this.isStacked ? 'row' : null
-            },
-            on: {
-              click: evt => { this.rowClicked(evt, item, rowIndex) },
-              contextmenu: evt => { this.rowContextmenu(evt, item, rowIndex) },
-              dblclick: evt => { this.rowDblClicked(evt, item, rowIndex) },
-              mouseenter: evt => { this.rowHovered(evt, item, rowIndex) },
-              mouseleave: evt => { this.rowUnhovered(evt, item, rowIndex) }
-            }
+            key: 'table-busy-slot',
+            staticClass: 'b-table-busy-slot',
+            class: [typeof this.tbodyTrClass === 'function' ? this.tbodyTrClass(item, 'table-busy') : this.tbodyTrClass],
+            attrs: trAttrs
           },
-          tds
+          [busyContent]
         )
       )
-      // Row Details slot
-      if (rowShowDetails) {
-        const tdAttrs = { colspan: String(fields.length) }
-        const trAttrs = { id: detailsId }
-        if (this.isStacked) {
-          tdAttrs['role'] = 'cell'
-          trAttrs['role'] = 'row'
+    } else {
+      // Show the rows
+      items.forEach((item, rowIndex) => {
+        const detailsSlot = $scoped['row-details']
+        const rowShowDetails = Boolean(item._showDetails && detailsSlot)
+        // Details ID needed for aria-describedby when details showing
+        const detailsId = rowShowDetails
+          ? this.safeId(`_details_${rowIndex}_`)
+          : null
+        const toggleDetailsFn = () => {
+          if (detailsSlot) {
+            this.$set(item, '_showDetails', !item._showDetails)
+          }
         }
-        const details = h('td', { attrs: tdAttrs }, [
-          detailsSlot({
-            item: item,
-            index: rowIndex,
-            fields: fields,
-            toggleDetails: toggleDetailsFn
-          })
-        ])
+        // For each item data field in row
+        const tds = fields.map((field, colIndex) => {
+          const formatted = this.getFormattedValue(item, field)
+          const data = {
+            key: `row-${rowIndex}-cell-${colIndex}`,
+            class: this.tdClasses(field, item),
+            attrs: this.tdAttrs(field, item, colIndex),
+            domProps: {}
+          }
+          let childNodes
+          if ($scoped[field.key]) {
+            childNodes = [
+              $scoped[field.key]({
+                item: item,
+                index: rowIndex,
+                field: field,
+                unformatted: _get(item, field.key, ''),
+                value: formatted,
+                toggleDetails: toggleDetailsFn,
+                detailsShowing: Boolean(item._showDetails)
+              })
+            ]
+            if (this.isStacked) {
+              // We wrap in a DIV to ensure rendered as a single cell when visually stacked!
+              childNodes = [h('div', {}, [childNodes])]
+            }
+          } else {
+            if (this.isStacked) {
+              // We wrap in a DIV to ensure rendered as a single cell when visually stacked!
+              childNodes = [h('div', formatted)]
+            } else {
+              // Non stacked
+              childNodes = formatted
+            }
+          }
+          // Render either a td or th cell
+          return h(field.isRowHeader ? 'th' : 'td', data, childNodes)
+        })
+        // Calculate the row number in the dataset (indexed from 1)
+        let ariaRowIndex = null
+        if (this.currentPage && this.perPage && this.perPage > 0) {
+          ariaRowIndex = String((this.currentPage - 1) * this.perPage + rowIndex + 1)
+        }
+        // Assemble and add the row
         rows.push(
           h(
             'tr',
             {
-              key: `details-${rowIndex}`,
-              staticClass: 'b-table-details',
-              class: [typeof this.tbodyTrClass === 'function' ? this.tbodyTrClass(item, 'row-details') : this.tbodyTrClass],
-              attrs: trAttrs
+              key: `row-${rowIndex}`,
+              class: [
+                this.rowClasses(item),
+                { 'b-table-has-details': rowShowDetails }
+              ],
+              attrs: {
+                'aria-describedby': detailsId,
+                'aria-owns': detailsId,
+                'aria-rowindex': ariaRowIndex,
+                role: this.isStacked ? 'row' : null
+              },
+              on: {
+                click: evt => { this.rowClicked(evt, item, rowIndex) },
+                contextmenu: evt => { this.rowContextmenu(evt, item, rowIndex) },
+                dblclick: evt => { this.rowDblClicked(evt, item, rowIndex) },
+                mouseenter: evt => { this.rowHovered(evt, item, rowIndex) },
+                mouseleave: evt => { this.rowUnhovered(evt, item, rowIndex) }
+              }
             },
-            [details]
+            tds
           )
         )
-      } else if (detailsSlot) {
-        // Only add the placeholder if a the table has a row-details slot defined (but not shown)
-        rows.push(h(false))
-      }
-    })
+        // Row Details slot
+        if (rowShowDetails) {
+          const tdAttrs = { colspan: String(fields.length) }
+          const trAttrs = { id: detailsId }
+          if (this.isStacked) {
+            tdAttrs['role'] = 'cell'
+            trAttrs['role'] = 'row'
+          }
+          const details = h('td', { attrs: tdAttrs }, [
+            detailsSlot({
+              item: item,
+              index: rowIndex,
+              fields: fields,
+              toggleDetails: toggleDetailsFn
+            })
+          ])
+          rows.push(
+            h(
+              'tr',
+              {
+                key: `details-${rowIndex}`,
+                staticClass: 'b-table-details',
+                class: [typeof this.tbodyTrClass === 'function' ? this.tbodyTrClass(item, 'row-details') : this.tbodyTrClass],
+                attrs: trAttrs
+              },
+              [details]
+            )
+          )
+        } else if (detailsSlot) {
+          // Only add the placeholder if a the table has a row-details slot defined (but not shown)
+          rows.push(h(false))
+        }
+      })
+    }
 
     // Empty Items / Empty Filtered Row slot
     if (this.showEmpty && (!items || items.length === 0)) {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -223,15 +223,15 @@ export default {
     }
 
     // Add the item data rows or the busy slot
-    if (this.computedBusy && $slots['table-busy']) {
-      // show the busy slot
-      const tdAttrs = { colspan: String(fields.length) }
-      const trAttrs = { }
-      if (this.isStacked) {
-        tdAttrs['role'] = 'cell'
-        trAttrs['role'] = 'row'
+    if ($slots['table-busy'] && this.computedBusy) {
+      // Show the busy slot
+      const trAttrs = {
+        role: this.isStacked ? 'row' : null
       }
-      const busyContent = h('td', { attrs: tdAttrs }, $slots['table-busy'])
+      const tdAttrs = {
+        colspan: String(fields.length),
+        role: this.isStacked ? 'cell' : null
+      }
       rows.push(
         h(
           'tr',
@@ -241,7 +241,7 @@ export default {
             class: [typeof this.tbodyTrClass === 'function' ? this.tbodyTrClass(null, 'table-busy') : this.tbodyTrClass],
             attrs: trAttrs
           },
-          [busyContent]
+          [h('td', { attrs: tdAttrs }, [$slots['table-busy']])]
         )
       )
     } else {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -238,7 +238,7 @@ export default {
           {
             key: 'table-busy-slot',
             staticClass: 'b-table-busy-slot',
-            class: [typeof this.tbodyTrClass === 'function' ? this.tbodyTrClass(item, 'table-busy') : this.tbodyTrClass],
+            class: [typeof this.tbodyTrClass === 'function' ? this.tbodyTrClass(null, 'table-busy') : this.tbodyTrClass],
             attrs: trAttrs
           },
           [busyContent]


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Adds a new slot `table-busy` which allows users to display a loading message when the table is in the busy state.

If no `table-busy` slot is present, the current rows are displayed (as was the behaviour before)

Includes new test suite for `busy` state testing using `vue-test-utils`

Closes #1859

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

