### PR TITLE
feat(link): Add support for nuxt-link

### DIFF
--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -148,3 +148,19 @@ a [`<nuxt-link>`](https://nuxtjs.org/api/components-nuxt-link) sub component ins
 To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the
 viewport, Nuxt.js will automatically prefetch the code splitted page. Setting `no-prefetch` will disabled
 this feature for the specific link.
+
+**Note:** If you have prefetching disabled in your `nuxt.config.js` configuration (`router: { prefetchLinks: false}`), or are using a version of Nuxt.JS `< 2.4.0`, then this prop will have no effect.
+
+Prefetching support requires [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
+to be supported (see [CanIUse](https://caniuse.com/#feat=intersectionobserver)). For browsers that do not support
+IntersectionObserver, you can use the following conditional polyfill in `nuxt.config.js`:
+
+```js
+export default {
+  head: {
+    script: [
+      { src: 'https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver', body: true }
+    ]
+  }
+}
+```

--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -133,3 +133,18 @@ Check out more examples explaining active link class [live](https://jsfiddle.net
 Configure the active CSS class applied when the link is active with exact match. Note the
 default value can also be configured globally via the `linkExactActiveClass` router constructor option.
 
+
+## Nuxt.js specific `nuxt-link` props
+When Bootstrap-Vue detects that your app is running under [Nuxt](https://nuxtjs.org), it will render
+a [`<nuxt-link>`](https://nuxtjs.org/api/components-nuxt-link) sub component instead of a `<router-link>`.
+`<nuxt-link>` supports all of the above router-link props, plus the following additional Nuxt specific props.
+
+### `no-prefetch`
+
+- type: `boolean`
+- default: `false`
+- availablity: Nuxt 2.4.0+
+
+To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the
+viewport, Nuxt.js will automatically prefetch the code splitted page. Setting `no-prefetch` will disabled
+this feature for the specific link.

--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -134,10 +134,10 @@ Configure the active CSS class applied when the link is active with exact match.
 default value can also be configured globally via the `linkExactActiveClass` router constructor option.
 
 
-## Nuxt.js specific `nuxt-link` props
-When Bootstrap-Vue detects that your app is running under [Nuxt](https://nuxtjs.org), it will render
+## Nuxt specific router link props
+When Bootstrap-Vue detects that your app is running under [Nuxt.js](https://nuxtjs.org), it will render
 a [`<nuxt-link>`](https://nuxtjs.org/api/components-nuxt-link) sub component instead of a `<router-link>`.
-`<nuxt-link>` supports all of the above router-link props, plus the following additional Nuxt specific props.
+`<nuxt-link>` supports all of the above router link props, plus the following additional Nuxt specific props.
 
 ### `no-prefetch`
 

--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -100,7 +100,7 @@ of keyboard and/or screen-reader users, and is also not very SEO friendly.
 ### `active-class`
 
 - type: `string`
-- default: `'router-link-active'`
+- default: `'router-link-active'` (`'nuxt-link-active'` when using Nuxt.js)
 
 Configure the active CSS class applied when the link is active. Note the default value can also
 be configured globally via the `linkActiveClass` router constructor option.
@@ -127,7 +127,7 @@ Check out more examples explaining active link class [live](https://jsfiddle.net
 ### `exact-active-class`
 
 - type: `string`
-- default: `'router-link-exact-active'`
+- default: `'router-link-exact-active'` (`'nuxt-link-exact-active'` when using Nuxt.js)
 - availablity: Vue-Router 2.5.0+
 
 Configure the active CSS class applied when the link is active with exact match. Note the

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -23,8 +23,8 @@ Router links support various additional props.  Refer to the [Router support](/d
 reference section for details.
 
 If your app is running under [Nuxt](https://nuxtjs.org), the [`<nuxt-link>`](https://nuxtjs.org/api/components-nuxt-link)
-component will be used instead of `<router-link>`.  The `<nuxt-link>` component supports all the
-same features as `<router-link>` (as it is a wrapper component for `<router-link>`).
+component will be used instead of `<router-link>`. The `<nuxt-link>` component supports all the
+same features as `<router-link>` (as it is a wrapper component for `<router-link>`) and more.
 
 
 ## Links with href="#"
@@ -32,7 +32,7 @@ same features as `<router-link>` (as it is a wrapper component for `<router-link
 Typically `<a href="#">` will cause the document to scroll to the top of page when clicked.
 `<b-link>` addresses this by preventing the default action (scroll to top) when `href` is set to `#`.
 
-If you need scroll to top behaviour, use a standard `<a>` tag.
+If you need scroll to top behaviour, use a standard `<a href="#">...</a>` tag.
 
 
 ## Link disabled state

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -32,6 +32,8 @@ same features as `<router-link>` (as it is a wrapper component for `<router-link
 Typically `<a href="#">` will cause the document to scroll to the top of page when clicked.
 `<b-link>` addresses this by preventing the default action (scroll to top) when `href` is set to `#`.
 
+If you need scroll to top behaviour, use a standard `<a>` tag.
+
 
 ## Link disabled state
 
@@ -59,7 +61,7 @@ a.disabled {
 }
 ```
 
-Note that not all browsers support `pointer-events: none;`.
+Not all browsers support `pointer-events: none;`.
 
 
 <!-- Component reference added automatically from component package.json -->

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -22,10 +22,16 @@ To generate a `<router-link>` instead, specify the route location via the `to` p
 Router links support various additional props.  Refer to the [Router support](/docs/reference/router-links)
 reference section for details.
 
+If your app is running under [Nuxt](https://nuxtjs.org), the [`<nuxt-link>`](https://nuxtjs.org/api/components-nuxt-link)
+component will be used instead of `<router-link>`.  The `<nuxt-link>` component supports all the
+same features as `<router-link>` (as it is a wrapper component for `<router-link>`).
+
+
 ## Links with href="#"
 
 Typically `<a href="#">` will cause the document to scroll to the top of page when clicked.
 `<b-link>` addresses this by preventing the default action (scroll to top) when `href` is set to `#`.
+
 
 ## Link disabled state
 
@@ -40,8 +46,8 @@ Disable link functionality by setting the `disabled` prop to true.
 ```
 
 Disabling a link will set the Bootstrap V4 `.disabled` class on the link
-as well as handles stoping event propegation, preventing the default action
-from occuring, and removing the link from the document tab sequence.
+as well as handles stoping event propagation, preventing the default action
+from occuring, and removing the link from the document tab sequence (`tabindex="-1"`).
 
 **Note:** Boostrap V4 CSS currently does not style disabled links differently than
 non-disabled links. You can use the following custom CSS to style disabled links
@@ -52,6 +58,8 @@ a.disabled {
   pointer-events: none;
 }
 ```
+
+Note that not all browsers support `pointer-events: none;`.
 
 
 <!-- Component reference added automatically from component package.json -->

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -115,7 +115,7 @@ export const computed = {
 }
 
 function computeTag (props, parent) {
-  return Boolean(parent.$router) && props.to && !props.disabled ? (Boolean(parent.$nuxt) ? 'nuxt-link' : 'router-link') : 'a'
+  return (parent.$router && props.to && !props.disabled) ? (parent.$nuxt ? 'nuxt-link' : 'router-link') : 'a'
 }
 
 function computeHref ({ disabled, href, to }, tag) {

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -115,7 +115,7 @@ export const computed = {
 }
 
 function computeTag (props, parent) {
-  return Boolean(parent.$router) && props.to && !props.disabled ? 'router-link' : 'a'
+  return Boolean(parent.$router) && props.to && !props.disabled ? (Boolean(parent.$nuxt) ? 'nuxt-link' : 'router-link') : 'a'
 }
 
 function computeHref ({ disabled, href, to }, tag) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Add support in `<b-link>` for `<nuxt-link>` when running under Nuxt.JS.

If Nuxt is detected, then will render a `<nuxt-link>` instead of `<router-link>` (`<nuxt-link>` supports all of the features of `<router-link>`, plus more).

Adds new prop `no-prefetch` which disables Nuxt's link prefetching feature (available in Nuxt v2.4.0+).

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

