### PR TITLE
feat(table): "Debounce" providerFunction and refresh methods

### DIFF
--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -1412,7 +1412,7 @@ trigger the calling of the provider function. So be sure to bind to the `per-pag
 (unless you have the respective `no-provider-*` prop set to `true`).
 - The `no-local-sorting` prop has no effect when `items` is a provider function.
 
-### Event based refreshing of data
+### Force refreshing of table data
 You may also trigger the refresh of the provider function by emitting the
 event `refresh::table` on `$root` with the single argument being the `id` of your `b-table`.
 You must have a unique ID on your table for this to work.
@@ -1421,7 +1421,7 @@ You must have a unique ID on your table for this to work.
     this.$root.$emit('bv::refresh::table', 'my-table');
 ```
 
-Or by calling the refresh method on the table reference
+Or by calling the `refresh()` method on the table reference
 ```html
 <b-table ref="table" ... ></b-table>
 ```
@@ -1429,7 +1429,9 @@ Or by calling the refresh method on the table reference
     this.$refs.table.refresh();
 ```
 
-**Note:** If the table is in the `busy` state, refresh event/methods will silently be ignored.
+**Note:** If the table is in the `busy` state (i.e. a provider update is currently running), the
+refresh will wait until the current update is completed. If there is currently a refresh pending and a
+new refresh is requested, then only one refresh will occur.
 
 
 ### Detection of sorting change

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -194,7 +194,7 @@ describe('b-table provider functions', async () => {
     wrapper.vm.refresh()
     wrapper.vm.refresh()
     // Trigger a context change that would trigger an internal _providerUpdate
-    wrapper.setProps({sortBy: 'b'})
+    wrapper.setProps({ sortBy: 'b' })
 
     await Vue.nextTick()
     expect(wrapper.emitted('refreshed')).not.toBeDefined()

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -129,10 +129,38 @@ describe('b-table provider functions', async () => {
     await Vue.nextTick()
 
     // Expect busy to be updated to false
+    expect(wrapper.vm.localBusy).toBe(false)
     const last = wrapper.emitted('update:busy').length - 1
     expect(wrapper.emitted('update:busy')[last][0]).toBe(false)
 
     expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
+  })
+
+  it('provider refreshing works', async () => {
+    function provider (ctx) {
+      return testItems.slice()
+    }
+    const wrapper = mount(Table, {
+      propsData: {
+        fields: testFields,
+        items: provider,
+        showEmpty: true
+      }
+    })
+    expect(wrapper).toBeDefined()
+
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('update:busy')).toBeDefined()
+    expect(wrapper.emitted('refreshed')).not.toBeDefined()
+
+    wrapper.vm.refresh()
+
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('refreshed')).toBeDefined()
+    // Should emit only a single refreshed event
+    expect(wrapper.emitted('refreshed').length).toBe(1)
   })
 })

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -68,4 +68,39 @@ describe('b-table provider functions', async () => {
     expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
   })
+
+  it('promise items provider works', async () => {
+    let resolve
+    const promise = new Promise((res, rej) => { resolve = res })
+    function provider (ctx) {
+      return promise
+    }
+    const wrapper = mount(Table, {
+      propsData: {
+        fields: testFields,
+        items: provider,
+        showEmpty: true
+      }
+    })
+    expect(wrapper).toBeDefined()
+
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('update:busy')).toBeDefined()
+
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    // Should have single empty row
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
+
+    await Vue.nextTick()
+
+    expect(resolve).toBeDefined()
+    resolve(testItems.slice())
+
+    await Vue.nextTick()
+
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+  })
 })

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -152,8 +152,8 @@ describe('b-table provider functions', async () => {
 
     await Vue.nextTick()
 
-    expect(wrapper.emitted('update:busy')).toBeDefined()
-    expect(wrapper.emitted('refreshed')).not.toBeDefined()
+    expect(wrapper.emitted('refreshed')).toBeDefined()
+    expect(wrapper.emitted('refreshed').length).toBe(1)
 
     wrapper.vm.refresh()
 
@@ -161,6 +161,6 @@ describe('b-table provider functions', async () => {
 
     expect(wrapper.emitted('refreshed')).toBeDefined()
     // Should emit only a single refreshed event
-    expect(wrapper.emitted('refreshed').length).toBe(1)
+    expect(wrapper.emitted('refreshed').length).toBe(2)
   })
 })

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -129,7 +129,7 @@ describe('b-table provider functions', async () => {
     await Vue.nextTick()
 
     // Expect busy to be updated to false
-    const last = wrapper.emitted('update:busy').length
+    const last = wrapper.emitted('update:busy').length - 1
     expect(wrapper.emitted('update:busy')[last][0]).toBe(false)
 
     expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -145,8 +145,9 @@ describe('b-table provider functions', async () => {
     const wrapper = mount(Table, {
       propsData: {
         id: 'thetable',
-        fields: testFields,
-        items: provider
+        fields: testFields.map(f => ({key:f, sortable: true})),
+        items: provider,
+        noProviderSorting: true
       }
     })
     expect(wrapper).toBeDefined()

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -1,0 +1,71 @@
+import Vue from 'vue'
+import Table from './table'
+import { mount } from '@vue/test-utils'
+
+const testItems = [
+  { a: 1, b: 2, c: 3 },
+  { a: 5, b: 5, c: 6 },
+  { a: 7, b: 8, c: 9 },
+  { a: 10, b: 11, c: 12 },
+  { a: 13, b: 14, c: 15 }
+]
+
+const testFields = Object.keys(testItems[0]).sort()
+
+describe('b-table provider functions', async () => {
+  it('syncronous items provider works', async () => {
+    function provider = (ctx) {
+      return testItems.slice()
+    }
+    const wrapper = mount(Table, {
+      propsData: {
+        fields: testFields,
+        items: provider
+      }
+    })
+    expect(wrapper).toBeDefined()
+
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('update:busy')).toBeDefined()
+
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+  })
+
+  it('callback items provider works', async () => {
+    let callback
+    function provider (ctx, cb) {
+      callback = cb
+      return null
+    }
+    const wrapper = mount(Table, {
+      propsData: {
+        fields: testFields,
+        items: provider,
+        showEmpty: true
+      }
+    })
+    expect(wrapper).toBeDefined()
+
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('update:busy')).toBeDefined()
+
+    expect(wrapper.find('tbody').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    // Should have single empty row
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
+
+    await Vue.nextTick()
+
+    expect(callback).toBeDefined()
+    callback(testItems.slice())
+
+    await Vue.nextTick()
+
+    expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)
+    expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+  })
+})

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -14,7 +14,7 @@ const testFields = Object.keys(testItems[0]).sort()
 
 describe('b-table provider functions', async () => {
   it('syncronous items provider works', async () => {
-    function provider = (ctx) {
+    function provider (ctx) {
       return testItems.slice()
     }
     const wrapper = mount(Table, {

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -176,7 +176,7 @@ describe('b-table provider functions', async () => {
     }
     const wrapper = mount(Table, {
       propsData: {
-        fields: testFields.map(f => ({ key:f, sortable: true })),,
+        fields: testFields.map(f => ({ key:f, sortable: true })),
         items: provider,
         sortBy: null
       }

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -177,7 +177,8 @@ describe('b-table provider functions', async () => {
     const wrapper = mount(Table, {
       propsData: {
         fields: testFields,
-        items: provider
+        items: provider,
+        sortBy: null
       }
     })
     expect(wrapper).toBeDefined()
@@ -192,6 +193,9 @@ describe('b-table provider functions', async () => {
     // No refreshing if localBusy is true
     wrapper.vm.refresh()
     wrapper.vm.refresh()
+    // Trigger a context change that would trigger an internal _providerUpdate
+    wrapper.setProps({sortBy: 'b'})
+
     await Vue.nextTick()
     expect(wrapper.emitted('refreshed')).not.toBeDefined()
 
@@ -199,10 +203,13 @@ describe('b-table provider functions', async () => {
     callback(testItems.slice())
     await Vue.nextTick()
 
-    // refresh should have happened only once, even though called twice while busy
+    // refreshed event should happen only once, even though thriggered 3 times while busy
     expect(wrapper.emitted('refreshed')).toBeDefined()
     expect(wrapper.emitted('refreshed').length).toBe(1)
 
+    // Just to be sure, we wait again and re-test
+    await Vue.nextTick()
+    expect(wrapper.emitted('refreshed').length).toBe(1)
     await Vue.nextTick()
     expect(wrapper.emitted('refreshed').length).toBe(1)
   })

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -28,6 +28,7 @@ describe('b-table provider functions', async () => {
     await Vue.nextTick()
 
     expect(wrapper.emitted('update:busy')).toBeDefined()
+    expect(wrapper.emitted('input')).toBeDefined()
 
     expect(wrapper.find('tbody').exists()).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').exists()).toBe(true)

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -166,5 +166,13 @@ describe('b-table provider functions', async () => {
     wrapper.vm.$root.$emit('bv::refresh::table', 'thetable')
     await Vue.nextTick()
     expect(wrapper.emitted('refreshed').length).toBe(3)
+
+    // No refreshing if localBusy is true
+    wrapper.vm.refresh()
+    wrapper.vm.refresh()
+    await Vue.nextTick()
+    expect(wrapper.emitted('refreshed').length).toBe(4)
+    await Vue.nextTick()
+    expect(wrapper.emitted('refreshed').length).toBe(4)
   })
 })

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -144,24 +144,27 @@ describe('b-table provider functions', async () => {
     }
     const wrapper = mount(Table, {
       propsData: {
+        id: 'thetable',
         fields: testFields,
-        items: provider,
-        showEmpty: true
+        items: provider
       }
     })
     expect(wrapper).toBeDefined()
 
     await Vue.nextTick()
 
+    // Always initially emits a refresh when provider used
     expect(wrapper.emitted('refreshed')).toBeDefined()
     expect(wrapper.emitted('refreshed').length).toBe(1)
 
+    // Instance refresh method
     wrapper.vm.refresh()
-
     await Vue.nextTick()
-
-    expect(wrapper.emitted('refreshed')).toBeDefined()
-    // Should emit only a single refreshed event
     expect(wrapper.emitted('refreshed').length).toBe(2)
+
+    // Root event refreshing
+    wrapper.vm.$root.$emit('bv::refresh::table', 'thetable')
+    await Vue.nextTick()
+    expect(wrapper.emitted('refreshed').length).toBe(3)
   })
 })

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -70,8 +70,8 @@ describe('b-table provider functions', async () => {
   })
 
   it('promise items provider works', async () => {
-    let resolve
-    const promise = new Promise((res, rej) => { resolve = res })
+    let doResolve
+    const promise = new Promise((resolve, reject) => { doResolve = resolve })
     function provider (ctx) {
       return promise
     }
@@ -95,8 +95,8 @@ describe('b-table provider functions', async () => {
 
     await Vue.nextTick()
 
-    expect(resolve).toBeDefined()
-    resolve(testItems.slice())
+    expect(doResolve).toBeDefined()
+    doResolve(testItems.slice())
 
     await Vue.nextTick()
 

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -176,9 +176,10 @@ describe('b-table provider functions', async () => {
     }
     const wrapper = mount(Table, {
       propsData: {
-        fields: testFields.map(f => ({ key:f, sortable: true })),
+        fields: testFields.map(f => ({ key: f, sortable: true })),
         items: provider,
-        sortBy: null
+        sortBy: null,
+        sortDesc: true
       }
     })
     expect(wrapper).toBeDefined()

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -145,9 +145,8 @@ describe('b-table provider functions', async () => {
     const wrapper = mount(Table, {
       propsData: {
         id: 'thetable',
-        fields: testFields.map(f => ({key:f, sortable: true})),
-        items: provider,
-        noProviderSorting: true
+        fields: testFields,
+        items: provider
       }
     })
     expect(wrapper).toBeDefined()
@@ -177,7 +176,7 @@ describe('b-table provider functions', async () => {
     }
     const wrapper = mount(Table, {
       propsData: {
-        fields: testFields,
+        fields: testFields.map(f => ({ key:f, sortable: true })),,
         items: provider,
         sortBy: null
       }

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -731,10 +731,15 @@ export default {
     }
   },
   mounted () {
+    // Call the items provider if necessary
     if (this.hasProvider && (!this.localItems || this.localItems.length === 0)) {
       // Fetch on mount if localItems is empty
       this._providerUpdate()
     }
+
+    // Initially update the v-model of displayed items
+    this.$emit('input', this.computedItems)
+
     // Listen for global messages to tell us to force refresh the table
     this.listenOnRoot('bv::refresh::table', id => {
       if (id === this.id || id === this) {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1061,7 +1061,7 @@ export default {
       // If table is busy, wait until refereshed before calling again
       if (this.computedBusy) {
         // Schedule a new refresh once `refreshed` is emitted
-        this.refresh()
+        this.$nextTick(this.refresh)
         return
       }
 
@@ -1089,11 +1089,12 @@ export default {
             warn('b-table provider function didn\'t request calback and did not return a promise or data')
             this.localBusy = false
           }
-        } catch (e) {
+        } catch (e) /* istanbul ignore next */ {
           // Provider function borked on us, so we spew out a warning
           // and clear the busy state
-          warn(`b-table provider function error [${e.name}]: ${e.message}`)
+          warn(`b-table provider function error [${e.name}] ${e.message}`)
           this.localBusy = false
+          this.$off('refreshed', this.refresh)
         }
       })
     }

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -356,7 +356,7 @@ export default {
       localSortDesc: this.sortDesc || false,
       localBusy: false,
       // Our local copy of the items. Must be an array
-      localItems: isArray(this.items) ? this.items : [],
+      localItems: isArray(this.items) ? this.items.slice() : [],
       // Flag for displaying which empty slot to show, and for some event triggering.
       isFiltered: false,
       selectedRows: [],

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -731,8 +731,6 @@ export default {
     }
   },
   mounted () {
-    this.localSortBy = this.sortBy
-    this.localSortDesc = this.sortDesc
     if (this.hasProvider && (!this.localItems || this.localItems.length === 0)) {
       // Fetch on mount if localItems is empty
       this._providerUpdate()

--- a/src/components/table/table.spec.js
+++ b/src/components/table/table.spec.js
@@ -369,6 +369,8 @@ describe('table', async () => {
   it('table_paginated should contain custom formatted footers', async () => {
     const { app: { $refs } } = window
 
+    await nextTick()
+
     const tfoot = [...$refs.table_paginated.$el.children].find(
       el => el && el.tagName === 'TFOOT'
     )


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

If criteria causes the provider function to need a refresh, and a refresh is currently in progress, schedules a new update request once the currently running provider completes.

Also applies to the 'refresh()` method if the provider is running when called.

This is not really a "debounce", but if multiple provider refresh updates are triggered while a provider is currently running, only a single refresh will be requested once the current provider completes (when `refreshed` is emitted).

TODO:
- [x] documentation updates
- [x] additional test suites for items provider functions

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other, please describe: additional table test suite

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:


**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

