### PR TITLE
fix(dropdown): focus menu container before emitting shown event. Closes #2520

### DIFF
--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -196,10 +196,14 @@ export default {
       }
 
       this.whileOpenListen(true)
-      this.$emit('shown')
-
-      // Focus on the menu container on show
-      this.$nextTick(this.focusMenu)
+      
+      // Wrap in nextTick to ensure menu is fully rendered/shown
+      this.$nextTick(() => {
+        // Focus on the menu container on show
+        this.focusMenu()
+        // Emit the shown event
+        this.$emit('shown')
+      })
     },
     hideMenu() {
       this.whileOpenListen(false)

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -196,7 +196,7 @@ export default {
       }
 
       this.whileOpenListen(true)
-      
+
       // Wrap in nextTick to ensure menu is fully rendered/shown
       this.$nextTick(() => {
         // Focus on the menu container on show


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

Change ordering of `shown` event and focusMenu method.

Focuses the menu container before emitting the `shown` event, so that users can optionally focus a menu item (or form input) once shown.

Closes #2520

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
