### PR TITLE
chore(docs): add overflow-x:auto to wider examples for small screen support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Anyone can file an expense. If the expense makes sense for the development of th
 ### Contributors
 
 Thank you to all the people who have already contributed to bootstrap-vue!
-<a href="graphs/contributors"><img src="https://opencollective.com/bootstrap-vue/contributors.svg?width=890" /></a>
+<a href="https://github.com/bootstrap-vue/bootstrap-vue/graphs/contributors"><img src="https://opencollective.com/bootstrap-vue/contributors.svg?width=890"></a>
 
 
 ### Backers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Anyone can file an expense. If the expense makes sense for the development of th
 ### Contributors
 
 Thank you to all the people who have already contributed to bootstrap-vue!
-<a href="https://github.com/bootstrap-vue/bootstrap-vue/graphs/contributors"><img src="https://opencollective.com/bootstrap-vue/contributors.svg?width=890"></a>
+<a href="https://github.com/bootstrap-vue/bootstrap-vue/graphs/contributors"><img src="https://opencollective.com/bootstrap-vue/contributors.svg?width=890" class="img-fluid"></a>
 
 
 ### Backers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,9 @@ Thank you to all the people who have already contributed to bootstrap-vue!
 
 Thank you to all our backers! [[Become a backer](https://opencollective.com/bootstrap-vue#backer)]
 
+<div class="w-100">
 <a href="https://opencollective.com/bootstrap-vue#backers" target="_blank"><img src="https://opencollective.com/bootstrap-vue/backers.svg?width=890" class="img-fluid"></a>
+</div>
 
 
 ### Sponsors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,7 @@ Thank you to all the people who have already contributed to bootstrap-vue!
 
 Thank you to all our backers! [[Become a backer](https://opencollective.com/bootstrap-vue#backer)]
 
-<div class="w-100">
 <a href="https://opencollective.com/bootstrap-vue#backers" target="_blank"><img src="https://opencollective.com/bootstrap-vue/backers.svg?width=890" class="img-fluid"></a>
-</div>
 
 
 ### Sponsors

--- a/docs/nuxt.config.js
+++ b/docs/nuxt.config.js
@@ -46,7 +46,6 @@ module.exports = {
             options: {
               renderer,
               headerIds: true,
-              sanitize: false,
               gfm: true
             }
           }

--- a/docs/nuxt.config.js
+++ b/docs/nuxt.config.js
@@ -46,6 +46,7 @@ module.exports = {
             options: {
               renderer,
               headerIds: true,
+              sanitize: false,
               gfm: true
             }
           }

--- a/src/components/pagination-nav/README.md
+++ b/src/components/pagination-nav/README.md
@@ -9,7 +9,7 @@ component instead.
 
 ```html
 <template>
-<div>
+<div style="overflow-x:auto;">
   <h6>Default</h6>
   <b-pagination-nav base-url="#" :number-of-pages="10" v-model="currentPage" />
 
@@ -17,7 +17,7 @@ component instead.
   <b-pagination-nav :link-gen="linkGen" :number-of-pages="10" v-model="currentPage" />
   <br>
 
-  <div class="mt-4">currentPage: {{currentPage}}</div>
+  <p class="mt-4">currentPage: {{currentPage}}</p>
 </div>
 </template>
 
@@ -96,7 +96,7 @@ which is a page number (1-N). The `page-gen` function should return a string.
 
 ```html
 <template>
-  <div>
+  <div style="overflow-x:auto;">
     <b-pagination-nav :link-gen="linkGen"
                       :page-gen="pageGen"
                       :number-of-pages="links.length"
@@ -142,7 +142,7 @@ prop to eiter `'am` for smaller buttons or `'lg'` for larger buttons.
 
 ```html
 <template>
-<div>
+<div style="overflow-x:auto:">
   <h6>Small</h6>
   <b-pagination-nav size="sm" base-url="#" :number-of-pages="5" v-model="currentPage" />
 

--- a/src/components/pagination-nav/README.md
+++ b/src/components/pagination-nav/README.md
@@ -142,7 +142,7 @@ prop to eiter `'am` for smaller buttons or `'lg'` for larger buttons.
 
 ```html
 <template>
-<div style="overflow-x:auto:">
+<div style="overflow-x:auto;">
   <h6>Small</h6>
   <b-pagination-nav size="sm" base-url="#" :number-of-pages="5" v-model="currentPage" />
 

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -8,7 +8,7 @@ component instead.
 
 ```html
 <template>
-  <div>
+  <div style="overflow-x:auto;">
     <h6>Default</h6>
     <b-pagination size="md" :total-rows="100" v-model="currentPage" :per-page="10">
     </b-pagination>


### PR DESCRIPTION
Add `overflow-x:auto:` to some of the documentation examples, so that they can be scrolled on small screens and don't cause the page to resize.

Note for things like drop downs and other components that dynamically position, this technique does not work due to positioning issues with overflow scroll.