### PR TITLE
fix(b-img-lazy): better initial inView check + new show prop (fixes #1755)

### DIFF
--- a/src/components/image/fixtures/image.html
+++ b/src/components/image/fixtures/image.html
@@ -22,4 +22,6 @@
   <b-img ref="right" right src="https://picsum.photos/200/200/?image=58"></b-img>
   <br>
   <b-img-lazy ref="lazy" blank blank-color="#f00" width="200" height="200" src="https://picsum.photos/200/200/?image=58"></b-img-lazy>
+  <br>
+  <b-img-lazy ref="lazy-show" show blank blank-color="#f00" width="200" height="200" src="https://picsum.photos/200/200/?image=58"></b-img-lazy>
 </div>

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -135,15 +135,18 @@ export default {
     }
   },
   activated () {
+    /* istanbul ignore if */
     if (!this.isShown) {
       this.setListeners(true)
       this.$nextTick(this.checkView)
     }
   },
   deactivated () {
+    /* istanbul ignore next */
     this.setListeners(false)
   },
   beforeDestroy () {
+    /* istanbul ignore next */
     this.setListeners(false)
   },
   methods: {

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -97,7 +97,7 @@ export default {
       return (!this.blankSrc || this.isShown) ? this.src : this.blankSrc
     },
     computedBlank () {
-      return !((this.isShown || this.blankSrc))
+      return !(this.isShown || this.blankSrc)
     },
     computedWidth () {
       return this.isShown ? this.width : (this.blankWidth || this.width)
@@ -111,7 +111,7 @@ export default {
       if (newVal !== oldVal) {
         this.isShown = newVal
         if (!newVal) {
-          // make sure listeners are re-enabled
+          // Make sure listeners are re-enabled if img is force set to blank
           this.setListeners(true)
         }
       }
@@ -123,9 +123,11 @@ export default {
       }
     }
   },
-  mounted () {
+  created () {
     this.isShown = this.show
-    if (!this.show) {
+  },
+  mounted () {
+    if (!this.isShown) {
       this.setListeners(true)
       this.$nextTick(this.checkView)
     }
@@ -139,6 +141,9 @@ export default {
   deactivated () {
     this.setListeners(false)
   },
+  beforeDestroy() {
+    this.setListeners(false)
+  },
   methods: {
     setListeners (on) {
       clearTimeout(this.scrollTimer)
@@ -148,10 +153,12 @@ export default {
         eventOn(root, 'scroll', this.onScroll)
         eventOn(root, 'resize', this.onScroll)
         eventOn(root, 'orientationchange', this.onScroll)
+        eventOn(document, 'transitionend', this.onScroll)
       } else {
         eventOff(root, 'scroll', this.onScroll)
         eventOff(root, 'resize', this.onScroll)
         eventOff(root, 'orientationchange', this.onScroll)
+        eventOff(document, 'transitionend', this.onScroll)
       }
     },
     checkView () {
@@ -206,8 +213,5 @@ export default {
         }
       }
     )
-  },
-  beforeDdestroy () {
-    this.setListeners(false)
   }
 }

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -150,11 +150,13 @@ export default {
       this.scrollTimeout = null
       const root = window
       if (on) {
+        eventOn(this.$el, 'load', this.checkView)
         eventOn(root, 'scroll', this.onScroll)
         eventOn(root, 'resize', this.onScroll)
         eventOn(root, 'orientationchange', this.onScroll)
         eventOn(document, 'transitionend', this.onScroll)
       } else {
+        eventOff(this.$el, 'load', this.checkView)
         eventOff(root, 'scroll', this.onScroll)
         eventOff(root, 'resize', this.onScroll)
         eventOff(root, 'orientationchange', this.onScroll)
@@ -163,8 +165,8 @@ export default {
     },
     checkView () /* istanbul ignore next: can't test getBoundingClientRect in JSDOM */ {
       // check bounding box + offset to see if we should show
-      if (!isVisible(this.$el)) {
-        // Element is hidden, so skip for now
+      if (this.isShown) {
+        this.setListeners(false)
         return
       }
       const offset = parseInt(this.offset, 10) || 0

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -141,7 +141,7 @@ export default {
   deactivated () {
     this.setListeners(false)
   },
-  beforeDestroy() {
+  beforeDestroy () {
     this.setListeners(false)
   },
   methods: {

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -161,7 +161,7 @@ export default {
         eventOff(document, 'transitionend', this.onScroll)
       }
     },
-    checkView () {
+    checkView () /* istanbul ignore next: can't test getBoundingClientRect in JSDOM */ {
       // check bounding box + offset to see if we should show
       if (!isVisible(this.$el)) {
         // Element is hidden, so skip for now
@@ -175,7 +175,9 @@ export default {
         b: docElement.clientHeight + offset,
         r: docElement.clientWidth + offset
       }
+      /* istanbul ignore next */
       const box = getBCR(this.$el)
+      /* istanbul ignore if */
       if (box.right >= view.l && box.bottom >= view.t && box.left <= view.r && box.top <= view.b) {
         // image is in view (or about to be in view)
         this.isShown = true

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -1,5 +1,5 @@
 import BImg from './img'
-import { isVisible, getBCR, eventOn, eventOff } from '../../utils/dom'
+import { getBCR, eventOn, eventOff } from '../../utils/dom'
 const THROTTLE = 100
 
 // @vue/component

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -127,7 +127,9 @@ export default {
     this.isShown = this.show
   },
   mounted () {
-    if (!this.isShown) {
+    if (this.isShown) {
+      this.setListeners(false)
+    } else {
       this.setListeners(true)
       this.$nextTick(this.checkView)
     }

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -41,6 +41,10 @@ export default {
       type: [Number, String],
       default: null
     },
+    show: {
+      type: Boolean,
+      default: false
+    },
     fluid: {
       type: Boolean,
       default: false
@@ -102,13 +106,35 @@ export default {
       return this.isShown ? this.height : (this.blankHeight || this.height)
     }
   },
+  watch: {
+    show (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.isShown = newVal
+        if (!newVal) {
+          // make sure listeners are re-enabled
+          this.setListeners(true)
+        }
+      }
+    },
+    isShown (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        // Update synched show prop
+        this.$emit('update:show', newVal)
+      }
+    }
+  },
   mounted () {
-    this.setListeners(true)
-    this.checkView()
+    this.isShown = this.show
+    if (!this.show) {
+      this.setListeners(true)
+      this.$nextTick(this.checkView)
+    }
   },
   activated () {
-    this.setListeners(true)
-    this.checkView()
+    if (!this.isShown) {
+      this.setListeners(true)
+      this.$nextTick(this.checkView)
+    }
   },
   deactivated () {
     this.setListeners(false)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

- Wraps initial inView check in `$nextTick` to ensure DOM rendering is complete.
- Listens to bubbled `transtionend` events to see of img is in viewport.
- Listens for image load events (placeholder).
- Adds new syncable prop `show` to force image to show.

Fixes #1755

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

