### PR TITLE
fix(tabs): Emit click on b-tab instance when button clicked. Fixes #2512

### DIFF
--- a/src/components/tabs/package.json
+++ b/src/components/tabs/package.json
@@ -31,6 +31,18 @@
       },
       { 
         "component": "BTab",
+        "events": [
+          {
+            "event": "click",
+            "description": "Emited when a tab is clicked, or is activated by keyboard navigation",
+            "args": [
+              { 
+                "arg": "evt",
+                "description": "Original event object"
+              }
+            ]
+          }
+        ],
         "slots": [
           {
             "name": "title",

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -345,7 +345,7 @@ export default {
     },
     // Emit a click event on a specified b-tab component instance
     emitTabClick(tab, evt) {
-      if (evt && (evt instanceof Event) && tab && tab.$emit && !tab.disabled) {
+      if (evt && evt instanceof Event && tab && tab.$emit && !tab.disabled) {
         tab.$emit('click', evt)
       }
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -351,7 +351,7 @@ export default {
     },
     // Click Handler
     clickTab(tab, evt) {
-      this.activateTab(tab))
+      this.activateTab(tab)
       this.emitTabClick(tab, evt)
     },
     // Move to first non-disabled tab

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -343,11 +343,23 @@ export default {
         }
       })
     },
+    // Emit a click event on a specified b-tab component instance
+    emitTabClick(tab, evt) {
+      if (evt && (evt instanceof Event) && tab && tab.$emit && !tab.disabled) {
+        tab.$emit('click', evt)
+      }
+    },
+    // Click Handler
+    clickTab(tab, evt) {
+      this.activateTab(tab))
+      this.emitTabClick(tab, evt)
+    },
     // Move to first non-disabled tab
     firstTab(focus) {
       const tab = this.tabs.find(notDisabled)
       if (this.activateTab(tab) && focus) {
         this.focusButton(tab)
+        this.emitTabClick(tab, focus)
       }
     },
     // Move to previous non-disabled tab
@@ -359,6 +371,7 @@ export default {
         .find(notDisabled)
       if (this.activateTab(tab) && focus) {
         this.focusButton(tab)
+        this.emitTabClick(tab, focus)
       }
     },
     // Move to next non-disabled tab
@@ -367,6 +380,7 @@ export default {
       const tab = this.tabs.slice(currentIndex + 1).find(notDisabled)
       if (this.activateTab(tab) && focus) {
         this.focusButton(tab)
+        this.emitTabClick(tab, focus)
       }
     },
     // Move to last non-disabled tab
@@ -377,6 +391,7 @@ export default {
         .find(notDisabled)
       if (this.activateTab(tab) && focus) {
         this.focusButton(tab)
+        this.emitTabClick(tab, focus)
       }
     }
   },
@@ -416,7 +431,7 @@ export default {
         },
         on: {
           click: evt => {
-            this.activateTab(tab)
+            this.clickTab(tab, evt)
           },
           first: this.firstTab,
           prev: this.previousTab,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

When a non-disabled tab button is clicked (or keyboard nav activates tab), emits a `click` event on the respective `b-tab` component instance.  Passes the event object as the first argument.

Fixes #2512

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
