### PR TITLE
fix(package.json):  prevent css and scss from being tree shaken out

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "./es/utils/object.js",
     "./src/utils/object.js",
     "./es/utils/array.js",
-    "./src/utils/array.js"
+    "./src/utils/array.js",
+    "**/*.scss",
+    "**/*.css"
   ],
   "scripts": {
     "build": "scripts/build",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,12 @@
     "nuxt",
     "es"
   ],
+  "sideEffects": [
+    "./es/utils/object.js",
+    "./src/utils/object.js",
+    "./es/utils/array.js",
+    "./stc/utils/array.js"
+  ],
   "scripts": {
     "build": "scripts/build",
     "watch": "rollup -c scripts/rollup.config.js --watch",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "./es/utils/object.js",
     "./src/utils/object.js",
     "./es/utils/array.js",
-    "./stc/utils/array.js"
+    "./src/utils/array.js"
   ],
   "scripts": {
     "build": "scripts/build",


### PR DESCRIPTION
Adds scss and css files to the `sideEffects` rule