### PR TITLE
fix(table): Emit v-model input event only when computedItems changes (closes #2231)

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -750,6 +750,10 @@ export default {
         this.$emit('update:busy', newVal)
       }
     },
+    // Watch for changes on computedItems and update the v-model
+    computedItems(newVal, OldVal) {
+      this.$emit('input', newVal)
+    },
     // Watch for changes to the filter criteria and filtered items vs localItems).
     // And set visual state and emit events as required
     filteredCheck ({ filteredItems, localItems, localFilter }) {
@@ -1034,8 +1038,6 @@ export default {
         // Grab the current page of data (which may be past filtered items limit)
         items = items.slice((currentPage - 1) * perPage, currentPage * perPage)
       }
-      // update the v-model view
-      this.$emit('input', items)
       // Return the items to display in the table
       return items
     },

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -751,7 +751,7 @@ export default {
       }
     },
     // Watch for changes on computedItems and update the v-model
-    computedItems(newVal, OldVal) {
+    computedItems (newVal, OldVal) {
       this.$emit('input', newVal)
     },
     // Watch for changes to the filter criteria and filtered items vs localItems).


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Rather than updating the v-model on every render, emit only when the displayed row data changes.

Closes #2231

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)
