### PR TITLE
fix(tabs): various fixes and improvements (Fixes: #2327, #2148. Closes: #2403, #2180)

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -20,14 +20,15 @@ For navigation based tabs, use the [`<b-nav>`](/docs/components/nav) component a
 ```
 
 **Tip:** You should supply each child `<b-tab>` component a unique `key` value if dynamically
-adding, removing, showing, or hiding `<b-tab>` components. The `key` attribute is a special Vue
-attribute, see https://vuejs.org/v2/api/#key).
+adding or removing `<b-tab>` components (i.e. `v-if` or for loops). The `key` attribute is a
+special Vue attribute, see https://vuejs.org/v2/api/#key).
+
 
 ## Cards Integration
 
 Tabs support integrating with bootstrap cards. Just add the `card` property to `<b-tabs>`. and place
-it inside a `<b-card>` component. Note that you should add `no-body` prop on `<b-card>` component in
-order to propertly decorate the card header and remove the extra padding introduced by `card-body`.
+it inside a `<b-card>` component. Note that you should add `no-body` prop on the `<b-card>` component
+in order to propertly decorate the card header and remove the extra padding introduced by `card-body`.
 
 ```html
 <b-card no-body>
@@ -72,8 +73,9 @@ When `<b-tabs>` is in `card` mode, each `<b-tab>` sub-component will automatical
 <!-- with-card-nobody.vue -->
 ```
 
-Setting the `no-body` prop on `<b-tab>` will have no affect when `<b-tabs>` is not in `card` mode
+**Note:** Setting the `no-body` prop on `<b-tab>` will have no affect when `<b-tabs>` is not in `card` mode
 (as the `card-body` class is only set when in `card` mode).
+
 
 ## Pills variant
 
@@ -174,9 +176,7 @@ additional custom styling._
 
 ## Fade animation
 
-Fade is enabled by default when changing tabs. It can disabled with `no-fade` property. Note you
-should use the `<b-nav-item>` component when adding contentless-tabs to maintain correct sizing and
-alignment. See the advanced usage examples below for an example.
+Fade is enabled by default when changing tabs. It can disabled with `no-fade` property.
 
 ## Add Tabs without content
 
@@ -193,24 +193,37 @@ If you want to add extra tabs that do not have any content, you can put them in 
 <!-- tabs-item-slot.vue -->
 ```
 
+**Note:** extra (contentless) tabs should be a `<b-nav-item>` or have the class `nav-item`
+with a root element of `<li>` for proper rendering.
+
+
 ## Add custom content to tab title
 
-If you want to add custom content to tab title, like HTML code, icons, or another Vue component,
-this possible by using `title` slot
+If you want to add custom content to tab title, like HTML code, icons, or another
+non-interactive Vue component, this possible by using `title` slot
 
 ```html
 <b-tabs>
-  <b-tab active key="tab-1">
-    <!-- Add your custom title here-->
+  <b-tab active>
     <template slot="title">
-      i'm <i>Custom</i> <strong>Title</strong>
+      <b-spinner type="grow" small /> i'm <i>Custom</i> <strong>Title</strong>
     </template>
-    Tab Contents 1
+    <p clas="m-3">Tab Contents 1</p>
+  </b-tab>
+  <b-tab>
+    <template slot="title">
+      <b-spinner type="border" small /> tab 2
+    </template>
+    <p clas="m-3">Tab Contents 2</p>
   </b-tab>
 </b-tabs>
 
 <!-- tabs-title-slot.vue -->
 ```
+
+**Do not** place inteactive elements/components inside the title slot. The tab button is a
+link which does not support child interactive elements per the HTML5 spec.
+
 
 ## Apply custom classes to the generated nav-tabs or pills
 
@@ -258,31 +271,46 @@ need to accomodate your custom classes for this._
 
 ## Keyboard Navigation
 
-Keyboard navigation is enabled by default.
+Keyboard navigation is enabled by default for ARIA compliance with tablists.
 
-| Keypress                                                              | Action                                   |
-| --------------------------------------------------------------------- | ---------------------------------------- |
-| <kbd>LEFT</kbd> or <kbd>UP</kbd>                                      | Move to the previous non-disabled tab    |
-| <kbd>RIGHT</kbd> or <kbd>DOWN</kbd>                                   | Move to the next non-disabled tab        |
-| <kbd>SHIFT</kbd>+<kbd>LEFT</kbd> or <kbd>SHIFT</kbd>+<kbd>UP</kbd>    | Move to the first non-disabled tab       |
-| <kbd>SHIFT</kbd>+<kbd>RIGHT</kbd> or <kbd>SHIFT</kbd>+<kbd>DOWN</kbd> | Move to the last non-disabled tab        |
-| <kbd>TAB</kbd>                                                        | Move to the next control on the page     |
-| <kbd>SHIFT</kbd>+<kbd>TAB</kbd>                                       | Move to the previous control on the page |
+| Keypress                                                              | Action                                    |
+| --------------------------------------------------------------------- | ----------------------------------------- |
+| <kbd>LEFT</kbd> or <kbd>UP</kbd>                                      | Activate the previous non-disabled tab    |
+| <kbd>RIGHT</kbd> or <kbd>DOWN</kbd>                                   | Activate the next non-disabled tab        |
+| <kbd>SHIFT</kbd>+<kbd>LEFT</kbd> or <kbd>SHIFT</kbd>+<kbd>UP</kbd>    | Activate the first non-disabled tab       |
+| <kbd>HOME</kbd>                                                       | Activate the first non-disabled tab       |
+| <kbd>SHIFT</kbd>+<kbd>RIGHT</kbd> or <kbd>SHIFT</kbd>+<kbd>DOWN</kbd> | Activate the last non-disabled tab        |
+| <kbd>END</kbd>                                                        | Activate the last non-disabled tab        |
+| <kbd>TAB</kbd>                                                        | Move focus to the active tab content      |
+| <kbd>SHIFT</kbd>+<kbd>TAB</kbd>                                       | Move to the previous control on the page  |
 
-Disable it by setting the prop `no-key-nav`. Behavior will now default to standard browser
+Disable keyboard navigation by setting the prop `no-key-nav`. Behavior will now default to standard browser
 navigation with TAB key.
 
 | Keypress                        | Action                                          |
 | ------------------------------- | ----------------------------------------------- |
 | <kbd>TAB</kbd>                  | Move to the next tab or control on the page     |
 | <kbd>SHIFT</kbd>+<kbd>TAB</kbd> | Move to the previous tab or control on the page |
+| <kbd>ENTER</kbd>                | Activate current focused tab                    |
 
-**Caution:** If you have text or text-like inputs in your tabs, leave keyboard navigation off, as it
-is not possble to use key presses to jump out of a text (or test-like) inputs.
+
+## Dynamically activating and deactivating tabs
+
+Use the `<b-tabs>` v-model to control which tab is active by setting the v-model to
+the index (zero-based) of the tab to be shown.
+
+Alternatively, you can use the `active` prop on each `<b-tab>` with the `.sync` modifier
+to activate the tab, or detect if a particular tab is active.
+
+Each `<b-tab>` instance also provides two public methods to activate or deactivate
+the tab. The methods are `.activate()` and `.deactivate()`, respectively. If activation
+or deactivaton fails (i.e. a tab is disabled or no tab is available to move activation
+to), then the currently active tab will remain active and the method will return `false`.
+
 
 ## Advanced Examples
 
-### External controls
+### External controls using v-model
 
 ```html
 <template>
@@ -325,7 +353,7 @@ is not possble to use key presses to jump out of a text (or test-like) inputs.
 <!-- tabs-controls.vue -->
 ```
 
-### Dynamic Tabs
+### Dynamic Tabs + tabs slot
 
 ```html
 <template>
@@ -341,7 +369,9 @@ is not possble to use key presses to jump out of a text (or test-like) inputs.
         </b-tab>
 
         <!-- New Tab Button (Using tabs slot) -->
-        <b-nav-item slot="tabs" @click.prevent="newTab" href="#"> + </b-nav-item>
+        <template slot="tabs">
+          <b-nav-item @click.prevent="newTab" href="#"><b>+</b></b-nav-item>
+        </template>
 
         <!-- Render this if no tabs -->
         <div slot="empty" class="text-center text-muted">

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -1,19 +1,19 @@
 # Tabs
 
-> Create tabbable panes of _local content_. The tabs component is built upon navs and cards
-> internally.
+> Create a widget of tabbable panes of _local content_. The tabs component is built upon navs and cards
+> internally, and provides full keyboard navigation control of the tabs.
 
-For navigation based tabs, use the [`<b-nav>`](/docs/components/nav) component and
-[`<b-card>`](/docs/components/card) component instead.
+For navigation based tabs (i.e. tabs that would change the URL), use the
+[`<b-nav>`](/docs/components/nav) component instead.
 
 
 ## Basic usage
 
 ```html
 <b-tabs>
-  <b-tab title="first" active> <br />I'm the first fading tab </b-tab>
-  <b-tab title="second"> <br />I'm the second tab content </b-tab>
-  <b-tab title="disabled" disabled> <br />Disabled tab! </b-tab>
+  <b-tab title="first" active><p class="m-3">I'm the first fading tab</p></b-tab>
+  <b-tab title="second"><p class="m-3">I'm the second tab content</p></b-tab>
+  <b-tab title="disabled" disabled><p class="m-3">Disabled tab!</p></b-tab>
 </b-tabs>
 
 <!-- basic.vue -->
@@ -33,8 +33,8 @@ in order to propertly decorate the card header and remove the extra padding intr
 ```html
 <b-card no-body>
   <b-tabs card>
-    <b-tab title="Tab 1" active key="tab-1"> Tab Contents 1 </b-tab>
-    <b-tab title="Tab 2" key="tab-2"> Tab Contents 2 </b-tab>
+    <b-tab title="Tab 1" active> Tab Contents 1 </b-tab>
+    <b-tab title="Tab 2"> Tab Contents 2 </b-tab>
   </b-tabs>
 </b-card>
 
@@ -48,19 +48,19 @@ When `<b-tabs>` is in `card` mode, each `<b-tab>` sub-component will automatical
 ```html
 <b-card no-body>
   <b-tabs card>
-    <b-tab no-body title="Picture 1" active key="tab-1">
+    <b-tab no-body title="Picture 1">
       <b-card-img bottom src="https://picsum.photos/600/200/?image=21" />
       <b-card-footer>Picture 1 footer</b-card-footer>
     </b-tab>
-    <b-tab no-body title="Picture 2" key="tab-2">
+    <b-tab no-body title="Picture 2">
       <b-card-img bottom src="https://picsum.photos/600/200/?image=25" />
       <b-card-footer>Picture 2 footer</b-card-footer>
     </b-tab>
-    <b-tab no-body title="Picture 3" key="tab-3">
+    <b-tab no-body title="Picture 3">
       <b-card-img bottom src="https://picsum.photos/600/200/?image=26" />
       <b-card-footer>Picture 3 footer</b-card-footer>
     </b-tab>
-    <b-tab title="Text" key="tab-4">
+    <b-tab title="Text">
       <h5>This tab does not have the <code>no-body</code> prop set</h5>
       Quis magna Lorem anim amet ipsum do mollit sit cillum voluptate ex nulla tempor. Laborum
       consequat non elit enim exercitation cillum aliqua consequat id aliqua. Esse ex consectetur
@@ -85,8 +85,8 @@ variant.
 ```html
 <b-card no-body>
   <b-tabs pills card>
-    <b-tab title="Tab 1" active key="tab-1"> Tab Contents 1 </b-tab>
-    <b-tab title="Tab 2" key="tab-2"> Tab Contents 2 </b-tab>
+    <b-tab title="Tab 1" active> Tab Contents 1 </b-tab>
+    <b-tab title="Tab 2"> Tab Contents 2 </b-tab>
   </b-tabs>
 </b-card>
 
@@ -100,8 +100,8 @@ Visually move the tab controls to the bottom by setting the prop `end`
 ```html
 <b-card no-body>
   <b-tabs pills card end>
-    <b-tab title="Tab 1" active key="tab-1"> Tab Contents 1 </b-tab>
-    <b-tab title="Tab 2" key="tab-2"> Tab Contents 2 </b-tab>
+    <b-tab title="Tab 1" active> Tab Contents 1 </b-tab>
+    <b-tab title="Tab 2"> Tab Contents 2 </b-tab>
   </b-tabs>
 </b-card>
 
@@ -127,9 +127,9 @@ tabs work with or without `card` mode enabled.
 ```html
 <b-card no-body>
   <b-tabs pills card vertical>
-    <b-tab title="Tab 1" active key="tab-1"> Tab Contents 1 </b-tab>
-    <b-tab title="Tab 2" key="tab-2"> Tab Contents 2 </b-tab>
-    <b-tab title="Tab 3" key="tab-3"> Tab Contents 3 </b-tab>
+    <b-tab title="Tab 1" active> Tab Contents 1 </b-tab>
+    <b-tab title="Tab 2"> Tab Contents 2 </b-tab>
+    <b-tab title="Tab 3"> Tab Contents 3 </b-tab>
   </b-tabs>
 </b-card>
 
@@ -141,9 +141,9 @@ Visually move the tab controls to the right hand side by setting the `end` prop:
 ```html
 <b-card no-body>
   <b-tabs pills card vertical end>
-    <b-tab title="Tab 1" active key="tab-1"> Tab Contents 1 </b-tab>
-    <b-tab title="Tab 2" key="tab-2"> Tab Contents 2 </b-tab>
-    <b-tab title="Tab 3" key="tab-3"> Tab Contents 3 </b-tab>
+    <b-tab title="Tab 1" active> Tab Contents 1 </b-tab>
+    <b-tab title="Tab 2"> Tab Contents 2 </b-tab>
+    <b-tab title="Tab 3"> Tab Contents 3 </b-tab>
   </b-tabs>
 </b-card>
 
@@ -158,9 +158,9 @@ column classes such as `col-2`, `col-3`, etc.
 ```html
 <b-card no-body>
   <b-tabs pills card vertical nav-wrapper-class="w-50">
-    <b-tab title="Tab 1" active key="tab-1"> Tab Contents 1 </b-tab>
-    <b-tab title="Tab 2" key="tab-2"> Tab Contents 2 </b-tab>
-    <b-tab title="Tab 3" key="tab-3"> Tab Contents 3 </b-tab>
+    <b-tab title="Tab 1" active> Tab Contents 1 </b-tab>
+    <b-tab title="Tab 2"> Tab Contents 2 </b-tab>
+    <b-tab title="Tab 3"> Tab Contents 3 </b-tab>
   </b-tabs>
 </b-card>
 
@@ -208,30 +208,30 @@ non-interactive Vue component, this possible by using `title` slot
     <template slot="title">
       <b-spinner type="grow" small /> i'm <i>Custom</i> <strong>Title</strong>
     </template>
-    <p clas="m-3">Tab Contents 1</p>
+    <p class="m-3">Tab Contents 1</p>
   </b-tab>
   <b-tab>
     <template slot="title">
       <b-spinner type="border" small /> tab 2
     </template>
-    <p clas="m-3">Tab Contents 2</p>
+    <p class="m-3">Tab Contents 2</p>
   </b-tab>
 </b-tabs>
 
 <!-- tabs-title-slot.vue -->
 ```
 
-**Do not** place inteactive elements/components inside the title slot. The tab button is a
+**Do not** place interactive elements/components inside the title slot. The tab button is a
 link which does not support child interactive elements per the HTML5 spec.
 
 
 ## Apply custom classes to the generated nav-tabs or pills
 
-The tab selectors are based on Boostrap V4's `nav` markup ( i.e.
-`ul.nav > li.nav-item > a.nav-link`). In some situations, you may want to add classes to the `<li>`
-(nav-item) and/or the `<a>` (nav-link) on a per tab basis. To do so, simply supply the classname to
-the `title-item-class` prop (for the `<li>` element) or `title-link-class` prop (for the `<a>`
-element). Value's can be passed as a string or array of strings.
+The tab selectors are based on Boostrap V4's `nav` markup ( i.e. `ul.nav > li.nav-item > a.nav-link`).
+In some situations, you may want to add classes to the `<li>` (nav-item) and/or the `<a>` (nav-link)
+on a per tab basis. To do so, simply supply the classname to the `title-item-class` prop (for the
+`<li>` element) or `title-link-class` prop (for the `<a>` element). Value's can be passed as a string
+or array of strings.
 
 **Note:** _The `active` class is automatically applied to the active tabs `<a>` element. You may
 need to accomodate your custom classes for this._
@@ -240,9 +240,9 @@ need to accomodate your custom classes for this._
 <template>
   <b-card no-body>
     <b-tabs card v-model="tabIndex">
-      <b-tab title="Tab 1" :title-link-class="linkClass(0)" key="tab-1"> Tab Contents 1 </b-tab>
-      <b-tab title="Tab 2" :title-link-class="linkClass(1)" key="tab-2"> Tab Contents 2 </b-tab>
-      <b-tab title="Tab 3" :title-link-class="linkClass(2)" key="tab-3"> Tab Contents 3 </b-tab>
+      <b-tab title="Tab 1" :title-link-class="linkClass(0)"> Tab Contents 1 </b-tab>
+      <b-tab title="Tab 2" :title-link-class="linkClass(1)"> Tab Contents 2 </b-tab>
+      <b-tab title="Tab 3" :title-link-class="linkClass(2)"> Tab Contents 3 </b-tab>
     </b-tabs>
   </b-card>
 </template>
@@ -294,18 +294,19 @@ navigation with TAB key.
 | <kbd>ENTER</kbd>                | Activate current focused tab                    |
 
 
-## Dynamically activating and deactivating tabs
+## Programatically activating and deactivating tabs
 
 Use the `<b-tabs>` v-model to control which tab is active by setting the v-model to
-the index (zero-based) of the tab to be shown.
+the index (zero-based) of the tab to be shown (see example below).
 
 Alternatively, you can use the `active` prop on each `<b-tab>` with the `.sync` modifier
-to activate the tab, or detect if a particular tab is active.
+to activate the tab, or to detect if a particular tab is active.
 
 Each `<b-tab>` instance also provides two public methods to activate or deactivate
 the tab. The methods are `.activate()` and `.deactivate()`, respectively. If activation
 or deactivaton fails (i.e. a tab is disabled or no tab is available to move activation
 to), then the currently active tab will remain active and the method will return `false`.
+You will need a reference to the `<b-tab>` in order to use these methods.
 
 
 ## Advanced Examples
@@ -318,12 +319,12 @@ to), then the currently active tab will remain active and the method will return
     <!-- Tabs with card integration -->
     <b-card no-body>
       <b-tabs small card v-model="tabIndex">
-        <b-tab title="General" key="tab-1"> I'm the first fading tab </b-tab>
-        <b-tab title="Edit profile" key="tab-2">
+        <b-tab title="General"> I'm the first fading tab </b-tab>
+        <b-tab title="Edit profile">
           I'm the second tab
           <b-card>I'm the card in tab</b-card>
         </b-tab>
-        <b-tab title="Premium Plan" disabled key="tab-3"> Sibzamini! </b-tab>
+        <b-tab title="Premium Plan" disabled> Sibzamini! </b-tab>
         <b-tab title="Info"> I'm the last tab </b-tab>
       </b-tabs>
     </b-card>
@@ -376,7 +377,7 @@ to), then the currently active tab will remain active and the method will return
         <!-- Render this if no tabs -->
         <div slot="empty" class="text-center text-muted">
           There are no open tabs <br />
-          Open a new tab using + button.
+          Open a new tab using the <b>+</b> button above.
         </div>
       </b-tabs>
     </b-card>

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -271,27 +271,28 @@ need to accomodate your custom classes for this._
 
 ## Keyboard Navigation
 
-Keyboard navigation is enabled by default for ARIA compliance with tablists.
+Keyboard navigation is enabled by default for ARIA compliance with tablists when
+a tab button has focus.
 
-| Keypress                                                              | Action                                    |
-| --------------------------------------------------------------------- | ----------------------------------------- |
-| <kbd>LEFT</kbd> or <kbd>UP</kbd>                                      | Activate the previous non-disabled tab    |
-| <kbd>RIGHT</kbd> or <kbd>DOWN</kbd>                                   | Activate the next non-disabled tab        |
-| <kbd>SHIFT</kbd>+<kbd>LEFT</kbd> or <kbd>SHIFT</kbd>+<kbd>UP</kbd>    | Activate the first non-disabled tab       |
-| <kbd>HOME</kbd>                                                       | Activate the first non-disabled tab       |
-| <kbd>SHIFT</kbd>+<kbd>RIGHT</kbd> or <kbd>SHIFT</kbd>+<kbd>DOWN</kbd> | Activate the last non-disabled tab        |
-| <kbd>END</kbd>                                                        | Activate the last non-disabled tab        |
-| <kbd>TAB</kbd>                                                        | Move focus to the active tab content      |
-| <kbd>SHIFT</kbd>+<kbd>TAB</kbd>                                       | Move to the previous control on the page  |
+| Keypress                                                              | Action                                         |
+| --------------------------------------------------------------------- | ---------------------------------------------- |
+| <kbd>LEFT</kbd> or <kbd>UP</kbd>                                      | Activate the previous non-disabled tab         |
+| <kbd>RIGHT</kbd> or <kbd>DOWN</kbd>                                   | Activate the next non-disabled tab             |
+| <kbd>SHIFT</kbd>+<kbd>LEFT</kbd> or <kbd>SHIFT</kbd>+<kbd>UP</kbd>    | Activate the first non-disabled tab            |
+| <kbd>HOME</kbd>                                                       | Activate the first non-disabled tab            |
+| <kbd>SHIFT</kbd>+<kbd>RIGHT</kbd> or <kbd>SHIFT</kbd>+<kbd>DOWN</kbd> | Activate the last non-disabled tab             |
+| <kbd>END</kbd>                                                        | Activate the last non-disabled tab             |
+| <kbd>TAB</kbd>                                                        | Move focus to the active tab content           |
+| <kbd>SHIFT</kbd>+<kbd>TAB</kbd>                                       | Move focus to the previous control on the page |
 
-Disable keyboard navigation by setting the prop `no-key-nav`. Behavior will now default to standard browser
-navigation with TAB key.
+Disable keyboard navigation by setting the prop `no-key-nav`. Behavior will now default to
+regular browser navigation with TAB key.
 
-| Keypress                        | Action                                          |
-| ------------------------------- | ----------------------------------------------- |
-| <kbd>TAB</kbd>                  | Move to the next tab or control on the page     |
-| <kbd>SHIFT</kbd>+<kbd>TAB</kbd> | Move to the previous tab or control on the page |
-| <kbd>ENTER</kbd>                | Activate current focused tab                    |
+| Keypress                        | Action                                                 |
+| ------------------------------- | ------------------------------------------------------ |
+| <kbd>TAB</kbd>                  | Move to the next tab button or control on the page     |
+| <kbd>SHIFT</kbd>+<kbd>TAB</kbd> | Move to the previous tab button or control on the page |
+| <kbd>ENTER</kbd>                | Activate current focused button's tab                  |
 
 
 ## Programatically activating and deactivating tabs

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -114,6 +114,14 @@ export default {
           }
         }
       }
+    },
+    disabled (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        if (!newVal && this.localActive && this.bTabs.firstTab) {
+          this.localActive = false
+          this.bTabs.firstTab()
+        }
+      }
     }
   },
   mounted () {

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -162,7 +162,7 @@ export default {
         // Not inside a b-tabs component
         return false
       }
-    },
+    }
   },
   render (h) {
     let content = h(

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -107,8 +107,11 @@ export default {
           // If activated post mount
           this.activate()
         } else {
-          // We don't have a method to deactivate a tab yet
-          this.$emit('update:active', this.localActive)
+          if (!this.deactivate()) {
+            // Tab couldn't be deactivated, so we reset the synced active prop
+            // Deactivation will fail if no other tabs to activate.
+            this.$emit('update:active', this.localActive)
+          }
         }
       }
     }
@@ -148,6 +151,7 @@ export default {
       if (this.bTabs.activateTab && !this.disabled) {
         return this.bTabs.activateTab(this)
       } else {
+        // Not inside a b-tabs component
         return false
       }
     },
@@ -155,6 +159,7 @@ export default {
       if (this.bTabs.deactivateTab) {
         return this.bTabs.deactivateTab(this)
       } else {
+        // Not inside a b-tabs component
         return false
       }
     },

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -107,6 +107,15 @@ export default {
     // }
   },
   methods: {
+    // Public methods
+    activate () {
+      if (this.bTabs.activateTab && !this.disabled) {
+        return this.bTabs.activateTab(this)
+      } else {
+        return false
+      }
+    },
+    // Transition handlers
     beforeEnter () {
       // change opacity (add 'show' class) 1 frame after display
       // otherwise css transition won't happen

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -152,15 +152,15 @@ export default {
       if (this.bTabs.activateTab && !this.disabled) {
         return this.bTabs.activateTab(this)
       } else {
-        // Not inside a b-tabs component
+        // Not inside a b-tabs component or tab is disabled
         return false
       }
     },
     deactivate () {
-      if (this.bTabs.deactivateTab) {
+      if (this.bTabs.deactivateTab && this.localActive) {
         return this.bTabs.deactivateTab(this)
       } else {
-        // Not inside a b-tabs component
+        // Not inside a b-tabs component or not active to begin with
         return false
       }
     }

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -117,7 +117,7 @@ export default {
     },
     disabled (newVal, oldVal) {
       if (newVal !== oldVal) {
-        if (!newVal && this.localActive && this.bTabs.firstTab) {
+        if (newVal && this.localActive && this.bTabs.firstTab) {
           this.localActive = false
           this.bTabs.firstTab()
         }

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -102,9 +102,7 @@ export default {
   },
   updated () {
     // Force the tab button content to update (since slots are not reactive)
-    console.log('b-tab update...')
     if (this.bTabs.updateButton) {
-      console.log('b-tab calling updateButton', this)
       this.bTabs.updateButton(this)
     }
   },
@@ -127,6 +125,7 @@ export default {
             window.mozRequestAnimationFrame ||
             window.msRequestAnimationFrame ||
             window.oRequestAnimationFrame ||
+            /* istanbul ignore next */
             function (cb) { setTimeout(cb, 16) }
 
       raf(() => { this.show = true })

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -96,6 +96,23 @@ export default {
       return true
     }
   },
+  watch: {
+    localActive (newVal, oldVal) {
+      // Make 'active' prop work with `.sync` modifier
+      this.$emit('update:active', newVal)
+    },
+    active (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        if (newVal) {
+          // If activated post mount
+          this.activate()
+        } else {
+          // We don't have a method to deactivate a tab yet
+          this.$emit('update:active', this.localActive)
+        }
+      }
+    }
+  },
   mounted () {
     // Initially show on mount if active and not disabled
     this.show = this.localActive

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -102,6 +102,7 @@ export default {
   },
   updated () {
     // Force the tab button content to update (since slots are not reactive)
+    console.log('b-tab update...')
     if (this.bTabs.updateButton) {
       console.log('b-tab calling updateButton', this)
       this.bTabs.updateButton(this)

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -124,14 +124,6 @@ export default {
     }
   },
   methods: {
-    // Public methods
-    activate () {
-      if (this.bTabs.activateTab && !this.disabled) {
-        return this.bTabs.activateTab(this)
-      } else {
-        return false
-      }
-    },
     // Transition handlers
     beforeEnter () {
       // change opacity (add 'show' class) 1 frame after display
@@ -150,7 +142,22 @@ export default {
     beforeLeave () {
       // Remove the 'show' class
       this.show = false
-    }
+    },
+    // Public methods
+    activate () {
+      if (this.bTabs.activateTab && !this.disabled) {
+        return this.bTabs.activateTab(this)
+      } else {
+        return false
+      }
+    },
+    deactivate () {
+      if (this.bTabs.deactivateTab) {
+        return this.bTabs.deactivateTab(this)
+      } else {
+        return false
+      }
+    },
   },
   render (h) {
     let content = h(

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -129,7 +129,7 @@ export default {
   },
   methods: {
     // Transition handlers
-    beforeEnter () {
+    beforeEnter () /* instanbul ignore next: difficult to test rAF in JSDOM */ {
       // change opacity (add 'show' class) 1 frame after display
       // otherwise css transition won't happen
       // TODO: Move raf method into utils/dom.js
@@ -143,7 +143,7 @@ export default {
 
       raf(() => { this.show = true })
     },
-    beforeLeave () {
+    beforeLeave () /* instanbul ignore next: difficult to test rAF in JSDOM */ {
       // Remove the 'show' class
       this.show = false
     },

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -130,7 +130,7 @@ export default {
       raf(() => { this.show = true })
     },
     beforeLeave () {
-      // remove the 'show' class
+      // Remove the 'show' class
       this.show = false
     }
   },

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -101,7 +101,7 @@ export default {
     this.show = this.localActive
   },
   updated () {
-    // Force the tab buton content to update (since slots are not reactive)
+    // Force the tab button content to update (since slots are not reactive)
     if (this.bTabs.updateButton) {
       this.bTabs.updateButton(this)
     }

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -103,6 +103,7 @@ export default {
   updated () {
     // Force the tab button content to update (since slots are not reactive)
     if (this.bTabs.updateButton) {
+      console.log('b-tab calling updateButton', this)
       this.bTabs.updateButton(this)
     }
   },

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -102,9 +102,9 @@ export default {
   },
   updated () {
     // Force the tab buton content to update (since slots are not reactive)
-    // if (this.bTabs.updateButton) {
-    //   this.bTabs.updateButton(this)
-    // }
+    if (this.bTabs.updateButton) {
+      this.bTabs.updateButton(this)
+    }
   },
   methods: {
     // Public methods

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -122,7 +122,8 @@ export default {
   },
   updated () {
     // Force the tab button content to update (since slots are not reactive)
-    if (this.bTabs.updateButton) {
+    // Only done if we have a title slot, as the title prop is reactive
+    if (this.$slots.title && this.bTabs.updateButton) {
       this.bTabs.updateButton(this)
     }
   },

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -231,8 +231,6 @@ describe('tab', async () => {
   })
 
   it('calls parent de/activateTab() when prop active changes', async () => {
-    let updateCalled = false
-    let value = null
     let activateCalled = false
     let activateVm = null
     let deactivateCalled = false
@@ -266,8 +264,6 @@ describe('tab', async () => {
       value = val
     })
 
-    expect(updateCalled).toBe(false)
-    expect(value).toBe(null)
     expect(activateCalled).toBe(false)
     expect(activateVm).toBe(null)
     expect(deactivateCalled).toBe(false)
@@ -275,22 +271,18 @@ describe('tab', async () => {
 
     wrapper.setProps({ active: true })
 
-    expect(updateCalled).toBe(false)
-    expect(value).toBe(null)
     expect(activateCalled).toBe(true)
     expect(activateVm).toBe(wrapper.vm)
     expect(deactivateCalled).toBe(false)
     expect(deactivateVm).toBe(null)
 
-    updateCalled = false
-    value = null
     activateCalled = false
     activateVm = null
+    deactivateCalled = false
+    deactivateVm = null
 
     wrapper.setProps({ active: false })
 
-    expect(updateCalled).toBe(false)
-    expect(value).toBe(null)
     expect(activateCalled).toBe(false)
     expect(activateVm).toBe(null)
     expect(deactivateCalled).toBe(true)

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -229,4 +229,74 @@ describe('tab', async () => {
     expect(called).toBe(true)
     expect(vm).toEqual(wrapper.vm)
   })
+
+  it('emits event "update:active" when prop active changes and calls de/activateTab', async () => {
+    let updateCalled = false
+    let value = null
+    let activateCalled = false
+    let activateVm = null
+    let deactivateCalled = false
+    let deactivateVm = null
+
+    const wrapper = mount(Tab, {
+      provide () {
+        return {
+          bTabs: {
+            fade: false,
+            lazy: false,
+            card: false,
+            noKeyNav: false,
+            activateTab (tab) {
+              called = true
+              vm = tab
+              return true
+            },
+            deactivateTab (tab) {
+              called = true
+              vm = tab
+              return true
+            }
+          }
+        }
+      }
+    })
+
+    wrapper.vm.$on('update:active', (val) => {
+      updateCalled = true
+      value = val
+    })
+
+    expect(updateCalled).toBe(false)
+    expect(value).toBe(null)
+    expect(activateCalled).toBe(false)
+    expect(activateVm).toBe(null)
+    expect(deactivateCalled).toBe(false)
+    expect(deactivateVm).toBe(null)
+    expect(wrapper.vm.localActive).toBe(false)
+
+    wrapper.setProps({ active: true })
+
+    expect(updateCalled).toBe(true)
+    expect(value).toBe(true)
+    expect(activateCalled).toBe(true)
+    expect(activateVm).toBe(wrapper.vm)
+    expect(deactivateCalled).toBe(false)
+    expect(deactivateVm).toBe(null)
+    expect(wrapper.vm.localActive).toBe(true)
+    
+    updateCalled = false
+    value = null
+    activateCalled = false
+    activateVm = null
+
+    wrapper.setProps({ active: false })
+
+    expect(updateCalled).toBe(true)
+    expect(value).toBe(false)
+    expect(activateCalled).toBe(false)
+    expect(activateVm).toBe(null)
+    expect(deactivateCalled).toBe(true)
+    expect(deactivateVm).toBe(wrapper.vm)
+    expect(wrapper.vm.localActive).toBe(false)
+  })
 })

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -1,0 +1,190 @@
+import Tab from './tab'
+import { mount } from '@vue/test-utils'
+
+describe('tab', async () => {
+  it('default has expected classes, attributes and structure', async () => {
+    const wrapper = mount(Tab)
+
+    expect(wrapper.is('div')).toBe(true)
+    expect(wrapper.classes()).toContain('tab-pane')
+    expect(wrapper.classes()).not.toContain('disabled')
+    expect(wrapper.classes()).not.toContain('active')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('card-body')
+    expect(wrapper.attributes('role')).toBe('tabpanel')
+    expect(wrapper.attributes('aria-hidden')).toBe('true')
+    expect(wrapper.attributes('aria-expanded')).toBe('false')
+    expect(wrapper.attributes('labelledby')).not.toBeDefined()
+    expect(wrapper.attributes('tabindex')).not.toBeDefined()
+    expect(wrapper.attributes('id')).toBeDefined()
+  })
+
+  it('default has expected data state', async () => {
+    const wrapper = mount(Tab)
+
+    expect(wrapper.vm._isTab).toBe(true)
+    expect(wrapper.vm.localActive).toBe(false)
+    expect(wrapper.vm.show).toBe(false)
+  })
+
+  it('has class disabled when disabled=true', async () => {
+    const wrapper = mount(Tab, {
+      propsData: { disabled: true }
+    })
+
+    expect(wrapper.classes()).toContain('disabled')
+    expect(wrapper.classes()).toContain('tab-pane')
+    expect(wrapper.classes()).not.toContain('active')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('card-body')
+  })
+
+  it('has class active when active=true', async () => {
+    const wrapper = mount(Tab, {
+      propsData: { active: true }
+    })
+    
+    expect(wrapper.classes()).toContain('active')
+    expect(wrapper.classes()).not.toContain('disabled')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('card-body')
+  })
+
+  it('does not have class active when active=true and disabled=true', async () => {
+    const wrapper = mount(Tab, {
+      propsData: {
+        active: true,
+        disabled: true
+      }
+    })
+    
+    expect(wrapper.classes()).not.toContain('active')
+    expect(wrapper.classes()).toContain('disabled')
+    expect(wrapper.classes()).toContain('tab-pane')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('card-body')
+  })
+
+  it('has class active when localActive becomes true', async () => {
+    const wrapper = mount(Tab)
+    
+    expect(wrapper.classes()).not.toContain('active')
+    expect(wrapper.classes()).not.toContain('disabled')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('card-body')
+
+    wrapper.setData({ localActive: true })
+
+    expect(wrapper.classes()).toContain('active')
+    expect(wrapper.classes()).not.toContain('disabled')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('card-body')
+  })
+
+  it('emits event `update:active' when localActive becomes true', async () => {
+    const wrapper = mount(Tab)
+    
+    let called = false
+    let value = null
+    wrapper.$on('update:active', (val) => {
+      called = true
+      value = val
+    })
+
+    expect(called).toBe(false)
+    expect(value).toBe(null)
+
+    wrapper.setData({ localActive: true })
+
+    expect(called).toBe(true)
+    expect(value).toBe(true)
+  })
+
+  it('has class fade when parent has fade=true', async () => {
+    const wrapper = mount(Tab, {
+      inject: {
+        bTabs: {
+          fade: true,
+          lazy: false,
+          card: false,
+          noKeyNav: true
+        }
+      }
+    })
+
+    expect(wrapper.classes()).toContain('fade')
+    expect(wrapper.classes()).toContain('tab-pane')
+    expect(wrapper.classes()).not.toContain('disabled')
+    expect(wrapper.classes()).not.toContain('active')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('card-body')
+  })
+
+  it('has class card-body when parent has card=true', async () => {
+    const wrapper = mount(Tab, {
+      inject: {
+        bTabs: {
+          fade: false,
+          lazy: false,
+          card: true,
+          noKeyNav: true
+        }
+      }
+    })
+
+    expect(wrapper.classes()).toContain('card-body')
+    expect(wrapper.classes()).toContain('tab-pane')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('disabled')
+    expect(wrapper.classes()).not.toContain('active')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+  })
+
+  it('does not have class card-body when parent has card=true and prop no-body is set', async () => {
+    const wrapper = mount(Tab, {
+      inject: {
+        bTabs: {
+          fade: false,
+          lazy: false,
+          card: true,
+          noKeyNav: true
+        }
+      },
+      propsData: {
+        noCard: true
+      }
+    })
+
+    expect(wrapper.classes()).not.toContain('card-body')
+    expect(wrapper.classes()).toContain('tab-pane')
+    expect(wrapper.classes()).not.toContain('fade')
+    expect(wrapper.classes()).not.toContain('disabled')
+    expect(wrapper.classes()).not.toContain('active')
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('fade')
+  })
+
+  it('has attribute tabindex="0" when parent has keynav enabled', async () => {
+    const wrapper = mount(Tab, {
+      inject: {
+        bTabs: {
+          fade: false,
+          lazy: false,
+          card: false,
+          noKeyNav: false
+        }
+      }
+    })
+
+    expect(wrapper.attributes('tabindex')).toBeDefined()
+    expect(wrapper.attributes('tabindex')).toBe('0')
+  })
+})

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -277,7 +277,7 @@ describe('tab', async () => {
     wrapper.setProps({ active: true })
 
     expect(updateCalled).toBe(false)
-    expect(value).toBe(true)
+    expect(value).toBe(null)
     expect(activateCalled).toBe(true)
     expect(activateVm).toBe(wrapper.vm)
     expect(deactivateCalled).toBe(false)
@@ -292,7 +292,7 @@ describe('tab', async () => {
     wrapper.setProps({ active: false })
 
     expect(updateCalled).toBe(false)
-    expect(value).toBe(false)
+    expect(value).toBe(null)
     expect(activateCalled).toBe(false)
     expect(activateVm).toBe(null)
     expect(deactivateCalled).toBe(true)

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -230,7 +230,7 @@ describe('tab', async () => {
     expect(vm).toEqual(wrapper.vm)
   })
 
-  it('emits event "update:active" when prop active changes and calls de/activateTab', async () => {
+  it('calls parent de/activateTab() when prop active changes', async () => {
     let updateCalled = false
     let value = null
     let activateCalled = false
@@ -276,7 +276,7 @@ describe('tab', async () => {
 
     wrapper.setProps({ active: true })
 
-    expect(updateCalled).toBe(true)
+    expect(updateCalled).toBe(false)
     expect(value).toBe(true)
     expect(activateCalled).toBe(true)
     expect(activateVm).toBe(wrapper.vm)
@@ -291,7 +291,7 @@ describe('tab', async () => {
 
     wrapper.setProps({ active: false })
 
-    expect(updateCalled).toBe(true)
+    expect(updateCalled).toBe(false)
     expect(value).toBe(false)
     expect(activateCalled).toBe(false)
     expect(activateVm).toBe(null)

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -351,4 +351,31 @@ describe('tab', async () => {
     expect(deactivateVm).toBe(null)
     expect(result).toBe(false)
   })
+
+  it('has class show when localActive becomes true', async () => {
+    const wrapper = mount(Tab)
+
+    expect(wrapper.classes()).not.toContain('active')
+    expect(wrapper.classes()).not.toContain('show')
+
+    wrapper.setData({ localActive: true })
+
+    expect(wrapper.classes()).toContain('active')
+    expect(wrapper.classes()).not.toContain('show')
+
+    // JSDOM doesnt support requestAnimationFrame
+    // So it falls back to setTimeout.  So we advance the time
+    jest.runAllTimers()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.classes()).toContain('show')
+    expect(wrapper.classes()).toContain('active')
+
+    wrapper.setData({ localActive: false })
+    jest.runAllTimers()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.classes()).not.toContain('show')
+    expect(wrapper.classes()).not.toContain('active')
+  })
 })

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -285,4 +285,70 @@ describe('tab', async () => {
     expect(deactivateCalled).toBe(true)
     expect(deactivateVm).toBe(wrapper.vm)
   })
+
+  it('does not call parent activateTab() when prop active changes and disabled=true', async () => {
+    let activateCalled = false
+    let activateVm = null
+
+    const wrapper = mount(Tab, {
+      provide () {
+        return {
+          bTabs: {
+            fade: false,
+            lazy: false,
+            card: false,
+            noKeyNav: false,
+            activateTab (tab) {
+              activateCalled = true
+              activateVm = tab
+              tab.localActive = true
+              return true
+            }
+          }
+        }
+      },
+      propsData: { disabled: true }
+    })
+
+    expect(activateCalled).toBe(false)
+    expect(activateVm).toBe(null)
+
+    wrapper.setProps({ active: true })
+
+    expect(activateCalled).toBe(false)
+    expect(activateVm).toBe(null)
+  })
+
+  it('does not call parent deactivateTab() when deactivate() called and not active', async () => {
+    let deactivateCalled = false
+    let deactivateVm = null
+
+    const wrapper = mount(Tab, {
+      provide () {
+        return {
+          bTabs: {
+            fade: false,
+            lazy: false,
+            card: false,
+            noKeyNav: false,
+            deactivateTab (tab) {
+              deactivateCalled = true
+              deactivateVm = tab
+              tab.localActive = false
+              return true
+            }
+          }
+        }
+      }
+    })
+
+    expect(deactivateCalled).toBe(false)
+    expect(deactivateVm).toBe(null)
+
+    const result = wrapper.vm.deactivate()
+
+    expect(deactivateCalled).toBe(false)
+    expect(deactivateVm).toBe(null)
+    expect(result).toBe(false)
+  })
 })

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -87,7 +87,7 @@ describe('tab', async () => {
     expect(wrapper.classes()).not.toContain('card-body')
   })
 
-  it('emits event `update:active' when localActive becomes true', async () => {
+  it('emits event "update:active" when localActive becomes true', async () => {
     const wrapper = mount(Tab)
     
     let called = false

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -259,11 +259,6 @@ describe('tab', async () => {
       }
     })
 
-    wrapper.vm.$on('update:active', (val) => {
-      updateCalled = true
-      value = val
-    })
-
     expect(activateCalled).toBe(false)
     expect(activateVm).toBe(null)
     expect(deactivateCalled).toBe(false)

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -353,6 +353,7 @@ describe('tab', async () => {
   })
 
   it('has class show when localActive becomes true', async () => {
+    jest.useFakeTimers()
     const wrapper = mount(Tab)
 
     expect(wrapper.classes()).not.toContain('active')
@@ -365,14 +366,14 @@ describe('tab', async () => {
 
     // JSDOM doesnt support requestAnimationFrame
     // So it falls back to setTimeout.  So we advance the time
-    jest.runAllTimers()
+    jest.runAllPendingTimers()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.classes()).toContain('show')
     expect(wrapper.classes()).toContain('active')
 
     wrapper.setData({ localActive: false })
-    jest.runAllTimers()
+    jest.runAllPendingTimers()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.classes()).not.toContain('show')

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -5,6 +5,10 @@ describe('tab', async () => {
   it('default has expected classes, attributes and structure', async () => {
     const wrapper = mount(Tab)
 
+    expect(wrapper).toBeDefined()
+
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.is('div')).toBe(true)
     expect(wrapper.classes()).toContain('tab-pane')
     expect(wrapper.classes()).not.toContain('disabled')
@@ -92,7 +96,7 @@ describe('tab', async () => {
 
     let called = false
     let value = null
-    wrapper.$on('update:active', (val) => {
+    wrapper.vm.$on('update:active', (val) => {
       called = true
       value = val
     })
@@ -125,7 +129,6 @@ describe('tab', async () => {
     expect(wrapper.classes()).not.toContain('disabled')
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes()).not.toContain('show')
-    expect(wrapper.classes()).not.toContain('fade')
     expect(wrapper.classes()).not.toContain('card-body')
   })
 
@@ -165,7 +168,7 @@ describe('tab', async () => {
         }
       },
       propsData: {
-        noCard: true
+        noBody: true
       }
     })
 
@@ -178,7 +181,7 @@ describe('tab', async () => {
     expect(wrapper.classes()).not.toContain('fade')
   })
 
-  it('has attribute tabindex="0" when parent has keynav enabled', async () => {
+  it('has attribute tabindex="0" when parent has keynav enabled and active', async () => {
     const wrapper = mount(Tab, {
       provide () {
         return {
@@ -189,7 +192,8 @@ describe('tab', async () => {
             noKeyNav: false
           }
         }
-      }
+      },
+      propsData: { active: true }
     })
 
     expect(wrapper.attributes('tabindex')).toBeDefined()
@@ -207,7 +211,7 @@ describe('tab', async () => {
             lazy: false,
             card: false,
             noKeyNav: false,
-            updateButton(tab) {
+            updateButton (tab) {
               called = true
               vm = tab
               return true
@@ -216,7 +220,7 @@ describe('tab', async () => {
         }
       },
       slots: {
-        default: '<b>foobar</b>'
+        title: '<b>foobar</b>'
       }
     })
 

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -353,27 +353,24 @@ describe('tab', async () => {
   })
 
   it('has class show when localActive becomes true', async () => {
-    jest.useFakeTimers()
-    const wrapper = mount(Tab)
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb()
+    })
+
+    const wrapper = mount(Tab, {
+      attachToDocument: true
+    })
 
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes()).not.toContain('show')
 
     wrapper.setData({ localActive: true })
-
-    expect(wrapper.classes()).toContain('active')
-    expect(wrapper.classes()).not.toContain('show')
-
-    // JSDOM doesnt support requestAnimationFrame
-    // So it falls back to setTimeout.  So we advance the time
-    jest.runAllTimers()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.classes()).toContain('show')
     expect(wrapper.classes()).toContain('active')
 
     wrapper.setData({ localActive: false })
-    jest.runAllTimers()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.classes()).not.toContain('show')

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -1,6 +1,8 @@
 import Tab from './tab'
 import { mount } from '@vue/test-utils'
 
+jest.useFakeTimers()
+
 describe('tab', async () => {
   it('default has expected classes, attributes and structure', async () => {
     const wrapper = mount(Tab)
@@ -358,19 +360,28 @@ describe('tab', async () => {
     })
 
     const wrapper = mount(Tab, {
-      attachToDocument: true
+      attachToDocument: true,
+      provide () {
+        return {
+          bTabs: {
+            fade: true
+          }
+        }
+      }
     })
 
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes()).not.toContain('show')
 
     wrapper.setData({ localActive: true })
+    jest.runAllTimers()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.classes()).toContain('show')
     expect(wrapper.classes()).toContain('active')
 
     wrapper.setData({ localActive: false })
+    jest.runAllTimers()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.classes()).not.toContain('show')

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -353,38 +353,4 @@ describe('tab', async () => {
     expect(deactivateVm).toBe(null)
     expect(result).toBe(false)
   })
-
-  it('has class show when localActive becomes true', async () => {
-    window.requestAnimationFrame = (cb) => { setTimeout(cb, 0) }
-
-    const wrapper = mount(Tab, {
-      attachToDocument: true,
-      provide () {
-        return {
-          bTabs: {
-            fade: true
-          }
-        }
-      }
-    })
-
-    expect(wrapper.classes()).not.toContain('active')
-    expect(wrapper.classes()).not.toContain('show')
-
-    wrapper.setData({ localActive: true })
-    await wrapper.vm.$nextTick()
-    jest.runAllTimers()
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.classes()).toContain('show')
-    expect(wrapper.classes()).toContain('active')
-
-    wrapper.setData({ localActive: false })
-    await wrapper.vm.$nextTick()
-    jest.runAllTimers()
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.classes()).not.toContain('show')
-    expect(wrapper.classes()).not.toContain('active')
-  })
 })

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -247,11 +247,13 @@ describe('tab', async () => {
             activateTab (tab) {
               activateCalled = true
               activateVm = tab
+              tab.localActive = true
               return true
             },
             deactivateTab (tab) {
               deactivateCalled = true
               deactivateVm = tab
+              tab.localActive = false
               return true
             }
           }

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -355,9 +355,7 @@ describe('tab', async () => {
   })
 
   it('has class show when localActive becomes true', async () => {
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
-      cb()
-    })
+    window.requestAnimationFrame = (cb) => { setTimeout(cb, 0) }
 
     const wrapper = mount(Tab, {
       attachToDocument: true,
@@ -374,6 +372,7 @@ describe('tab', async () => {
     expect(wrapper.classes()).not.toContain('show')
 
     wrapper.setData({ localActive: true })
+    await wrapper.vm.$nextTick()
     jest.runAllTimers()
     await wrapper.vm.$nextTick()
 
@@ -381,6 +380,7 @@ describe('tab', async () => {
     expect(wrapper.classes()).toContain('active')
 
     wrapper.setData({ localActive: false })
+    await wrapper.vm.$nextTick()
     jest.runAllTimers()
     await wrapper.vm.$nextTick()
 

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -247,13 +247,13 @@ describe('tab', async () => {
             card: false,
             noKeyNav: false,
             activateTab (tab) {
-              called = true
-              vm = tab
+              activateCalled = true
+              activateVm = tab
               return true
             },
             deactivateTab (tab) {
-              called = true
-              vm = tab
+              deactivateCalled = true
+              deactivateVm = tab
               return true
             }
           }
@@ -283,7 +283,7 @@ describe('tab', async () => {
     expect(deactivateCalled).toBe(false)
     expect(deactivateVm).toBe(null)
     expect(wrapper.vm.localActive).toBe(true)
-    
+
     updateCalled = false
     value = null
     activateCalled = false

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -272,7 +272,6 @@ describe('tab', async () => {
     expect(activateVm).toBe(null)
     expect(deactivateCalled).toBe(false)
     expect(deactivateVm).toBe(null)
-    expect(wrapper.vm.localActive).toBe(false)
 
     wrapper.setProps({ active: true })
 
@@ -282,7 +281,6 @@ describe('tab', async () => {
     expect(activateVm).toBe(wrapper.vm)
     expect(deactivateCalled).toBe(false)
     expect(deactivateVm).toBe(null)
-    expect(wrapper.vm.localActive).toBe(true)
 
     updateCalled = false
     value = null
@@ -297,6 +295,5 @@ describe('tab', async () => {
     expect(activateVm).toBe(null)
     expect(deactivateCalled).toBe(true)
     expect(deactivateVm).toBe(wrapper.vm)
-    expect(wrapper.vm.localActive).toBe(false)
   })
 })

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -45,7 +45,7 @@ describe('tab', async () => {
     const wrapper = mount(Tab, {
       propsData: { active: true }
     })
-    
+
     expect(wrapper.classes()).toContain('active')
     expect(wrapper.classes()).not.toContain('disabled')
     expect(wrapper.classes()).not.toContain('show')
@@ -60,7 +60,7 @@ describe('tab', async () => {
         disabled: true
       }
     })
-    
+
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes()).toContain('disabled')
     expect(wrapper.classes()).toContain('tab-pane')
@@ -71,7 +71,7 @@ describe('tab', async () => {
 
   it('has class active when localActive becomes true', async () => {
     const wrapper = mount(Tab)
-    
+
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes()).not.toContain('disabled')
     expect(wrapper.classes()).not.toContain('show')
@@ -89,7 +89,7 @@ describe('tab', async () => {
 
   it('emits event "update:active" when localActive becomes true', async () => {
     const wrapper = mount(Tab)
-    
+
     let called = false
     let value = null
     wrapper.$on('update:active', (val) => {
@@ -108,12 +108,14 @@ describe('tab', async () => {
 
   it('has class fade when parent has fade=true', async () => {
     const wrapper = mount(Tab, {
-      inject: {
-        bTabs: {
-          fade: true,
-          lazy: false,
-          card: false,
-          noKeyNav: true
+      provide () {
+        return {
+          bTabs: {
+            fade: true,
+            lazy: false,
+            card: false,
+            noKeyNav: true
+          }
         }
       }
     })
@@ -129,12 +131,14 @@ describe('tab', async () => {
 
   it('has class card-body when parent has card=true', async () => {
     const wrapper = mount(Tab, {
-      inject: {
-        bTabs: {
-          fade: false,
-          lazy: false,
-          card: true,
-          noKeyNav: true
+      provide () {
+        return {
+          bTabs: {
+            fade: false,
+            lazy: false,
+            card: true,
+            noKeyNav: true
+          }
         }
       }
     })
@@ -150,12 +154,14 @@ describe('tab', async () => {
 
   it('does not have class card-body when parent has card=true and prop no-body is set', async () => {
     const wrapper = mount(Tab, {
-      inject: {
-        bTabs: {
-          fade: false,
-          lazy: false,
-          card: true,
-          noKeyNav: true
+      provide () {
+        return {
+          bTabs: {
+            fade: false,
+            lazy: false,
+            card: true,
+            noKeyNav: true
+          }
         }
       },
       propsData: {
@@ -174,12 +180,14 @@ describe('tab', async () => {
 
   it('has attribute tabindex="0" when parent has keynav enabled', async () => {
     const wrapper = mount(Tab, {
-      inject: {
-        bTabs: {
-          fade: false,
-          lazy: false,
-          card: false,
-          noKeyNav: false
+      provide () {
+        return {
+          bTabs: {
+            fade: false,
+            lazy: false,
+            card: false,
+            noKeyNav: false
+          }
         }
       }
     })

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -366,14 +366,14 @@ describe('tab', async () => {
 
     // JSDOM doesnt support requestAnimationFrame
     // So it falls back to setTimeout.  So we advance the time
-    jest.runAllPendingTimers()
+    jest.runAllTimers()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.classes()).toContain('show')
     expect(wrapper.classes()).toContain('active')
 
     wrapper.setData({ localActive: false })
-    jest.runAllPendingTimers()
+    jest.runAllTimers()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.classes()).not.toContain('show')

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -195,4 +195,34 @@ describe('tab', async () => {
     expect(wrapper.attributes('tabindex')).toBeDefined()
     expect(wrapper.attributes('tabindex')).toBe('0')
   })
+
+  it('calls parent\'s updateButton() when title slot provided', async () => {
+    let called = false
+    let vm = null
+    const wrapper = mount(Tab, {
+      provide () {
+        return {
+          bTabs: {
+            fade: false,
+            lazy: false,
+            card: false,
+            noKeyNav: false,
+            updateButton(tab) {
+              called = true
+              vm = tab
+              return true
+            }
+          }
+        }
+      },
+      slots: {
+        default: '<b>foobar</b>'
+      }
+    })
+
+    wrapper.setData({ localActive: true })
+
+    expect(called).toBe(true)
+    expect(vm).toEqual(wrapper.vm)
+  })
 })

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -87,9 +87,7 @@ export default {
   name: 'BTabs',
   mixins: [idMixin],
   provide () {
-    return {
-      tabs: this
-    }
+    return { bTabs: this }
   },
   props: {
     tag: {
@@ -359,7 +357,7 @@ export default {
             },
             keydown: evt => {
               if (!this.noKeyNav && tab.localActive && !tab.disabled) {
-                this.onKeyNav(evt)
+                this.onKeynav(evt)
               }
             }
           }

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -257,15 +257,29 @@ export default {
     // Force a button to re-render it's content, given a b-tab instance
     // Called by b-tab on update()
     updateButton (tab) {
-      const index = this.tabs.indexOf(tab)
-      const button = this.$refs.buttons[index]
+      const button = this.$refs.buttons[this.tabs.indexOf(tab)]
       if (button) {
         button.$forceUpdate()
       }
     },
-    focusButton (index) {
-      // Focus a tab button given it's index
-      const button = this.$refs.buttons[index]
+    // Activate a tab given a b-tab instance
+    // Also accessed by b-tab
+    activateTab (tab) {
+      if (tab) {
+        if (tab.disabled) {
+          return false
+        } else {
+          const index = this.tabs.indexOf(tab)
+          this.currentTab = index
+          return index > -1
+        }
+      } else {
+        return false
+      }
+    },
+    // Focus a tab button given it's b-tab instance
+    focusButton (tab) {
+      const button = this.$refs.buttons[this.tabs.indexOf(tab)]
       if (button && button.focus) {
         button.focus()
       }
@@ -299,22 +313,21 @@ export default {
     },
     // Move to first non-disabled tab
     firstTab (focus) {
-      const tabs = this.tabs
-      const index = tabs.indexOf(tabs.find(tab => !tab.disabled))
-      this.currentTab = index
+      const tab = this.tabs.find(tab => !tab.disabled)
+      this.activateTab(tab)
       if (focus) {
-        this.focusButton(index)
+        this.focusButton(tab)
       }
     },
     // Move to previous non-disabled tab
     previousTab (focus) {
       const currentIndex = Math.max(this.currentTab, 0)
-      const tabs = this.tabs.slice(0, currentIndex)
-      const index = tabs.lastIndexOf(tabs.find(tab => !tab.disabled))
-      if (index > -1) {
-        this.currentTab = index
+      const tabs = this.tabs.slice(0, currentIndex).reverse()
+      const tab = tabs.find(tab => !tab.disabled)
+      if (tab) {
+        this.activateTab(tab)
         if (focus) {
-          this.focusButton(index)
+          this.focusButton(tab)
         }
       } else {
         this.$emit('input', this.currentTab)
@@ -323,12 +336,11 @@ export default {
     // Move to next non-disabled tab
     nextTab (focus) {
       const currentIndex = Math.max(this.currentTab, -1)
-      const tabs = this.tabs
-      const index = tabs.indexOf(tabs.slice(currentIndex + 1).find(tab => !tab.disabled))
-      if (index > -1) {
-        this.currentTab = index
+      const tab = this.tabs.slice(currentIndex + 1).find(tab => !tab.disabled)
+      if (tab) {
+        this.activateTab(tab)
         if (focus) {
-          this.focusButton(index)
+          this.focusButton(tab)
         }
       } else {
         this.$emit('input', this.currentTab)
@@ -336,11 +348,10 @@ export default {
     },
     // Move to last non-disabled tab
     lastTab (focus) {
-      const tabs = this.tabs
-      const index = tabs.indexOf(tabs.slice().reverse().find(tab => !tab.disabled))
-      this.currentTab = index
+      const tab = this.tabs.slice().reverse().find(tab => !tab.disabled)
+      this.activateTab(tab)
       if (focus) {
-        this.focusButton(index)
+        this.focusButton(tab)
       }
     }
   },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -196,9 +196,9 @@ export default {
       } else {
         // Try next/prev tabs
         if (val < old) {
-          this.nextTab()
-        } else {
           this.previousTab()
+        } else {
+          this.nextTab()
         }
       }
     }
@@ -312,10 +312,12 @@ export default {
       const tabs = this.tabs.slice(0, currentIndex)
       const index = tabs.lastIndexOf(tabs.find(tab => !tab.disabled))
       if (index > -1) {
-        this.currentTab = currentIndex - 1 - index
+        this.currentTab = index
         if (focus) {
           this.focusButton(index)
         }
+      } else {
+        this.$emit('input', this.currentTab)
       }
     },
     // Move to next non-disabled tab
@@ -328,6 +330,8 @@ export default {
         if (focus) {
           this.focusButton(index)
         }
+      } else {
+        this.$emit('input', this.currentTab)
       }
     },
     // Move to last non-disabled tab

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -102,6 +102,9 @@ const BTabButtonHelper = {
   }
 }
 
+// Filter function to filter out disabled tabs
+const notDisabled = tab => !tab.disabled
+
 // @vue/component
 export default {
   name: 'BTabs',
@@ -249,7 +252,7 @@ export default {
         const currentTab = this.currentTab
         if (currentTab >= tabs.length) {
           // Handle last tab being removed, so find the last non-disabled tab
-          tabIndex = tabs.indexOf(tabs.slice().reverse().find(tab => !tab.disabled))
+          tabIndex = tabs.indexOf(tabs.slice().reverse().find(notDisabled))
         } else if (tabs[currentTab] && !tabs[currentTab].disabled) {
           // current tab is not disabled
           tabIndex = currentTab
@@ -258,7 +261,7 @@ export default {
 
       // Else find *first* non-disabled tab in current tabs
       if (tabIndex < 0) {
-        tabIndex = tabs.indexOf(tabs.find(tab => !tabs.disabled))
+        tabIndex = tabs.indexOf(tabs.find(notDisabled))
       }
 
       // Set the current tab state to active
@@ -271,12 +274,15 @@ export default {
       // Set the currentTab index (can be -1 if no non-disabled tabs)
       this.currentTab = tabIndex
     },
+    // Find a button taht controls a tab, given the tab reference
+    // Returns the button vm instance
+    getButtonForTab (tab) {
+      return = (this.$refs.buttons || []).find(btn => btn.tab === tab)
+    },
     // Force a button to re-render it's content, given a b-tab instance
     // Called by b-tab on update()
     updateButton (tab) {
-      console.log('b-tabs received button update request for tab', tab)
-      const button = this.$refs.buttons[this.tabs.indexOf(tab)]
-      console.log('b-tabs update button', button)
+      const button = this.getButtonForTab(tab)
       if (button && button.$forceUpdate) {
         button.$forceUpdate()
       }
@@ -298,14 +304,14 @@ export default {
     },
     // Focus a tab button given it's b-tab instance
     focusButton (tab) {
-      const button = this.$refs.buttons[this.tabs.indexOf(tab)]
+      const button = this.getButtonForTab(tab)
       if (button && button.focus) {
         button.focus()
       }
     },
     // Move to first non-disabled tab
     firstTab (focus) {
-      const tab = this.tabs.find(tab => !tab.disabled)
+      const tab = this.tabs.find(notDisabled)
       this.activateTab(tab)
       if (focus) {
         this.focusButton(tab)
@@ -315,7 +321,7 @@ export default {
     previousTab (focus) {
       const currentIndex = Math.max(this.currentTab, 0)
       const tabs = this.tabs.slice(0, currentIndex).reverse()
-      const tab = tabs.find(tab => !tab.disabled)
+      const tab = tabs.find(notDisabled)
       if (tab) {
         this.activateTab(tab)
         if (focus) {
@@ -328,7 +334,7 @@ export default {
     // Move to next non-disabled tab
     nextTab (focus) {
       const currentIndex = Math.max(this.currentTab, -1)
-      const tab = this.tabs.slice(currentIndex + 1).find(tab => !tab.disabled)
+      const tab = this.tabs.slice(currentIndex + 1).find(notDisabled)
       if (tab) {
         this.activateTab(tab)
         if (focus) {
@@ -340,7 +346,7 @@ export default {
     },
     // Move to last non-disabled tab
     lastTab (focus) {
-      const tab = this.tabs.slice().reverse().find(tab => !tab.disabled)
+      const tab = this.tabs.slice().reverse().find(notDisabled)
       this.activateTab(tab)
       if (focus) {
         this.focusButton(tab)

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -18,9 +18,12 @@ const BTabButtonHelper = {
   },
   methods: {
     focus () {
-      if (this.$refs.link && this.refs.link.focus) {
-        this.$refs.link.focus()
-      }
+      // wrap in nextTick to ensure DOM has completed rendering
+      this.$nextTick(() => {
+        if (this.$refs && this.$refs.link && this.refs.link.focus) {
+          this.$refs.link.focus()
+        }
+      })
     },
     handleEvt (evt) {
       function stop () {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -18,7 +18,9 @@ const BTabButtonHelper = {
   },
   methods: {
     focus () {
+      console.log('Btn Focus...', this)
       if (this.$refs && this.$refs.link && this.refs.link.focus) {
+        console.log('Btn Focus $refs', this.$refs)
         this.$refs.link.focus()
       }
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -279,7 +279,7 @@ export default {
     // Find a button taht controls a tab, given the tab reference
     // Returns the button vm instance
     getButtonForTab (tab) {
-      return = (this.$refs.buttons || []).find(btn => btn.tab === tab)
+      return (this.$refs.buttons || []).find(btn => btn.tab === tab)
     },
     // Force a button to re-render it's content, given a b-tab instance
     // Called by b-tab on update()

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -199,7 +199,7 @@ export default {
       if (val === old) {
         return
       }
-      // Ensure only one tab is active
+      // Ensure only one tab is active at most
       this.tabs.forEach((tab, idx) => {
         tab.localActive = val === idx && !tab.disabled
       })
@@ -302,6 +302,21 @@ export default {
         }
       } else {
         return false
+      }
+    },
+    // Deactivate a tab given a b-tab instance
+    // Accessed by b-tab
+    deactivateTab (tab) {
+      if (tab) {
+        // Find first non-disabled tab that isn't the one being deactivated
+        const newTab = this.tabs.filter(t => t !== tab).find(notDisabled)
+        if (newTab) {
+          // activate found tab
+          this.activateTab(newTab)
+        } else {
+          // No tab to show
+          this.currentTab = -1
+        }
       }
     },
     // Focus a tab button given it's b-tab instance

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -31,8 +31,7 @@ const BTabButtonHelper = {
         ],
         props: {
           href: this.href, // To be deprecated to always be '#'
-          disabled: this.disabled,
-          active: this.active
+          disabled: this.disabled
         },
         attrs: {
           role: 'tab',
@@ -71,10 +70,13 @@ const BTabButtonHelper = {
       if (this.disabled) {
         return
       }
-      if (evt.type === 'click' || (evt.keyCode === KeyCodes.SPACE && !this.noKeyNav)) {
+      if (
+        evt.type === 'click' ||
+        (!this.noKeyNav && evt.type === 'keydown' && evt.keyCode === KeyCodes.SPACE)
+      ) {
         stop()
         this.$emit('click', evt)
-      } else if (evt.type === 'keydown' && this.active && !this.noKeyNav) {
+      } else if (evt.type === 'keydown' && !this.noKeyNav) {
         // for keyboard navigation
         this.$emit('keydown', evt)
       }
@@ -268,6 +270,9 @@ export default {
     },
     // handle keyboard navigation
     onKeynav (evt) {
+      if (!this.nokeyNav) {
+        return
+      }
       const key = evt.keyCode
       const shift = evt.shiftKey
       function stop () {
@@ -304,25 +309,29 @@ export default {
       const currentIndex = Math.max(this.currentTab, 0)
       const tabs = this.tabs.slice(0, currentIndex)
       const index = tabs.lastIndexOf(tabs.find(tab => !tab.disabled))
-      this.currentTab = currentIndex - 1 - index
-      if (focus) {
-        this.focusButton(index)
+      if (index > -1) {
+        this.currentTab = currentIndex - 1 - index
+        if (focus) {
+          this.focusButton(index)
+        }
       }
     },
     // Move to next non-disabled tab
     nextTab (focus) {
       const currentIndex = Math.max(this.currentTab, -1)
       const tabs = this.tabs
-      const index = tabs.indexOf(tabs.find(tab => !tab.disabled), currentIndex + 1)
-      this.currentTab = index
-      if (focus) {
-        this.focusButton(index)
+      const index = tabs.indexOf(tabs.slice(currentIndex + 1).find(tab => !tab.disabled))
+      if (index > -1) {
+        this.currentTab = index
+        if (focus) {
+          this.focusButton(index)
+        }
       }
     },
     // Move to last non-disabled tab
     lastTab (focus) {
       const tabs = this.tabs
-      const index = tabs.lastIndexOf(tabs.find(tab => !tab.disabled))
+      const index = tabs.indexOf(tabs.slice().reverse().find(tab => !tab.disabled))
       this.currentTab = index
       if (focus) {
         this.focusButton(index)
@@ -356,7 +365,7 @@ export default {
               this.currentTab = index
             },
             keydown: evt => {
-              if (!this.noKeyNav && tab.localActive && !tab.disabled) {
+              if (!this.noKeyNav && !tab.disabled) {
                 this.onKeynav(evt)
               }
             }

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -18,9 +18,7 @@ const BTabButtonHelper = {
   },
   methods: {
     focus () {
-      console.log('Btn Focus...', this)
-      if (this.$refs && this.$refs.link && this.refs.link.focus) {
-        console.log('Btn Focus $refs', this.$refs)
+      if (this.$refs && this.$refs.link && this.$refs.link.focus) {
         this.$refs.link.focus()
       }
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -274,8 +274,10 @@ export default {
     // Force a button to re-render it's content, given a b-tab instance
     // Called by b-tab on update()
     updateButton (tab) {
+      console.log('b-tabs received button update request for tab', tab)
       const button = this.$refs.buttons[this.tabs.indexOf(tab)]
-      if (button) {
+      console.log('b-tabs update button', button)
+      if (button && button.$forceUpdate) {
         button.$forceUpdate()
       }
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -15,6 +15,7 @@ const BTabButtonHelper = {
     id: { type: String, default: null },
     active: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
+    tabIndex: { type: Boolean, default: null },
     linkClass: { default: null },
     itemClass: { default: null },
     noKeyNav: { type: Boolean, default: false }
@@ -37,7 +38,7 @@ const BTabButtonHelper = {
           role: 'tab',
           id: this.id,
           // Roving tab index when keynav enabled
-          tabindex: this.noKeyNav ? null : (this.active ? null : '-1'),
+          tabindex: this.tabIndex,
           'aria-selected': this.active ? 'true' : 'false',
           'aria-setsize': this.setSize,
           'aria-posinset': this.posInSet,
@@ -343,8 +344,21 @@ export default {
   render (h) {
     const tabs = this.tabs
     // Navigation 'buttons'
+    let activeTab = tabs.find(tab => tab.localActive && !tab.disabled)
+    const fallbackTab = tabs.find(tab => !tab.disabled)
+    // For each b-tab found
     const buttons = tabs.map((tab, index) => {
       const buttonId = tab.controlledBy || this.safeId(`_BV_tab_${index + 1}_`)
+      let tabindex = null
+      // Ensure at least one tab button is focusable when keynav enabled (if possible)
+      if (!this.noKeyNav) {
+        // buttons are not in tab index unless active, or a fallback tab
+        tabindex = '-1'
+        if (activeTab === tab || (!activeTab && fallbackTab === tab)) {
+          // Place tab button in tab sequence
+          tabindex = null
+        }
+      }
       return h(
         BTabButtonHelper,
         {
@@ -353,6 +367,7 @@ export default {
           props: {
             href: tab.href, // To be deprecated to be always '#'
             id: buttonId,
+            tabIndex: tabindex,
             active: tab.localActive && !tab.disabled,
             disabled: tab.disabled,
             setSize: tabs.length,

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -316,7 +316,7 @@ export default {
         return this.activateTab(this.tabs.filter(t => t !== tab).find(notDisabled))
       } else {
         // No tab specified
-        reutrn false
+        return false
       }
     },
     // Focus a tab button given it's b-tab instance

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -188,16 +188,18 @@ export default {
         return
       }
       val = parseInt(val, 10)
+      old = parseInt(old, 10) || 0
       const tabs = this.tabs
       const currentIndex = this.currentTab
       if (tabs[val] && !tabs[val].disabled) {
         this.currentTab = val
-      } else if (tabs[currentIndex] && !tabs[currentIndex].disabled) {
-        // Stick with current tab, so update-v-model
-        this.$emit('input', this.currentTab)
       } else {
-        // Tab not available
-        this.currentTab = -1
+        // Try next/prev tabs
+        if (val < old) {
+          this.nextTab()
+        } else {
+          this.previousTab()
+        }
       }
     }
   },
@@ -270,7 +272,7 @@ export default {
     },
     // handle keyboard navigation
     onKeynav (evt) {
-      if (!this.nokeyNav) {
+      if (this.nokeyNav) {
         return
       }
       const key = evt.keyCode
@@ -443,7 +445,10 @@ export default {
       this.tag,
       {
         staticClass: 'tabs',
-        class: { row: this.vertical, 'no-gutters': this.vertical && this.card },
+        class: {
+          row: this.vertical, 
+          'no-gutters': this.vertical && this.card
+        },
         attrs: { id: this.safeId() }
       },
       [

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -191,7 +191,6 @@ export default {
       val = parseInt(val, 10)
       old = parseInt(old, 10) || 0
       const tabs = this.tabs
-      const currentIndex = this.currentTab
       if (tabs[val] && !tabs[val].disabled) {
         this.currentTab = val
       } else {
@@ -461,7 +460,7 @@ export default {
       {
         staticClass: 'tabs',
         class: {
-          row: this.vertical, 
+          row: this.vertical,
           'no-gutters': this.vertical && this.card
         },
         attrs: { id: this.safeId() }

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -78,7 +78,7 @@ const BTabButtonHelper = {
         stop()
         this.$emit('click', evt)
       } else if (evt.type === 'keydown' && !this.noKeyNav) {
-        // for keyboard navigation
+        // For keyboard navigation
         this.$emit('keydown', evt)
       }
     }
@@ -249,9 +249,9 @@ export default {
         tab.localActive = idx === tabIndex && !tab.disabled
       })
 
-      // update the array of tab children
+      // Update the array of tab children
       this.tabs = tabs
-      // Set teh currentTab index (can be -1 if no non-disabled tabs)
+      // Set the currentTab index (can be -1 if no non-disabled tabs)
       this.currentTab = tabIndex
     },
     // Force a button to re-render it's content, given a b-tab instance
@@ -366,7 +366,7 @@ export default {
       let tabindex = null
       // Ensure at least one tab button is focusable when keynav enabled (if possible)
       if (!this.noKeyNav) {
-        // buttons are not in tab index unless active, or a fallback tab
+        // Buttons are not in tab index unless active, or a fallback tab
         tabindex = '-1'
         if (activeTab === tab || (!activeTab && fallbackTab === tab)) {
           // Place tab button in tab sequence

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -37,7 +37,7 @@ const BTabButtonHelper = {
           role: 'tab',
           id: this.id,
           // Roving tab index when keynav enabled
-          tabindex: this.noKeyNav ? null : (this.active ? '0' : '-1'),
+          tabindex: this.noKeyNav ? null : (this.active ? null : '-1'),
           'aria-selected': this.active ? 'true' : 'false',
           'aria-setsize': this.setSize,
           'aria-posinset': this.posInSet,

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -195,6 +195,7 @@ export default {
   },
   watch: {
     currentTab (val, old) {
+      /* istanbul ignore if */
       if (val === old) {
         return
       }
@@ -205,6 +206,7 @@ export default {
       this.$emit('input', val)
     },
     value (val, old) {
+      /* istanbul ignore if */
       if (val === old) {
         return
       }

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -370,6 +370,8 @@ export default {
         {
           key: buttonId || index,
           ref: 'buttons',
+          // Needed to make this.$refs.buttons an array
+          refInFor: true,
           props: {
             tab: tab,
             id: buttonId,

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -67,7 +67,7 @@ const BTabButtonHelper = {
         ref: 'link',
         staticClass: 'nav-link',
         class: [
-          { 
+          {
             active: this.tab.localActive && !this.tab.disabled,
             disabled: this.tab.disabled
           },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -103,7 +103,7 @@ const BTabButtonHelper = {
 }
 
 // Filter function to filter out disabled tabs
-function notDisabled (tab) { 
+function notDisabled (tab) {
   return !tab.disabled
 }
 
@@ -332,7 +332,7 @@ export default {
     // Move to first non-disabled tab
     firstTab (focus) {
       const tab = this.tabs.find(notDisabled)
-      if (this.activateTab(tab) && focus) {        
+      if (this.activateTab(tab) && focus) {
         this.focusButton(tab)
       }
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -311,11 +311,12 @@ export default {
         // Find first non-disabled tab that isn't the one being deactivated
         const newTab = this.tabs.filter(t => t !== tab).find(notDisabled)
         if (newTab) {
-          // activate found tab
+          // Activate found tab (which will deactivate calling tab)
           this.activateTab(newTab)
+          return true
         } else {
-          // No tab to show
-          this.currentTab = -1
+          // No tab to fall back to
+          return false
         }
       }
     },


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Description of Pull Request:

- [x] Probes `this.$slots.default` to determine render order of child tab components (as `this.$children` doesn't guarantee node order)
- [x] Add lazy prop to `b-tab`, to allow individual tabs to be lazy rendered (b-tabs lazy prop takes precedence if true). a lazy tab will not render its default slot when not active but the b-tab wrapper elements will always be rendered to allow for transitions to work correctly.
- [x] Better reactivity of tab title slot
- [x] Better reactivity of tab title prop
- [x] Switches to `provide` and `inject`, rather than using `this.$parent` for parent-child communication.
- [x] Add `activate()` public method to `b-tab` component (if tab isn't disabled, it will set this tab as active)
- [x] Add `deactivate()` public method to `b-tab` component (deactivating will activate the first non-disabled tab)
- [x] handles b-tab being dynamically disabled after mount
- [x] Switch to roving tabindex method for keynav
- [x] Better ARIA compliance when keynav enabled, by adding `tabindex="0"` to the active tab so that screen reader users can focus the actively disaplayed tab so that it can be read by screen readers.
- [x] Additional units tests

Fixes: #2327
Fixes: #2148
Closes: #2403
Closes: #2180 

Users (web authors) must also realize that tabs' controls are (or act like) buttons.  One cannot place form controls inside a button/link per HTML/HTML5 standards.  Stop trying to do this! :stuck_out_tongue_closed_eyes: 


## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact:


**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [ ] The PR should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos", "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**
- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives 
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's description above includes:**
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
