### PR TITLE
feat(list-group): add striped support

### DIFF
--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -6,5 +6,6 @@
 @import "form-input/index";
 @import "form-radio/index";
 @import "input-group/index";
+@import "list-group/index";
 @import "spinner/index";
 @import "table/index";

--- a/src/components/list-group/README.md
+++ b/src/components/list-group/README.md
@@ -83,6 +83,25 @@ Or if you prefer `<buttons>` over links, set the `button` prop to `true`.
 (other than `active`) and the `tag` prop will have no effect.
 - When `href` or `to` are set, the `tag` prop has no effect.
 
+
+## Striped
+Alternate the background colors of list items with by adding the prop `striped`.
+
+```html
+<div>
+  <b-list-group striped>
+    <b-list-group-item>Cras justo odio</b-list-group-item>
+    <b-list-group-item>Dapibus ac facilisis in</b-list-group-item>
+    <b-list-group-item">Morbi leo risus</b-list-group-item>
+    <b-list-group-item>Porta ac consectetur ac</b-list-group-item>
+    <b-list-group-item>Vestibulum at eros</b-list-group-item>
+  </b-list-group>
+</div>
+
+<!-- list-group-striped.vue -->
+```
+
+
 ## Contextual variants
 Use contextual variants to style list items with a stateful background and color, via
 the `variant` prop.

--- a/src/components/list-group/README.md
+++ b/src/components/list-group/README.md
@@ -84,24 +84,6 @@ Or if you prefer `<buttons>` over links, set the `button` prop to `true`.
 - When `href` or `to` are set, the `tag` prop has no effect.
 
 
-## Striped
-Alternate the background colors of list items with by adding the prop `striped`.
-
-```html
-<div>
-  <b-list-group striped>
-    <b-list-group-item>Cras justo odio</b-list-group-item>
-    <b-list-group-item>Dapibus ac facilisis in</b-list-group-item>
-    <b-list-group-item">Morbi leo risus</b-list-group-item>
-    <b-list-group-item>Porta ac consectetur ac</b-list-group-item>
-    <b-list-group-item>Vestibulum at eros</b-list-group-item>
-  </b-list-group>
-</div>
-
-<!-- list-group-striped.vue -->
-```
-
-
 ## Contextual variants
 Use contextual variants to style list items with a stateful background and color, via
 the `variant` prop.
@@ -147,6 +129,25 @@ Using color to add meaning only provides a visual indication, which will not be 
 of assistive technologies – such as screen readers. Ensure that information denoted by the color
 is either obvious from the content itself (e.g. the visible text), or is included through alternative
 means, such as additional text hidden using the `.sr-only` class.
+
+
+## Striped
+Alternate the background colors of list items with by adding the prop `striped`.
+
+```html
+<b-list-group striped>
+  <b-list-group-item>Cras justo odio</b-list-group-item>
+  <b-list-group-item>Dapibus ac facilisis in</b-list-group-item>
+  <b-list-group-item>Morbi leo risus</b-list-group-item>
+  <b-list-group-item>Porta ac consectetur ac</b-list-group-item>
+  <b-list-group-item>Vestibulum at eros</b-list-group-item>
+</b-list-group>
+
+<!-- list-group-striped.vue -->
+```
+
+**Note:** currently, the `striped` option will not work well with list group items which
+are `active`, or have a `variant` set.
 
 
 ## With badges

--- a/src/components/list-group/_list-group.scss
+++ b/src/components/list-group/_list-group.scss
@@ -1,0 +1,18 @@
+// Interim CSS until Bootstrap V4.2 released
+
+@if variable-exists(list-group-striped-bg) == false {
+  // Conditionally include CSS
+
+  $list-group-striped-order: odd !default;
+	$list-group-striped-bg:    darken($list-group-bg, 5%) !default;
+  
+  // Zebra-striping
+	//
+	// Default zebra-stripe styles (alternating gray and transparent backgrounds)
+	
+	.list-group-striped {
+	  .list-group-item:nth-of-type(#{$list-group-striped-order}) {
+	    background-color: $list-group-striped-bg;
+	  }
+	}
+}

--- a/src/components/list-group/fixtures/list-group.html
+++ b/src/components/list-group/fixtures/list-group.html
@@ -1,11 +1,39 @@
 <div id="app">
-    <b-list-group>
-        <b-list-group-item active>Awesome list</b-list-group-item>
-        <b-list-group-item href="#">
-            Action links are easy
-        </b-list-group-item>
-        <b-list-group-item>
-            This is a text only item
-        </b-list-group-item>
+  <b-list-group>
+    <b-list-group-item active>Awesome list</b-list-group-item>
+    <b-list-group-item href="#">
+      Action links are easy
+    </b-list-group-item>
+    <b-list-group-item>
+      This is a text only item
+    </b-list-group-item>
+  </b-list-group>
+
+  <br><br>
+
+  <b-list-group striped>
+    <b-list-group-item active>Awesome list</b-list-group-item>
+    <b-list-group-item href="#">
+      Action links are easy
+    </b-list-group-item>
+    <b-list-group-item variant="info">
+      This is a text only item with variant info
+    </b-list-group-item>
+  </b-list-group>
+
+  <br><br>
+
+  <b-card no-body header="<b>Card with flush list group</b>">
+    <b-list-group flush>
+      <b-list-group-item href="#">Cras justo odio</b-list-group-item>
+      <b-list-group-item href="#">Dapibus ac facilisis in</b-list-group-item>
+      <b-list-group-item href="#">Vestibulum at eros</b-list-group-item>
     </b-list-group>
+    <b-card-body>
+      Quis magna Lorem anim amet ipsum do mollit sit cillum voluptate ex
+      nulla tempor. Laborum consequat non elit enim exercitation cillum aliqua
+      consequat id aliqua. Esse ex consectetur mollit voluptate est in duis laboris
+      ad sit ipsum anim Lorem.
+    </b-card-body>
+  </b-card>
 </div>

--- a/src/components/list-group/index.scss
+++ b/src/components/list-group/index.scss
@@ -1,0 +1,1 @@
+@import "list-group";

--- a/src/components/list-group/list-group.js
+++ b/src/components/list-group/list-group.js
@@ -8,6 +8,10 @@ export const props = {
   flush: {
     type: Boolean,
     default: false
+  },
+  striped: {
+    type: Boolean,
+    default: false
   }
 }
 
@@ -18,9 +22,11 @@ export default {
   render (h, { props, data, children }) {
     const componentData = {
       staticClass: 'list-group',
-      class: { 'list-group-flush': props.flush }
+      class: {
+        'list-group-flush': props.flush,
+        'list-group-striped': props.striped
+      }
     }
-
     return h(props.tag, mergeData(data, componentData), children)
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Conditionally includes a Boostrap V4.2 SCSS section for supporting zebra striped list-groups (similar to striped tables).

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

