### PR TITLE
feat(table): add support for scoped empty slots

### DIFF
--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -1001,10 +1001,10 @@ following properties:
 
 | Property            | Type   | Description                                        |
 | ------------------- | ------ | -------------------------------------------------- |
-| `emptyHtml`         | String | The `emptyHtml` prop                               |
-| `emptyText`         | String | The `emptyText` prop                               |
-| `emptyFilteredHtml` | String | The `emptyFilteredHtml` prop                       |
-| `emptyFilteredText` | String | The `emptyFilteredText` prop                       |
+| `emptyHtml`         | String | The `empty-html` prop                              |
+| `emptyText`         | String | The `empty-text` prop                              |
+| `emptyFilteredHtml` | String | The `empty-filtered-html` prop                     |
+| `emptyFilteredText` | String | The `empty-filtered-text` prop                     |
 | `fields`            | Array  | The `fields` prop                                  |
 | `items`             | Array  | The `items` prop. Exposed here to check null vs [] |
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -973,6 +973,42 @@ formatted value as a string (HTML strings are not supported)
 <!-- b-table-data-formatter.vue -->
 ```
 
+## Custom empty/emptyfiltered rendering via slots
+
+Aside from using `empty-text`, `empty-filtered-text`, `empty-html`, and `empty-filtered-html`, it is
+also possible to provide custom rendering for tables that have no data to display using named slots.
+
+In order for these slots to be shown, the `show-empty` attribute must be set and `items` must be
+either falsy or an array of length 0.
+
+
+```html
+<div>
+  <b-table :fields="fields" :items="items" show-empty>
+    <template slot="empty" slot-scope="scope">
+      <h4>{{ scope.emptyText }}</h4>
+    </template>
+    <template slot="emptyfiltered" slot-scope="scope">
+      <h4>{{ scope.emptyFilteredText }}</h4>
+    </template>
+  </b-table>
+</div>
+
+```
+
+The slot can optionally be scoped. The slot's scope (`scope` in the above example) will have the
+following properties:
+
+| Property            | Type   | Description                                        |
+| ------------------- | ------ | -------------------------------------------------- |
+| `emptyHtml`         | String | The `emptyHtml` prop                               |
+| `emptyText`         | String | The `emptyText` prop                               |
+| `emptyFilteredHtml` | String | The `emptyFilteredHtml` prop                       |
+| `emptyFilteredText` | String | The `emptyFilteredText` prop                       |
+| `fields`            | Array  | The `fields` prop                                  |
+| `items`             | Array  | The `items` prop. Exposed here to check null vs [] |
+
+
 ## Header/Footer custom rendering via scoped slots
 
 It is also possible to provide custom rendering for the tables `thead` and `tfoot` elements. Note by

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1154,6 +1154,12 @@ export default {
       ? h('colgroup', { key: 'colgroup' }, $slots['table-colgroup'])
       : h(false)
 
+    // Support scoped and unscoped slots when needed
+    const normalizeSlot = (slotName, slotScope = {}) => {
+      const slot = $scoped[slotName] || $slots[slotName]
+      return typeof slot === 'function' ? slot(slotScope) : slot
+    }
+
     // factory function for thead and tfoot cells (th's)
     const makeHeadCells = (isFoot = false) => {
       return fields.map((field, colIndex) => {
@@ -1473,7 +1479,14 @@ export default {
       (!items || items.length === 0) &&
       !($slots['table-busy'] && this.computedBusy)
     ) {
-      let empty = this.isFiltered ? $slots['emptyfiltered'] : $slots['empty']
+      let empty = normalizeSlot(this.isFiltered ? 'emptyfiltered' : 'empty', {
+        emptyFilteredHtml: this.emptyFilteredHtml,
+        emptyFilteredText: this.emptyFilteredText,
+        emptyHtml: this.emptyHtml,
+        emptyText: this.emptyText,
+        fields: fields,
+        items: items
+      })
       if (!empty) {
         empty = h('div', {
           class: ['text-center', 'my-2'],


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

The Table component "empty" slot isn't very flexible, as it must be a named slot and cannot be scoped (relates to https://github.com/bootstrap-vue/bootstrap-vue/issues/2206 which is explicitly part of core, see https://github.com/vuejs/vue/blob/4d4d22a3f6017c46d08b67afe46af43027b06629/src/core/instance/render-helpers/resolve-slots.js#L23), preventing the `b-table` component from being wrapped (relates to https://github.com/vuejs/vue/issues/7587). As a solution, I've taken a cue from  https://github.com/bootstrap-vue/bootstrap-vue/issues/2206#issuecomment-443336885 to add flexibility to the `empty` and `emptyfiltered` slots to support both unscoped and scoped slots, allowing the developer to have flexibility with the implementation needed.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [-] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [-] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
