### PR TITLE
chore(docs): dropdown $root events example.

### DIFF
--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -496,6 +496,21 @@ The `hide()` method accepts a single boolean argument. If the argument is `true`
 returned to the dropdown toggle button after the menu has closed. Otherwise the document will gain
 focus once the menu is closed.
 
+## Listening to dropdown changes via \$root events
+
+To listen to any dropdown opening, use:
+
+```js
+mounted() {
+  this.$root.$on('bv::dropdown::show', (bvEvent) => {
+    console.log('Dropdown is about to be shown', bvEvent)
+  })
+}
+```
+
+Refer to the [Events](/docs/components/dropdown#component-reference) section of documentation for the
+full list of events.
+
 ## Accessibility
 
 Providing a unique `id` prop ensures ARIA compliance by automatically adding the appropriate


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

Add example of $root events for dropdown. 

Closes #2514 

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
