### PR TITLE
chore: add tests for card sub-components

### DIFF
--- a/src/components/card/card-body.spec.js
+++ b/src/components/card/card-body.spec.js
@@ -79,9 +79,7 @@ describe('card-body', async () => {
     const wrapper = mount(CardBody, {
       context: {
         props: {
-          bodyTextVariant: 'info',
-          bodyBgVariant: 'danger',
-          bodyBorderVariant: 'dark'
+          overlay: true
         }
       }
     })
@@ -94,7 +92,7 @@ describe('card-body', async () => {
     const wrapper = mount(CardBody, {
       context: {
         props: {
-          title: 'title',
+          title: 'title'
         }
       }
     })
@@ -105,18 +103,7 @@ describe('card-body', async () => {
     const wrapper = mount(CardBody, {
       context: {
         props: {
-          subTitle: 'sub title',
-        }
-      }
-    })
-    expect(wrapper.find('div.card-subtitle')).toBeDefined()
-  })
-
-  it('has card-sub-title when sub-title prop is set', async () => {
-    const wrapper = mount(CardBody, {
-      context: {
-        props: {
-          subTitle: 'sub title',
+          subTitle: 'sub title'
         }
       }
     })

--- a/src/components/card/card-body.spec.js
+++ b/src/components/card/card-body.spec.js
@@ -74,4 +74,52 @@ describe('card-body', async () => {
     expect(wrapper.classes()).toContain('border-dark')
     expect(wrapper.classes().length).toBe(4)
   })
+
+  it('has class "card-img-overlay" when overlay="true"', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: {
+          bodyTextVariant: 'info',
+          bodyBgVariant: 'danger',
+          bodyBorderVariant: 'dark'
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-body')
+    expect(wrapper.classes()).toContain('card-img-overlay')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has card-title when title prop is set', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: {
+          title: 'title',
+        }
+      }
+    })
+    expect(wrapper.find('div.card-title')).toBeDefined()
+  })
+
+  it('has card-sub-title when sub-title prop is set', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: {
+          subTitle: 'sub title',
+        }
+      }
+    })
+    expect(wrapper.find('div.card-subtitle')).toBeDefined()
+  })
+
+  it('has card-sub-title when sub-title prop is set', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: {
+          subTitle: 'sub title',
+        }
+      }
+    })
+    expect(wrapper.find('div.card-subtitle')).toBeDefined()
+  })
 })

--- a/src/components/card/card-body.spec.js
+++ b/src/components/card/card-body.spec.js
@@ -1,0 +1,77 @@
+import CardBody from './card-body'
+import { mount } from '@vue/test-utils'
+
+describe('card-body', async () => {
+  it('has root element "div"', async () => {
+    const wrapper = mount(CardBody)
+    expect(wrapper.is('div')).toBe(true)
+  })
+
+  it('has class card-body', async () => {
+    const wrapper = mount(CardBody)
+    expect(wrapper.classes()).toContain('card-body')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has custom root element when prop bodyTag is set', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: {
+          bodyTag: 'article'
+        }
+      }
+    })
+    expect(wrapper.is('article')).toBe(true)
+    expect(wrapper.classes()).toContain('card-body')
+  })
+
+  it('has class bg-info when prop bodyBgVariant=info', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: { bodyBgVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-body')
+    expect(wrapper.classes()).toContain('bg-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has class text-info when prop bodyTextVariant=info', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: { bodyTextVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-body')
+    expect(wrapper.classes()).toContain('text-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has class border-info when prop bodyBorderVariant=info', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: { bodyBorderVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-body')
+    expect(wrapper.classes()).toContain('border-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has all variant classes when all variant props set', async () => {
+    const wrapper = mount(CardBody, {
+      context: {
+        props: {
+          bodyTextVariant: 'info',
+          bodyBgVariant: 'danger',
+          bodyBorderVariant: 'dark'
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-body')
+    expect(wrapper.classes()).toContain('text-info')
+    expect(wrapper.classes()).toContain('bg-danger')
+    expect(wrapper.classes()).toContain('border-dark')
+    expect(wrapper.classes().length).toBe(4)
+  })
+})

--- a/src/components/card/card-footer.spec.js
+++ b/src/components/card/card-footer.spec.js
@@ -1,0 +1,77 @@
+import CardFooter from './card-footer'
+import { mount } from '@vue/test-utils'
+
+describe('card-footer', async () => {
+  it('has root element "div"', async () => {
+    const wrapper = mount(CardFooter)
+    expect(wrapper.is('div')).toBe(true)
+  })
+
+  it('has class card-header', async () => {
+    const wrapper = mount(CardFooter)
+    expect(wrapper.classes()).toContain('card-footer')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has custom root element when prop footerTag is set', async () => {
+    const wrapper = mount(CardFooter, {
+      context: {
+        props: {
+          footerTag: 'footer'
+        }
+      }
+    })
+    expect(wrapper.is('footer')).toBe(true)
+    expect(wrapper.classes()).toContain('card-footer')
+  })
+
+  it('has class bg-info when prop footerBgVariant=info', async () => {
+    const wrapper = mount(CardFooter, {
+      context: {
+        props: { footerBgVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-footer')
+    expect(wrapper.classes()).toContain('bg-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has class text-info when prop footerTextVariant=info', async () => {
+    const wrapper = mount(CardFooter, {
+      context: {
+        props: { footerTextVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-footer')
+    expect(wrapper.classes()).toContain('text-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has class border-info when prop footerBorderVariant=info', async () => {
+    const wrapper = mount(CardFooter, {
+      context: {
+        props: { footerBorderVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-footer')
+    expect(wrapper.classes()).toContain('border-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has all variant classes when all variant props set', async () => {
+    const wrapper = mount(CardFooter, {
+      context: {
+        props: {
+          footerTextVariant: 'info',
+          footerBgVariant: 'danger',
+          footerBorderVariant: 'dark'
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-footer')
+    expect(wrapper.classes()).toContain('text-info')
+    expect(wrapper.classes()).toContain('bg-danger')
+    expect(wrapper.classes()).toContain('border-dark')
+    expect(wrapper.classes().length).toBe(4)
+  })
+})

--- a/src/components/card/card-group.js
+++ b/src/components/card/card-group.js
@@ -21,14 +21,13 @@ export default {
   functional: true,
   props,
   render (h, { props, data, children }) {
-    let staticClass = 'card-group'
-    if (props.columns) {
-      staticClass = 'card-columns'
-    }
+    let baseClass = 'card-group'
     if (props.deck) {
-      staticClass = 'card-deck'
+      baseClass = 'card-deck'
+    } else if (props.columns) {
+      baseClass = 'card-columns'
     }
 
-    return h(props.tag, mergeData(data, { staticClass }), children)
+    return h(props.tag, mergeData(data, { class: baseClass }), children)
   }
 }

--- a/src/components/card/card-group.spec.js
+++ b/src/components/card/card-group.spec.js
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils'
 
 describe('card-group', async () => {
   it('has root element "div"', async () => {
-    const wrapper = mount(CardText)
+    const wrapper = mount(CardGroup)
     expect(wrapper.is('div')).toBe(true)
   })
 
@@ -46,7 +46,7 @@ describe('card-group', async () => {
   })
 
   it('accepts custom classes', async () => {
-    const wrapper = mount(CardText, {
+    const wrapper = mount(CardGroup, {
       context: {
         class: ['foobar']
       }

--- a/src/components/card/card-group.spec.js
+++ b/src/components/card/card-group.spec.js
@@ -22,7 +22,7 @@ describe('card-group', async () => {
       }
     })
     expect(wrapper.is('article')).toBe(true)
-    expect(wrapper.classes()).toContain('card-text')
+    expect(wrapper.classes()).toContain('card-group')
   })
 
   it('has class card-deck when prop deck=true', async () => {

--- a/src/components/card/card-group.spec.js
+++ b/src/components/card/card-group.spec.js
@@ -17,7 +17,7 @@ describe('card-group', async () => {
     const wrapper = mount(CardGroup, {
       context: {
         props: {
-          textTag: 'article'
+          tag: 'article'
         }
       }
     })

--- a/src/components/card/card-group.spec.js
+++ b/src/components/card/card-group.spec.js
@@ -1,0 +1,57 @@
+import CardGroup from './card-group'
+import { mount } from '@vue/test-utils'
+
+describe('card-group', async () => {
+  it('has root element "div"', async () => {
+    const wrapper = mount(CardText)
+    expect(wrapper.is('div')).toBe(true)
+  })
+
+  it('has class card-group', async () => {
+    const wrapper = mount(CardGroup)
+    expect(wrapper.classes()).toContain('card-group')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has custom root element when prop tag is set', async () => {
+    const wrapper = mount(CardGroup, {
+      context: {
+        props: {
+          textTag: 'article'
+        }
+      }
+    })
+    expect(wrapper.is('article')).toBe(true)
+    expect(wrapper.classes()).toContain('card-text')
+  })
+
+  it('has class card-deck when prop deck=true', async () => {
+    const wrapper = mount(CardGroup, {
+      context: {
+        props: { deck: true }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-deck')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class card-columns when prop columns=true', async () => {
+    const wrapper = mount(CardGroup, {
+      context: {
+        props: { columns: true }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-columns')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('accepts custom classes', async () => {
+    const wrapper = mount(CardText, {
+      context: {
+        class: ['foobar']
+      }
+    })
+    expect(wrapper.classes()).toContain('card-group')
+    expect(wrapper.classes()).toContain('foobar')
+  })
+})

--- a/src/components/card/card-header.spec.js
+++ b/src/components/card/card-header.spec.js
@@ -1,0 +1,77 @@
+import CardHeader from './card-header'
+import { mount } from '@vue/test-utils'
+
+describe('card-header', async () => {
+  it('has root element "div"', async () => {
+    const wrapper = mount(CardHeader)
+    expect(wrapper.is('div')).toBe(true)
+  })
+
+  it('has class card-header', async () => {
+    const wrapper = mount(CardHeader)
+    expect(wrapper.classes()).toContain('card-header')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has custom root element when prop headerTag is set', async () => {
+    const wrapper = mount(CardHeader, {
+      context: {
+        props: {
+          headerTag: 'header'
+        }
+      }
+    })
+    expect(wrapper.is('header')).toBe(true)
+    expect(wrapper.classes()).toContain('card-header')
+  })
+
+  it('has class bg-info when prop headerBgVariant=info', async () => {
+    const wrapper = mount(CardHeader, {
+      context: {
+        props: { headerBgVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-header')
+    expect(wrapper.classes()).toContain('bg-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has class text-info when prop headerTextVariant=info', async () => {
+    const wrapper = mount(CardHeader, {
+      context: {
+        props: { headerTextVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-header')
+    expect(wrapper.classes()).toContain('text-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has class border-info when prop headerBorderVariant=info', async () => {
+    const wrapper = mount(CardHeader, {
+      context: {
+        props: { headerBorderVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-header')
+    expect(wrapper.classes()).toContain('border-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has all variant classes when all variant props set', async () => {
+    const wrapper = mount(CardHeader, {
+      context: {
+        props: {
+          headerTextVariant: 'info',
+          headerBgVariant: 'danger',
+          headerBorderVariant: 'dark'
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-header')
+    expect(wrapper.classes()).toContain('text-info')
+    expect(wrapper.classes()).toContain('bg-danger')
+    expect(wrapper.classes()).toContain('border-dark')
+    expect(wrapper.classes().length).toBe(4)
+  })
+})

--- a/src/components/card/card-img.js
+++ b/src/components/card/card-img.js
@@ -56,23 +56,30 @@ export default {
   functional: true,
   props,
   render (h, { props, data }) {
-    let staticClass = 'card-img'
+    let baseClass = 'card-img'
     if (props.top) {
-      staticClass += '-top'
+      baseClass += '-top'
     } else if (props.right || props.end) {
-      staticClass += '-right'
+      baseClass += '-right'
     } else if (props.bottom) {
-      staticClass += '-bottom'
+      baseClass += '-bottom'
     } else if (props.left || props.start) {
-      staticClass += '-left'
+      baseClass += '-left'
     }
 
     return h(
       'img',
       mergeData(data, {
-        staticClass,
-        class: { 'img-fluid': props.fluid },
-        attrs: { src: props.src, alt: props.alt, height: props.height, width: props.width }
+        class: [
+          baseClass,
+          props.fluid ? 'img-fluid' : null
+        ],
+        attrs: {
+          src: props.src,
+          alt: props.alt,
+          height: props.height,
+          width: props.width
+        }
       })
     )
   }

--- a/src/components/card/card-img.spec.js
+++ b/src/components/card/card-img.spec.js
@@ -1,0 +1,184 @@
+import CardImg from './card-img'
+import { mount } from '@vue/test-utils'
+
+describe('card-image', async () => {
+  it('default has tag "img"', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.is('img')).toBe(true)
+  })
+
+  it('default has src attribute', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.attributes('src')).toBe('https://picsum.photos/600/300/?image=25')
+  })
+
+  it('default does not have attributes alt, width, or height', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.attributes('alt')).not.toBeDefined()
+    expect(wrapper.attributes('width')).not.toBeDefined()
+    expect(wrapper.attributes('height')).not.toBeDefined()
+  })
+
+  it('default has class "card-img"', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-top" when prop top=true', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          top: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-top')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-bottom" when prop bottom=true', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          bottom: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-top')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-top" when props top=true and bottom=true', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          top: true,
+          bottom: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-top')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-left" when prop left=true', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          bottom: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-left')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-right" when prop right=true', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          bottom: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-left')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "img-fluid" when fluid=true', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          fluid: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img')
+    expect(wrapper.classes()).toContain('img-fluid')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has class "img-fluid" when fluid=true', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          fluid: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img')
+    expect(wrapper.classes()).toContain('img-fluid')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has attribute alt when prop alt set', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          alt: 'image'
+        }
+      }
+    })
+    expect(wrapper.attributes('alt')).toBeDefined()
+    expect(wrapper.attributes('alt')).toBe('image')
+  })
+
+  it('has attribute width when prop width set', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          width: '600'
+        }
+      }
+    })
+    expect(wrapper.attributes('width')).toBeDefined()
+    expect(wrapper.attributes('width')).toBe('600')
+  })
+
+  it('has attribute heigth when prop height set', async () => {
+    const wrapper = mount(CardImg, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          height: '300'
+        }
+      }
+    })
+    expect(wrapper.attributes('height')).toBeDefined()
+    expect(wrapper.attributes('height')).toBe('300')
+  })
+})

--- a/src/components/card/card-img.spec.js
+++ b/src/components/card/card-img.spec.js
@@ -71,7 +71,7 @@ describe('card-image', async () => {
         }
       }
     })
-    expect(wrapper.classes()).toContain('card-img-top')
+    expect(wrapper.classes()).toContain('card-img-bottom')
     expect(wrapper.classes().length).toBe(1)
   })
 
@@ -94,7 +94,7 @@ describe('card-image', async () => {
       context: {
         props: {
           src: 'https://picsum.photos/600/300/?image=25',
-          bottom: true
+          left: true
         }
       }
     })
@@ -107,26 +107,12 @@ describe('card-image', async () => {
       context: {
         props: {
           src: 'https://picsum.photos/600/300/?image=25',
-          bottom: true
+          right: true
         }
       }
     })
-    expect(wrapper.classes()).toContain('card-img-left')
+    expect(wrapper.classes()).toContain('card-img-right')
     expect(wrapper.classes().length).toBe(1)
-  })
-
-  it('has class "img-fluid" when fluid=true', async () => {
-    const wrapper = mount(CardImg, {
-      context: {
-        props: {
-          src: 'https://picsum.photos/600/300/?image=25',
-          fluid: true
-        }
-      }
-    })
-    expect(wrapper.classes()).toContain('card-img')
-    expect(wrapper.classes()).toContain('img-fluid')
-    expect(wrapper.classes().length).toBe(2)
   })
 
   it('has class "img-fluid" when fluid=true', async () => {

--- a/src/components/card/card-sub-title.js
+++ b/src/components/card/card-sub-title.js
@@ -3,7 +3,7 @@ import { mergeData } from 'vue-functional-data-merge'
 export const props = {
   subTitle: {
     type: String,
-    default: null
+    default: ''
   },
   subTitleTag: {
     type: String,

--- a/src/components/card/card-sub-title.js
+++ b/src/components/card/card-sub-title.js
@@ -1,5 +1,4 @@
 import { mergeData } from 'vue-functional-data-merge'
-import stripScripts from '../../utils/strip-scripts'
 
 export const props = {
   subTitle: {
@@ -22,17 +21,15 @@ export default {
   functional: true,
   props,
   render (h, { props, data, children }) {
-    const domProps = children ? {} : { innerHTML: stripScripts(props.subTitle) }
     return h(
       props.subTitleTag,
       mergeData(data, {
         staticClass: 'card-subtitle',
         class: [
           props.subTitleTextVariant ? `text-${props.subTitleTextVariant}` : null
-        ],
-        domProps
+        ]
       }),
-      children
+      children || props.subTitle
     )
   }
 }

--- a/src/components/card/card-sub-title.spec.js
+++ b/src/components/card/card-sub-title.spec.js
@@ -4,7 +4,7 @@ import { mount } from '@vue/test-utils'
 describe('card-sub-title', async () => {
   it('default has tag "h6"', async () => {
     const wrapper = mount(CardSubTitle)
-    expect(wrapper.is('hs')).toBe(true)
+    expect(wrapper.is('h6')).toBe(true)
   })
 
   it('default has class "card-subtitle" and "text-muted"', async () => {
@@ -23,10 +23,10 @@ describe('card-sub-title', async () => {
     expect(wrapper.is('div')).toBe(true)
   })
 
-  it('accepts subTitleVariant value', async () => {
+  it('accepts subTitleTextVariant value', async () => {
     const wrapper = mount(CardSubTitle, {
       context: {
-        props: { subTitleVariant: 'info' }
+        props: { subTitleTextVariant: 'info' }
       }
     })
     expect(wrapper.classes()).toContain('card-subtitle')

--- a/src/components/card/card-sub-title.spec.js
+++ b/src/components/card/card-sub-title.spec.js
@@ -1,0 +1,45 @@
+import CardSubTitle from './card-sub-title'
+import { mount } from '@vue/test-utils'
+
+describe('card-sub-title', async () => {
+  it('default has tag "h6"', async () => {
+    const wrapper = mount(CardSubTitle)
+    expect(wrapper.is('hs')).toBe(true)
+  })
+
+  it('default has class "card-subtitle" and "text-muted"', async () => {
+    const wrapper = mount(CardSubTitle)
+    expect(wrapper.classes()).toContain('card-subtitle')
+    expect(wrapper.classes()).toContain('text-muted')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('renders custom tag', async () => {
+    const wrapper = mount(CardSubTitle, {
+      context: {
+        props: { subTitleTag: 'div' }
+      }
+    })
+    expect(wrapper.is('div')).toBe(true)
+  })
+
+  it('accepts subTitleVariant value', async () => {
+    const wrapper = mount(CardSubTitle, {
+      context: {
+        props: { subTitleVariant: 'info' }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-subtitle')
+    expect(wrapper.classes()).toContain('text-info')
+    expect(wrapper.classes().length).toBe(2)
+  })
+
+  it('has content from default slot', async () => {
+    const wrapper = mount(CardSubTitle, {
+      slots: {
+        default: 'foobar'
+      }
+    })
+    expect(wrapper.text()).toContain('foobar')
+  })
+})

--- a/src/components/card/card-title.js
+++ b/src/components/card/card-title.js
@@ -4,7 +4,7 @@ import stripScripts from '../../utils/strip-scripts'
 export const props = {
   title: {
     type: String,
-    default: null
+    default: ''
   },
   titleTag: {
     type: String,
@@ -18,14 +18,12 @@ export default {
   functional: true,
   props,
   render (h, { props, data, children }) {
-    const domProps = children ? {} : { innerHTML: stripScripts(props.title) }
     return h(
       props.titleTag,
       mergeData(data, {
-        staticClass: 'card-title',
-        domProps
+        staticClass: 'card-title'
       }),
-      children
+      children || props.title
     )
   }
 }

--- a/src/components/card/card-title.js
+++ b/src/components/card/card-title.js
@@ -1,5 +1,4 @@
 import { mergeData } from 'vue-functional-data-merge'
-import stripScripts from '../../utils/strip-scripts'
 
 export const props = {
   title: {

--- a/src/components/card/card-title.spec.js
+++ b/src/components/card/card-title.spec.js
@@ -3,18 +3,12 @@ import { mount } from '@vue/test-utils'
 
 describe('card-title', async () => {
   it('default has tag "h4"', async () => {
-    const wrapper = mount(CardTitle, {
-      context: {
-      }
-    })
+    const wrapper = mount(CardTitle)
     expect(wrapper.is('h4')).toBe(true)
   })
 
   it('default has class "card-title"', async () => {
-    const wrapper = mount(CardTitle, {
-      context: {
-      }
-    })
+    const wrapper = mount(CardTitle)
     expect(wrapper.classes()).toContain('card-title')
     expect(wrapper.classes().length).toBe(1)
   })
@@ -22,7 +16,7 @@ describe('card-title', async () => {
   it('renders custom tag', async () => {
     const wrapper = mount(CardTitle, {
       context: {
-        tag: 'div'
+        props: { tag: 'div' }
       }
     })
     expect(wrapper.is('div')).toBe(true)
@@ -31,7 +25,7 @@ describe('card-title', async () => {
   it('has content when title prop set', async () => {
     const wrapper = mount(CardTitle, {
       context: {
-        title: 'foobar'
+        props: { title: 'foobar' }
       }
     })
     expect(wrapper.classes()).toContain('card-title')
@@ -42,7 +36,7 @@ describe('card-title', async () => {
   it('has content from default slot', async () => {
     const wrapper = mount(CardTitle, {
       context: {
-        title: 'foo'
+        props: { tag: 'div' }
       },
       slots: {
         default: 'bar'

--- a/src/components/card/card-title.spec.js
+++ b/src/components/card/card-title.spec.js
@@ -22,20 +22,8 @@ describe('card-title', async () => {
     expect(wrapper.is('div')).toBe(true)
   })
 
-  it('has content when title prop set', async () => {
-    const wrapper = mount(CardTitle, {
-      context: {
-        props: { title: 'foobar' }
-      }
-    })
-    expect(wrapper.text()).toContain('foobar')
-  })
-
   it('has content from default slot', async () => {
     const wrapper = mount(CardTitle, {
-      context: {
-        props: { title: 'foo' }
-      },
       slots: {
         default: 'bar'
       }

--- a/src/components/card/card-title.spec.js
+++ b/src/components/card/card-title.spec.js
@@ -1,0 +1,55 @@
+import CardTitle from './card-title'
+import { mount } from '@vue/test-utils'
+
+describe('card-title', async () => {
+  it('default has tag "h4"', async () => {
+    const wrapper = mount(CardTitle, {
+      context: {
+      }
+    })
+    expect(wrapper.is('h4')).toBe(true)
+  })
+
+  it('default has class "card-title"', async () => {
+    const wrapper = mount(CardTitle, {
+      context: {
+      }
+    })
+    expect(wrapper.classes()).toContain('card-title')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('renders custom tag', async () => {
+    const wrapper = mount(CardTitle, {
+      context: {
+        tag: 'div'
+      }
+    })
+    expect(wrapper.is('div')).toBe(true)
+  })
+
+  it('has content when title prop set', async () => {
+    const wrapper = mount(CardTitle, {
+      context: {
+        title: 'foobar'
+      }
+    })
+    expect(wrapper.classes()).toContain('card-title')
+    expect(wrapper.classes().length).toBe(1)
+    expect(wrapper.text()).toContain('foobar')
+  })
+
+  it('has content from default slot', async () => {
+    const wrapper = mount(CardTitle, {
+      context: {
+        title: 'foo'
+      },
+      slots: {
+        default: 'bar'
+      }
+    })
+    expect(wrapper.classes()).toContain('card-title')
+    expect(wrapper.classes().length).toBe(1)
+    expect(wrapper.text()).toContain('bar')
+  })
+})

--- a/src/components/card/card-title.spec.js
+++ b/src/components/card/card-title.spec.js
@@ -16,7 +16,7 @@ describe('card-title', async () => {
   it('renders custom tag', async () => {
     const wrapper = mount(CardTitle, {
       context: {
-        props: { tag: 'div' }
+        props: { titleTag: 'div' }
       }
     })
     expect(wrapper.is('div')).toBe(true)
@@ -28,22 +28,18 @@ describe('card-title', async () => {
         props: { title: 'foobar' }
       }
     })
-    expect(wrapper.classes()).toContain('card-title')
-    expect(wrapper.classes().length).toBe(1)
     expect(wrapper.text()).toContain('foobar')
   })
 
   it('has content from default slot', async () => {
     const wrapper = mount(CardTitle, {
       context: {
-        props: { tag: 'div' }
+        props: { title: 'foo' }
       },
       slots: {
         default: 'bar'
       }
     })
-    expect(wrapper.classes()).toContain('card-title')
-    expect(wrapper.classes().length).toBe(1)
     expect(wrapper.text()).toContain('bar')
   })
 })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Add unit tests for card sub-components.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other, please describe: unit tests

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:


**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
