### PR TITLE
fix(link): use `active` class when manually placed into active state

### DIFF
--- a/src/components/link/fixtures/link.html
+++ b/src/components/link/fixtures/link.html
@@ -11,6 +11,9 @@
     <b-link ref="disabled"
             disabled>Link</b-link>
 
+    <b-link ref="active"
+            active>Link</b-link>
+
     <b-link ref="click"
             @click="handleClick">Link</b-link>
 

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -30,21 +30,30 @@ export function propsFactory () {
       type: Boolean,
       default: false
     },
-    activeClass: {
-      type: String
-      // default: undefined
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    // router-link specific props
+    to: {
+      type: [String, Object],
+      default: null
     },
     append: {
       type: Boolean,
       default: false
     },
-    disabled: {
+    replace: {
       type: Boolean,
       default: false
     },
     event: {
       type: [String, Array],
       default: 'click'
+    },
+    activeClass: {
+      type: String
+      // default: undefined
     },
     exact: {
       type: Boolean,
@@ -54,17 +63,9 @@ export function propsFactory () {
       type: String
       // default: undefined
     },
-    replace: {
-      type: Boolean,
-      default: false
-    },
     routerTag: {
       type: String,
       default: 'a'
-    },
-    to: {
-      type: [String, Object],
-      default: null
     },
     // nuxt-link specific prop(s)
     noPrefetch: {
@@ -204,10 +205,7 @@ export default {
     }
 
     const componentData = mergeData(data, {
-      class: [
-        props.active ? (props.exact ? props.exactActiveClass : props.activeClass) : null,
-        { disabled: props.disabled }
-      ],
+      class: { active: props.active, disabled: props.disabled },
       attrs: {
         rel,
         target: props.target,

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -29,6 +29,11 @@ describe('link', async () => {
     expect(app.$refs.rel.getAttribute('rel')).toBe('alternate')
   })
 
+  it("should add '.active' class when prop active=true", async () => {
+    const { app } = window
+    expect(app.$refs.active).toHaveClass('active')
+  })
+
   it('should not add aria-disabled when not disabled', async () => {
     const { app } = window
     expect(app.$refs.plain.hasAttribute('aria-disabled')).toBe(false)
@@ -39,7 +44,7 @@ describe('link', async () => {
     expect(app.$refs.disabled.getAttribute('aria-disabled')).toBe('true')
   })
 
-  it("should add '.disabled' class when disabled", async () => {
+  it("should add '.disabled' class when prop disabled=true", async () => {
     const { app } = window
     expect(app.$refs.disabled).toHaveClass('disabled')
   })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

active-class and exact-active-class props are applied automatically by router-link.

The active prop should only turn off/on the `active` class.


## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:


**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
