### PR TITLE
perf(events): use passive event listeners where possible

### DIFF
--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -85,7 +85,7 @@ export default {
   updated () {
     this.$root.$emit(EVENT_STATE, this.id, this.show)
   },
-  beforeDestroy () {
+  beforeDestroy () /* istanbul ignore next */ {
     if (this.isNav && typeof document !== 'undefined') {
       eventOff(window, 'resize', this.handleResize, EventOptions)
       eventOff(window, 'orientationchange', this.handleResize, EventOptions)

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -7,6 +7,9 @@ const EVENT_ACCORDION = 'bv::collapse::accordion'
 // Events we listen to on $root
 const EVENT_TOGGLE = 'bv::toggle::collapse'
 
+// Event Listener options
+const EventOptions = { passive: true, capture: false }
+
 // @vue/component
 export default {
   name: 'BCollapse',
@@ -73,8 +76,8 @@ export default {
   mounted () {
     if (this.isNav && typeof document !== 'undefined') {
       // Set up handlers
-      eventOn(window, 'resize', this.handleResize, false)
-      eventOn(window, 'orientationchange', this.handleResize, false)
+      eventOn(window, 'resize', this.handleResize, EventOptions)
+      eventOn(window, 'orientationchange', this.handleResize, EventOptions)
       this.handleResize()
     }
     this.emitState()
@@ -84,8 +87,8 @@ export default {
   },
   beforeDestroy () {
     if (this.isNav && typeof document !== 'undefined') {
-      eventOff(window, 'resize', this.handleResize, false)
-      eventOff(window, 'orientationchange', this.handleResize, false)
+      eventOff(window, 'resize', this.handleResize, EventOptions)
+      eventOff(window, 'orientationchange', this.handleResize, EventOptions)
     }
   },
   methods: {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -586,18 +586,19 @@ export default {
     // Turn on/off focusin listener
     setEnforceFocus (on) {
       if (on) {
-        eventOn(document, 'focusin', this.focusHandler, false)
+        eventOn(document, 'focusin', this.focusHandler)
       } else {
-        eventOff(document, 'focusin', this.focusHandler, false)
+        eventOff(document, 'focusin', this.focusHandler)
       }
     },
     // Resize Listener
     setResizeEvent (on) {
+      const options = { passive: true, capture: false }
       ['resize', 'orientationchange'].forEach(evtName => {
         if (on) {
-          eventOn(window, evtName, this.adjustDialog)
+          eventOn(window, evtName, this.adjustDialog, options)
         } else {
-          eventOff(window, evtName, this.adjustDialog)
+          eventOff(window, evtName, this.adjustDialog, options)
         }
       })
     },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -585,14 +585,15 @@ export default {
     },
     // Turn on/off focusin listener
     setEnforceFocus (on) {
+      const options = { passive: true, capture: false }
       if (on) {
-        eventOn(document, 'focusin', this.focusHandler)
+        eventOn(document, 'focusin', this.focusHandler, options)
       } else {
-        eventOff(document, 'focusin', this.focusHandler)
+        eventOff(document, 'focusin', this.focusHandler, options)
       }
     },
     // Resize Listener
-    setResizeEvent (on) {
+    setResizeEvent (on) /* istanbul ignore next: can't easily test in JSDOM */ {
       const options = { passive: true, capture: false }
       ['resize', 'orientationchange'].forEach(evtName => {
         if (on) {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -594,14 +594,16 @@ export default {
     },
     // Resize Listener
     setResizeEvent (on) /* istanbul ignore next: can't easily test in JSDOM */ {
-      const options = { passive: true, capture: false }
-      ['resize', 'orientationchange'].forEach(evtName => {
-        if (on) {
-          eventOn(window, evtName, this.adjustDialog, options)
-        } else {
-          eventOff(window, evtName, this.adjustDialog, options)
+      ['resize', 'orientationchange'].forEach(
+        evtName => {
+          const options = { passive: true, capture: false }
+          if (on) {
+            eventOn(window, evtName, this.adjustDialog, options)
+          } else {
+            eventOff(window, evtName, this.adjustDialog, options)
+          }
         }
-      })
+      )
     },
     // Root Listener handlers
     showHandler (id, triggerEl) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

Use passive event listeners where possible

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other, please describe: performance

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:


**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

