### PR TITLE
feat(form-checkbox): support custom switch styling

### DIFF
--- a/src/components/form-checkbox/README.md
+++ b/src/components/form-checkbox/README.md
@@ -171,6 +171,74 @@ be placed in a [`<b-form-group>`](/docs/components/form-group) component to
 associate a label with the entire group of checkboxes. See examples above.
 
 
+## Switch style checkboxes
+You can optionally render checkboxes to appear as switches, either individually, or in a group.
+
+**Note:** If the checkbox is in [button mode](#button-style-checkboxes), switch mode will have no effect.
+
+### Individual checkbox switch style
+A single checkbox can be rendered with a switch appearance by setting the prop `switch` to `true`
+
+```html
+<template>
+  <div>
+    <b-form-checkbox switch v-model="checked" name="check-button">
+      Switch Checkbox <b>(Checked: {{ checked }})</b>
+    </b-form-checkbox>
+   </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      checked: false
+    }
+  }
+}
+</script>
+
+<!-- form-checkbox-switch.vue -->
+```
+
+### Grouped switch style checkboxes
+Render groups of checkboxes with the look of a switches by setting the prop `switches` on `<b-form-checkbox-group>`.
+
+```html
+<template>
+  <div>
+    <b-form-group label="Inline switch style checkboxes">
+      <b-form-checkbox-group switchess v-model="selected" name="switches1" :options="options">
+      </b-form-checkbox-group>
+    </b-form-group>
+
+    <b-form-group label="Stacked (vertical) switch style checkboxes">
+      <b-form-checkbox-group switches v-model="selected" stacked :options="options">
+      </b-form-checkbox-group>
+    </b-form-group>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      selected: [], // Must be an array reference!
+      options: [
+        {text: 'Orange', value: 'orange'},
+        {text: 'Apple', value: 'apple'},
+        {text: 'Pineapple', value: 'pineapple'},
+        {text: 'Grape', value: 'grape'}
+      ]
+    }
+  }
+}
+</script>
+
+<!-- form-checkboxs-switch-group.vue -->
+```
+
+
 ## Button style checkboxes
 You can optionally render checkboxes to appear as buttons, either individually, or in a group.
 

--- a/src/components/form-checkbox/README.md
+++ b/src/components/form-checkbox/README.md
@@ -171,74 +171,6 @@ be placed in a [`<b-form-group>`](/docs/components/form-group) component to
 associate a label with the entire group of checkboxes. See examples above.
 
 
-## Switch style checkboxes
-You can optionally render checkboxes to appear as switches, either individually, or in a group.
-
-**Note:** If the checkbox is in [button mode](#button-style-checkboxes), switch mode will have no effect.
-
-### Individual checkbox switch style
-A single checkbox can be rendered with a switch appearance by setting the prop `switch` to `true`
-
-```html
-<template>
-  <div>
-    <b-form-checkbox switch v-model="checked" name="check-button">
-      Switch Checkbox <b>(Checked: {{ checked }})</b>
-    </b-form-checkbox>
-   </div>
-</template>
-
-<script>
-export default {
-  data () {
-    return {
-      checked: false
-    }
-  }
-}
-</script>
-
-<!-- form-checkbox-switch.vue -->
-```
-
-### Grouped switch style checkboxes
-Render groups of checkboxes with the look of a switches by setting the prop `switches` on `<b-form-checkbox-group>`.
-
-```html
-<template>
-  <div>
-    <b-form-group label="Inline switch style checkboxes">
-      <b-form-checkbox-group switchess v-model="selected" name="switches1" :options="options">
-      </b-form-checkbox-group>
-    </b-form-group>
-
-    <b-form-group label="Stacked (vertical) switch style checkboxes">
-      <b-form-checkbox-group switches v-model="selected" stacked :options="options">
-      </b-form-checkbox-group>
-    </b-form-group>
-  </div>
-</template>
-
-<script>
-export default {
-  data () {
-    return {
-      selected: [], // Must be an array reference!
-      options: [
-        {text: 'Orange', value: 'orange'},
-        {text: 'Apple', value: 'apple'},
-        {text: 'Pineapple', value: 'pineapple'},
-        {text: 'Grape', value: 'grape'}
-      ]
-    }
-  }
-}
-</script>
-
-<!-- form-checkboxs-switch-group.vue -->
-```
-
-
 ## Button style checkboxes
 You can optionally render checkboxes to appear as buttons, either individually, or in a group.
 
@@ -328,6 +260,74 @@ export default {
 </script>
 
 <!-- form-checkboxs-button-group.vue -->
+```
+
+
+## Switch style checkboxes
+You can optionally render checkboxes to appear as switches, either individually, or in a group.
+
+**Note:** If the checkbox is in [button mode](#button-style-checkboxes), switch mode will have no effect.
+
+### Individual checkbox switch style
+A single checkbox can be rendered with a switch appearance by setting the prop `switch` to `true`
+
+```html
+<template>
+  <div>
+    <b-form-checkbox switch v-model="checked" name="check-button">
+      Switch Checkbox <b>(Checked: {{ checked }})</b>
+    </b-form-checkbox>
+   </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      checked: false
+    }
+  }
+}
+</script>
+
+<!-- form-checkbox-switch.vue -->
+```
+
+### Grouped switch style checkboxes
+Render groups of checkboxes with the look of a switches by setting the prop `switches` on `<b-form-checkbox-group>`.
+
+```html
+<template>
+  <div>
+    <b-form-group label="Inline switch style checkboxes">
+      <b-form-checkbox-group switches v-model="selected" name="switches1" :options="options">
+      </b-form-checkbox-group>
+    </b-form-group>
+
+    <b-form-group label="Stacked (vertical) switch style checkboxes">
+      <b-form-checkbox-group switches v-model="selected" stacked :options="options">
+      </b-form-checkbox-group>
+    </b-form-group>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      selected: [], // Must be an array reference!
+      options: [
+        {text: 'Red', value: 'red'},
+        {text: 'Green', value: 'green'},
+        {text: 'Yellow (disabled)', value: 'yellow', disabled: true},
+        {text: 'Blue', value: 'blue'}
+      ]
+    }
+  }
+}
+</script>
+
+<!-- form-checkboxs-switch-group.vue -->
 ```
 
 

--- a/src/components/form-checkbox/README.md
+++ b/src/components/form-checkbox/README.md
@@ -264,7 +264,10 @@ export default {
 
 
 ## Switch style checkboxes
-You can optionally render checkboxes to appear as switches, either individually, or in a group.
+Bootstrap V4.2 (unreleased) adds in support for _Switch Style_ checkboxes. Bootstrap-Vue has added
+this pre-release feature by conditionally including the required custom SCSS styles.
+
+Switch styling is supported on idividual checkboxes and via `<b-formcheckbox-group>`.
 
 **Note:** If the checkbox is in [button mode](#button-style-checkboxes), switch mode will have no effect.
 
@@ -403,7 +406,7 @@ prop (defaults to `false`). Clicking the checkbox will clear its indeterminate s
 The `indeterminate` prop can be synced to the checkbox's state by v-binding the
 `indeterminate` prop with the `.sync` modifier.
 
-**Note:** indeterminate is not supported in button mode, nor is it supported in
+**Note:** indeterminate styling is not supported in button or switch mode, nor is it supported in
 `<b-form-checkbox-group>` (multiple checkboxes).
 
 **Single Indeterminate checkbox:**

--- a/src/components/form-checkbox/README.md
+++ b/src/components/form-checkbox/README.md
@@ -267,7 +267,7 @@ export default {
 Bootstrap V4.2 (unreleased) adds in support for _Switch Style_ checkboxes. Bootstrap-Vue has added
 this pre-release feature by conditionally including the required custom SCSS styles.
 
-Switch styling is supported on idividual checkboxes and via `<b-formcheckbox-group>`.
+Switch styling is supported on `<b-form-checkbox>` and `<b-form-checkbox-group>` components.
 
 **Note:** If the checkbox is in [button mode](#button-style-checkboxes), switch mode will have no effect.
 

--- a/src/components/form-checkbox/_form-checkbox.scss
+++ b/src/components/form-checkbox/_form-checkbox.scss
@@ -1,6 +1,7 @@
 
 @if global-variable-exists(custom-switch-width) == false {
-  // Only include this SCSS if not already defined
+  // Only include this SCSS if not already defined (i.e. not using V4.2 SCSS)
+
   // From Boostrap v4.2 SCSS _custom-forms.scss
   // Define default values
   $custom-control-indicator-border-width: $input-border-width !default;
@@ -10,11 +11,16 @@
   $custom-switch-indicator-border-radius: $custom-control-indicator-size / 2 !default;
   $custom-switch-indicator-size:          calc(#{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4}) !default;
 
+  // Override for V4.1.3
+  $bv-custom-control-gutter:                 .5rem !default;
+
   // switches
   //
   // Tweak a few things for switches
   .custom-switch {
-    padding-left: $custom-switch-width + $custom-control-gutter;
+    // V4.2 uses a different gutter size
+    // padding-left: $custom-switch-width + $custom-control-gutter;
+    padding-left: $custom-switch-width + $bv-custom-control-gutter;
 
     .custom-control-label {
       &::before {

--- a/src/components/form-checkbox/_form-checkbox.scss
+++ b/src/components/form-checkbox/_form-checkbox.scss
@@ -4,6 +4,8 @@
   // From Boostrap v4.2 SCSS _custom-forms.scss
   // Define default values
   $custom-control-indicator-border-width: $input-border-width !default;
+  $custom-control-indicator-border-color: $gray-500 !default;
+
   $custom-switch-width:                   $custom-control-indicator-size * 1.75 !default;
   $custom-switch-indicator-border-radius: $custom-control-indicator-size / 2 !default;
   $custom-switch-indicator-size:          calc(#{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4}) !default;

--- a/src/components/form-checkbox/_form-checkbox.scss
+++ b/src/components/form-checkbox/_form-checkbox.scss
@@ -1,0 +1,48 @@
+
+@if $custom-switch-width == null {
+  // Only include this SCSS if not already defined
+  // From Boostrap v4.2 SCSS _custom-forms.scss
+  // Define default values
+  $custom-switch-width:                   $custom-control-indicator-size * 1.75 !default;
+  $custom-switch-indicator-border-radius: $custom-control-indicator-size / 2 !default;
+  $custom-switch-indicator-size:          calc(#{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4}) !default;
+
+  // switches
+  //
+  // Tweak a few things for switches
+  .custom-switch {
+    padding-left: $custom-switch-width + $custom-control-gutter;
+
+    .custom-control-label {
+      &::before {
+        left: -($custom-switch-width + $custom-control-gutter);
+        width: $custom-switch-width;
+        pointer-events: all;
+        border-radius: $custom-switch-indicator-border-radius;
+      }
+
+      &::after {
+        top: calc(#{(($font-size-base * $line-height-base - $custom-control-indicator-size) / 2)} + #{$custom-control-indicator-border-width * 2});
+        left: calc(#{-($custom-switch-width + $custom-control-gutter)} + #{$custom-control-indicator-border-width * 2});
+        width: $custom-switch-indicator-size;
+        height: $custom-switch-indicator-size;
+        background-color: $custom-control-indicator-border-color;
+        border-radius: $custom-switch-indicator-border-radius;
+        @include transition(transform .15s ease-in-out, $custom-forms-transition);
+      }
+    }
+
+    .custom-control-input:checked ~ .custom-control-label {
+      &::after {
+        background-color: $custom-control-indicator-bg;
+        transform: translateX($custom-switch-width - $custom-control-indicator-size);
+      }
+    }
+
+    .custom-control-input:disabled {
+      &:checked ~ .custom-control-label::before {
+        background-color: $custom-control-indicator-checked-disabled-bg;
+      }
+    }
+  }
+}

--- a/src/components/form-checkbox/_form-checkbox.scss
+++ b/src/components/form-checkbox/_form-checkbox.scss
@@ -1,5 +1,5 @@
 
-@if $custom-switch-width == null {
+@if global-variable-exists(custom-switch-width) == false {
   // Only include this SCSS if not already defined
   // From Boostrap v4.2 SCSS _custom-forms.scss
   // Define default values

--- a/src/components/form-checkbox/_form-checkbox.scss
+++ b/src/components/form-checkbox/_form-checkbox.scss
@@ -3,6 +3,7 @@
   // Only include this SCSS if not already defined
   // From Boostrap v4.2 SCSS _custom-forms.scss
   // Define default values
+  $custom-control-indicator-border-width: $input-border-width !default;
   $custom-switch-width:                   $custom-control-indicator-size * 1.75 !default;
   $custom-switch-indicator-border-radius: $custom-control-indicator-size / 2 !default;
   $custom-switch-indicator-size:          calc(#{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4}) !default;

--- a/src/components/form-checkbox/_form-checkbox.scss
+++ b/src/components/form-checkbox/_form-checkbox.scss
@@ -1,5 +1,5 @@
 
-@if global-variable-exists(custom-switch-width) == false {
+@if variable-exists(custom-switch-width) == false {
   // Only include this SCSS if not already defined (i.e. not using V4.2 SCSS)
 
   // From Boostrap v4.2 SCSS _custom-forms.scss

--- a/src/components/form-checkbox/_form-checkbox.scss
+++ b/src/components/form-checkbox/_form-checkbox.scss
@@ -24,7 +24,9 @@
 
     .custom-control-label {
       &::before {
-        left: -($custom-switch-width + $custom-control-gutter);
+        // V4.2 uses a different gutter size
+        // left: -($custom-switch-width + $custom-control-gutter);
+        left: -($custom-switch-width + $bv-custom-control-gutter);
         width: $custom-switch-width;
         pointer-events: all;
         border-radius: $custom-switch-indicator-border-radius;
@@ -32,7 +34,9 @@
 
       &::after {
         top: calc(#{(($font-size-base * $line-height-base - $custom-control-indicator-size) / 2)} + #{$custom-control-indicator-border-width * 2});
-        left: calc(#{-($custom-switch-width + $custom-control-gutter)} + #{$custom-control-indicator-border-width * 2});
+        // V4.2 uses a different gutter size
+        // left: calc(#{-($custom-switch-width + $custom-control-gutter)} + #{$custom-control-indicator-border-width * 2});
+        left: calc(#{-($custom-switch-width + $bv-custom-control-gutter)} + #{$custom-control-indicator-border-width * 2});
         width: $custom-switch-indicator-size;
         height: $custom-switch-indicator-size;
         background-color: $custom-control-indicator-border-color;

--- a/src/components/form-checkbox/_form-checkbox.scss
+++ b/src/components/form-checkbox/_form-checkbox.scss
@@ -1,3 +1,4 @@
+// This SCSS file can be removed once Bootstrap V4.2 is released and Boostrap-Vue is upgraded to use it.
 
 @if variable-exists(custom-switch-width) == false {
   // Only include this SCSS if not already defined (i.e. not using V4.2 SCSS)
@@ -6,13 +7,12 @@
   // Define default values
   $custom-control-indicator-border-width: $input-border-width !default;
   $custom-control-indicator-border-color: $gray-500 !default;
-
   $custom-switch-width:                   $custom-control-indicator-size * 1.75 !default;
   $custom-switch-indicator-border-radius: $custom-control-indicator-size / 2 !default;
   $custom-switch-indicator-size:          calc(#{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4}) !default;
 
-  // Override for V4.1.3
-  $bv-custom-control-gutter:                 .5rem !default;
+  // Override for V4.1.3 SCSS
+  $bv-temp-custom-control-gutter:                 .5rem !default;
 
   // switches
   //
@@ -20,13 +20,13 @@
   .custom-switch {
     // V4.2 uses a different gutter size
     // padding-left: $custom-switch-width + $custom-control-gutter;
-    padding-left: $custom-switch-width + $bv-custom-control-gutter;
+    padding-left: $custom-switch-width + $bv-temp-custom-control-gutter;
 
     .custom-control-label {
       &::before {
         // V4.2 uses a different gutter size
         // left: -($custom-switch-width + $custom-control-gutter);
-        left: -($custom-switch-width + $bv-custom-control-gutter);
+        left: -($custom-switch-width + $bv-temp-custom-control-gutter);
         width: $custom-switch-width;
         pointer-events: all;
         border-radius: $custom-switch-indicator-border-radius;
@@ -36,7 +36,7 @@
         top: calc(#{(($font-size-base * $line-height-base - $custom-control-indicator-size) / 2)} + #{$custom-control-indicator-border-width * 2});
         // V4.2 uses a different gutter size
         // left: calc(#{-($custom-switch-width + $custom-control-gutter)} + #{$custom-control-indicator-border-width * 2});
-        left: calc(#{-($custom-switch-width + $bv-custom-control-gutter)} + #{$custom-control-indicator-border-width * 2});
+        left: calc(#{-($custom-switch-width + $bv-temp-custom-control-gutter)} + #{$custom-control-indicator-border-width * 2});
         width: $custom-switch-indicator-size;
         height: $custom-switch-indicator-size;
         background-color: $custom-control-indicator-border-color;

--- a/src/components/form-checkbox/form-checkbox-group.js
+++ b/src/components/form-checkbox/form-checkbox-group.js
@@ -24,6 +24,11 @@ export default {
     }
   },
   props: {
+    switches: {
+      // Custom switch styling
+      type: Boolean,
+      default: false
+    },
     checked: {
       type: [String, Number, Object, Array, Boolean],
       default: null

--- a/src/components/form-checkbox/form-checkbox.js
+++ b/src/components/form-checkbox/form-checkbox.js
@@ -37,6 +37,11 @@ export default {
       type: Boolean,
       default: false
     },
+    switch: {
+      // Custom switch styling
+      type: Boolean,
+      default: false
+    },
     checked: {
       // v-model
       type: [String, Number, Object, Array, Boolean],

--- a/src/components/form-checkbox/form-checkbox.spec.js
+++ b/src/components/form-checkbox/form-checkbox.spec.js
@@ -539,6 +539,89 @@ describe('form-checkbox', async () => {
     expect(input.classes()).not.toContain('is-valid')
   })
 
+  /* switch styling - stand alone */
+
+  it('switch has structure <div><input/><label></label></div>', async () => {
+    const wrapper = mount(Input, {
+      propsData: {
+        'switch': true,
+        checked: '',
+        value: 'a'
+      },
+      slots: {
+        default: 'foobar'
+      }
+    })
+    expect(wrapper).toBeDefined()
+    expect(wrapper.is('div')).toBe(true)
+    const children = wrapper.element.children
+    expect(children.length).toEqual(2)
+    expect(children[0].tagName).toEqual('INPUT')
+    expect(children[1].tagName).toEqual('LABEL')
+  })
+
+  it('switch has wrapper classes custom-control and custom-switch', async () => {
+    const wrapper = mount(Input, {
+      propsData: {
+        'switch': true,
+        checked: '',
+        value: 'a'
+      },
+      slots: {
+        default: 'foobar'
+      }
+    })
+    expect(wrapper.classes().length).toEqual(2)
+    expect(wrapper.classes()).toContain('custom-control')
+    expect(wrapper.classes()).toContain('custom-switch')
+  })
+
+  it('switch has input type checkbox', async () => {
+    const wrapper = mount(Input, {
+      propsData: {
+        'switch': true,
+        checked: '',
+        value: 'a'
+      },
+      slots: {
+        default: 'foobar'
+      }
+    })
+    const input = wrapper.find('input')
+    expect(input.attributes('type')).toBeDefined()
+    expect(input.attributes('type')).toEqual('checkbox')
+  })
+
+  it('switch has input class custom-control-input', async () => {
+    const wrapper = mount(Input, {
+      propsData: {
+        'switch': true,
+        checked: false
+      },
+      slots: {
+        default: 'foobar'
+      }
+    })
+    const input = wrapper.find('input')
+    expect(input.classes().length).toEqual(1)
+    expect(input.classes()).toContain('custom-control-input')
+  })
+
+  it('switch has label class custom-control-label', async () => {
+    const wrapper = mount(Input, {
+      propsData: {
+        'switch': true,
+        checked: false
+      },
+      slots: {
+        default: 'foobar'
+      }
+    })
+    const input = wrapper.find('label')
+    expect(input.classes().length).toEqual(1)
+    expect(input.classes()).toContain('custom-control-label')
+  })
+
   /* button styling - stand-alone mode */
 
   it('stand-alone button has structure <div><label><input/></label></div>', async () => {

--- a/src/components/form-checkbox/index.scss
+++ b/src/components/form-checkbox/index.scss
@@ -1,1 +1,2 @@
+@import "form-checkbox";
 @import "form-checkbox-group";

--- a/src/mixins/form-radio-check.js
+++ b/src/mixins/form-radio-check.js
@@ -67,7 +67,7 @@ export default {
     },
     is_Switch () {
       // Custom switch styling (checkboxes only)
-      return (this.is_BtnMode || this.is_Radio) ? false : (this.is_Group ? this.bvGroup.switches : this.switch)
+      return (this.is_BtnMode || this.is_Radio || this.is_Plain) ? false : (this.is_Group ? this.bvGroup.switches : this.switch)
     },
     is_Inline () {
       return this.bvGroup.inline

--- a/src/mixins/form-radio-check.js
+++ b/src/mixins/form-radio-check.js
@@ -65,6 +65,10 @@ export default {
     is_Custom () {
       return this.is_BtnMode ? false : !this.bvGroup.plain
     },
+    is_Switch () {
+      // Custom switch styling (checkboxes only)
+      return (this.is_BtnMode || this.is_Radio) ? false : return this.is_Group ? this.bvGroup.switches : this.switch
+    },
     is_Inline () {
       return this.bvGroup.inline
     },
@@ -211,9 +215,10 @@ export default {
           class: {
             'form-check': this.is_Plain,
             'form-check-inline': this.is_Plain && this.is_Inline,
-            'custom-control': this.is_Custom,
+            'custom-control': this.is_Custom || this.is_Switch,
             'custom-control-inline': this.is_Custom && this.is_Inline,
-            'custom-checkbox': this.is_Custom && this.is_Check,
+            'custom-checkbox': this.is_Custom && this.is_Check && !this.is_Switch,
+            'custom-switch': this.is_Switch,
             'custom-radio': this.is_Custom && this.is_Radio,
             // Temprary until BS V4 supports sizing
             [`form-control-${this.get_Size}`]: Boolean(this.get_Size && !this.is_BtnMode)

--- a/src/mixins/form-radio-check.js
+++ b/src/mixins/form-radio-check.js
@@ -67,7 +67,7 @@ export default {
     },
     is_Switch () {
       // Custom switch styling (checkboxes only)
-      return (this.is_BtnMode || this.is_Radio) ? false : return this.is_Group ? this.bvGroup.switches : this.switch
+      return (this.is_BtnMode || this.is_Radio) ? false : (this.is_Group ? this.bvGroup.switches : this.switch)
     },
     is_Inline () {
       return this.bvGroup.inline
@@ -215,7 +215,7 @@ export default {
           class: {
             'form-check': this.is_Plain,
             'form-check-inline': this.is_Plain && this.is_Inline,
-            'custom-control': this.is_Custom || this.is_Switch,
+            'custom-control': this.is_Custom,
             'custom-control-inline': this.is_Custom && this.is_Inline,
             'custom-checkbox': this.is_Custom && this.is_Check && !this.is_Switch,
             'custom-switch': this.is_Switch,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Implements Boostrap V4.2 custom-switch style checkboxes.

Conditionally adds new CSS if not using v4.2 CSS

Adding support for switch styling involves only minor updates to the checkbox.

TODO:
- [x] Validate that new styles work with v4.1.3 CSS
- [x] Documentation (conditional on above working)
- [x] Tests

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

