### PR TITLE
fix(scss): import _input-group.scss once at most

### DIFF
--- a/src/components/input-group/_input-group.scss
+++ b/src/components/input-group/_input-group.scss
@@ -1,22 +1,29 @@
-/* workaround for https://github.com/bootstrap-vue/bootstrap-vue/issues/1560 */
-/* workaround for https://github.com/bootstrap-vue/bootstrap-vue/issues/2114 */
-/* source: bootstrap _input-group.scss */
-.input-group {
-  > .input-group-prepend > .btn-group,
-  > .input-group-append:not(:last-child) > .btn-group,
-  > .input-group-append:last-child > .btn-group:not(:last-child):not(.dropdown-toggle) {
-    > .btn {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-  }
+$bv-input-group-dropdown-patched: false !default;
 
-  > .input-group-append > .btn-group,
-  > .input-group-prepend:not(:first-child) > .btn-group,
-  > .input-group-prepend:first-child > .btn-group:not(:first-child) {
-    > .btn {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
+@if $bv-input-group-dropdown-patched == false {
+  // Only include this style patch once in final CSS
+  $bv-input-group-dropdown-patched: true;
+
+  /* workaround for https://github.com/bootstrap-vue/bootstrap-vue/issues/1560 */
+  /* workaround for https://github.com/bootstrap-vue/bootstrap-vue/issues/2114 */
+  /* based on: bootstrap/scss/_input-group.scss */
+  .input-group {
+    > .input-group-prepend > .btn-group,
+    > .input-group-append:not(:last-child) > .btn-group,
+    > .input-group-append:last-child > .btn-group:not(:last-child):not(.dropdown-toggle) {
+      > .btn {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+    }
+
+    > .input-group-append > .btn-group,
+    > .input-group-prepend:not(:first-child) > .btn-group,
+    > .input-group-prepend:first-child > .btn-group:not(:first-child) {
+      > .btn {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Prevents the CSS from appearing in the compiled output CSS more than once.

Reduces file size of generated bootstrap-vue.css

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other, please describe: CSS

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
