### PR TITLE
fix(tabs): `tabIndex` prop type

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -11,7 +11,7 @@ const BTabButtonHelper = {
     tab: { default: null, required: true },
     id: { type: String, default: null },
     controls: { type: String, default: null },
-    tabIndex: { type: Boolean, default: null },
+    tabIndex: { type: Number, default: -1 },
     posInSet: { type: Number, default: null },
     setSize: { type: Number, default: null },
     noKeyNav: { type: Boolean, default: false }

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -11,7 +11,7 @@ const BTabButtonHelper = {
     tab: { default: null, required: true },
     id: { type: String, default: null },
     controls: { type: String, default: null },
-    tabIndex: { type: Number, default: -1 },
+    tabIndex: { type: Number, default: null },
     posInSet: { type: Number, default: null },
     setSize: { type: Number, default: null },
     noKeyNav: { type: Boolean, default: false }
@@ -390,14 +390,14 @@ export default {
     // For each b-tab found create teh tab buttons
     const buttons = tabs.map((tab, index) => {
       const buttonId = tab.controlledBy || this.safeId(`_BV_tab_${index + 1}_`)
-      let tabindex = null
+      let tabIndex = null
       // Ensure at least one tab button is focusable when keynav enabled (if possible)
       if (!this.noKeyNav) {
         // Buttons are not in tab index unless active, or a fallback tab
-        tabindex = '-1'
+        tabIndex = -1
         if (activeTab === tab || (!activeTab && fallbackTab === tab)) {
           // Place tab button in tab sequence
-          tabindex = null
+          tabIndex = null
         }
       }
       return h(BTabButtonHelper, {
@@ -409,7 +409,7 @@ export default {
           tab: tab,
           id: buttonId,
           controls: this.safeId('_BV_tab_container_'),
-          tabIndex: tabindex,
+          tabIndex,
           setSize: tabs.length,
           posInSet: index + 1,
           noKeyNav: this.noKeyNav


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

This PR corrects the type of the `tabIndex` property form `Boolean` to `Number`.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
