### PR TITLE
perf(progress): use provide and inject for inter component communication

### DIFF
--- a/src/components/progress/progress-bar.js
+++ b/src/components/progress/progress-bar.js
@@ -3,6 +3,14 @@ import { htmlOrText } from '../../utils/html'
 // @vue/component
 export default {
   name: 'BProgressBar',
+  inject: {
+    progress: {
+      from: 'progress',
+      default: function() {
+        return {}
+      }
+    }
+  },
   props: {
     value: {
       type: Number,
@@ -49,7 +57,6 @@ export default {
   computed: {
     progressBarClasses() {
       return [
-        'progress-bar',
         this.computedVariant ? `bg-${this.computedVariant}` : '',
         this.computedStriped || this.computedAnimated ? 'progress-bar-striped' : '',
         this.computedAnimated ? 'progress-bar-animated' : ''
@@ -60,39 +67,39 @@ export default {
         width: 100 * (this.value / this.computedMax) + '%'
       }
     },
-    progress() {
+    computedProgress() {
       const p = Math.pow(10, this.computedPrecision)
       return Math.round((100 * p * this.value) / this.computedMax) / p
     },
     computedMax() {
       // Prefer our max over parent setting
-      return typeof this.max === 'number' ? this.max : this.$parent.max || 100
+      return typeof this.max === 'number' ? this.max : this.progress.max || 100
     },
     computedVariant() {
       // Prefer our variant over parent setting
-      return this.variant || this.$parent.variant
+      return this.variant || this.progress.variant
     },
     computedPrecision() {
       // Prefer our precision over parent setting
-      return typeof this.precision === 'number' ? this.precision : this.$parent.precision || 0
+      return typeof this.precision === 'number' ? this.precision : this.progress.precision || 0
     },
     computedStriped() {
       // Prefer our striped over parent setting
-      return typeof this.striped === 'boolean' ? this.striped : this.$parent.striped || false
+      return typeof this.striped === 'boolean' ? this.striped : this.progress.striped || false
     },
     computedAnimated() {
       // Prefer our animated over parent setting
-      return typeof this.animated === 'boolean' ? this.animated : this.$parent.animated || false
+      return typeof this.animated === 'boolean' ? this.animated : this.progress.animated || false
     },
     computedShowProgress() {
       // Prefer our showProgress over parent setting
       return typeof this.showProgress === 'boolean'
         ? this.showProgress
-        : this.$parent.showProgress || false
+        : this.progress.showProgress || false
     },
     computedShowValue() {
       // Prefer our showValue over parent setting
-      return typeof this.showValue === 'boolean' ? this.showValue : this.$parent.showValue || false
+      return typeof this.showValue === 'boolean' ? this.showValue : this.progress.showValue || false
     }
   },
   render(h) {
@@ -102,13 +109,14 @@ export default {
     } else if (this.label || this.labelHTML) {
       childNodes = h('span', { domProps: htmlOrText(this.labelHTML, this.label) })
     } else if (this.computedShowProgress) {
-      childNodes = this.progress.toFixed(this.computedPrecision)
+      childNodes = this.computedProgress.toFixed(this.computedPrecision)
     } else if (this.computedShowValue) {
       childNodes = this.value.toFixed(this.computedPrecision)
     }
     return h(
       'div',
       {
+        staticClass: 'progress-bar',
         class: this.progressBarClasses,
         style: this.progressBarStyles,
         attrs: {

--- a/src/components/progress/progress.js
+++ b/src/components/progress/progress.js
@@ -4,6 +4,9 @@ import BProgressBar from './progress-bar'
 export default {
   name: 'BProgress',
   components: { BProgressBar },
+  provide() {
+    return { progress: this }
+  },
   props: {
     // These props can be inherited via the child b-progress-bar(s)
     variant: {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

Use `provide` and `inject` for better communication between progress and progress-bar

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
