### PR TITLE
feat(card-img-lazy): new card-img-lazy sub-component

### DIFF
--- a/docs/markdown/reference/images/README.md
+++ b/docs/markdown/reference/images/README.md
@@ -32,6 +32,7 @@ transformAssetUrls: {
   'b-img-lazy': ['src', 'blank-src'],
   'b-card': 'img-src',
   'b-card-img': 'img-src',
+  'b-card-img-lazy': ['src', 'blank-src'],
   'b-carousel-slide': 'img-src',
   'b-embed': 'src'
 }
@@ -68,6 +69,7 @@ module.exports = {
           'b-img-lazy': ['src', 'blank-src'],
           'b-card': 'img-src',
           'b-card-img': 'img-src',
+          'b-card-img-lazy': ['src', 'blank-src'],
           'b-carousel-slide': 'img-src',
           'b-embed': 'src'
         }
@@ -95,6 +97,7 @@ build: {
       'b-img-lazy': ['src', 'blank-src'],
       'b-card': 'img-src',
       'b-card-img': 'img-src',
+      'b-card-img-lazy': ['src', 'blank-src'],
       'b-carousel-slide': 'img-src',
       'b-embed': 'src'
     }

--- a/src/components/card/README.md
+++ b/src/components/card/README.md
@@ -44,7 +44,7 @@ following are examples of what’s supported inside a `<b-card>`
 The building block of a `<b-card>` is the `<b-card-body>` section which provides a padded section
 within a card.
 
-By default the `<b-card>` content is automatically placed in a`<b-card-body>` section:
+By default the `<b-card>` content is automatically placed in a `<b-card-body>` section:
 
 ```html
 <div>
@@ -115,9 +115,12 @@ Links can be added and placed next to each other by adding the `.card-link` clas
 
 ### Images
 
-The prop `img-src` places an image on the top of the card, and use the `img-alt` prop to specify a
-string to be placed in the image's `alt` attribute. The image specified by the `img-src` prop will
-be responsive and will adjust it's width when the width of the card is changed.
+The `<b-card>` prop `img-src` places an image on the top of the card, and use the `img-alt` prop to
+specify a string to be placed in the image's `alt` attribute. The image specified by the `img-src`
+prop will be responsive and will adjust it's width when the width of the card is changed.
+
+Alternatively you can manually place images inside `<b-card>` using the sub-component `<b-card-img>`.
+See the kitchen sink example below for usage.
 
 ```html
 <div>
@@ -184,6 +187,12 @@ Place the image in the background of the card by setting the boolean prop `overl
 
 <!-- b-card-overlay-img-.vue -->
 ```
+
+#### Lazy loaded images
+
+Use the `<b-card-img-lazy>` sub-component to lazy load images as they scroll into view.
+`<b-card-img-lazy>` supports the same props as `<b-card-img>` as well as many of the props of
+the [`<b-img-lazy>`](/docs/components/image#lazy-loaded-images) component.
 
 ### Header and footer
 

--- a/src/components/card/README.md
+++ b/src/components/card/README.md
@@ -119,8 +119,8 @@ The `<b-card>` prop `img-src` places an image on the top of the card, and use th
 specify a string to be placed in the image's `alt` attribute. The image specified by the `img-src`
 prop will be responsive and will adjust it's width when the width of the card is changed.
 
-Alternatively you can manually place images inside `<b-card>` using the sub-component `<b-card-img>`.
-See the kitchen sink example below for usage.
+Alternatively you can manually place images inside `<b-card>` using the sub-component
+`<b-card-img>`. See the kitchen sink example below for usage.
 
 ```html
 <div>
@@ -191,8 +191,8 @@ Place the image in the background of the card by setting the boolean prop `overl
 #### Lazy loaded images
 
 Use the `<b-card-img-lazy>` sub-component to lazy load images as they scroll into view.
-`<b-card-img-lazy>` supports the same props as `<b-card-img>` as well as many of the props of
-the [`<b-img-lazy>`](/docs/components/image#lazy-loaded-images) component.
+`<b-card-img-lazy>` supports the same props as `<b-card-img>` as well as many of the props of the
+[`<b-img-lazy>`](/docs/components/image#lazy-loaded-images) component.
 
 ### Header and footer
 

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -3,9 +3,10 @@ import { mergeData } from 'vue-functional-data-merge'
 
 // Copy of b-img-lazy props, and remove conflicting/non-applicable props
 const lazyProps = { ...BImgLazy.props }
-
 ;['left', 'right', 'center', 'block', 'rounded', 'thumbnail', 'fluid', 'fluidGrow'].forEach(
-  prop => { delete lazyProps[prop] }
+  prop => {
+    delete lazyProps[prop]
+  }
 )
 
 export const props = {

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -1,8 +1,20 @@
 import BImgLazy from '../image/img-lazy'
+import pluckProps from '../../utils/pluck-props'
 import { mergeData } from 'vue-functional-data-merge'
 
+// Copy of b-img-lazy props, and remove conflicting/non-applicable props
+const lazyProps = { ...BImgLazy.props }
+delete lazyProps.left
+delete lazyProps.right
+delete lazyProps.center
+delete lazyProps.block
+delete lazyProps.rounded
+delete lazyProps.thumbnail
+delete lazyProps.fluid
+delete lazyProps.fluidGrow
+
 export const props = {
-  ...BImgLazy.props,
+  ...lazyProps,
   top: {
     type: Boolean,
     default: false
@@ -48,11 +60,16 @@ export default {
       baseClass += '-left'
     }
 
+    // Remove the left/center/right props before passing to b-img-lazy
+    const lazyProps = { ...props }
+    delete lazyProps.left
+    delete lazyProps.right
+    delete lazyProps.center
     return h(
       BImgLazy,
       mergeData(data, {
         class: [baseClass],
-        props
+        props: lazyProps
       })
     )
   }

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -4,7 +4,7 @@ import { mergeData } from 'vue-functional-data-merge'
 // Copy of b-img-lazy props, and remove conflicting/non-applicable props
 const lazyProps = { ...BImgLazy.props }
 
-['left', 'right', 'center', 'block', 'rounded', 'thumbnail', 'fluid', 'fluidGrow'].forEach(
+;['left', 'right', 'center', 'block', 'rounded', 'thumbnail', 'fluid', 'fluidGrow'].forEach(
   prop => { delete lazyProps[prop] }
 )
 

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -3,18 +3,10 @@ import { mergeData } from 'vue-functional-data-merge'
 
 // Copy of b-img-lazy props, and remove conflicting/non-applicable props
 const lazyProps = { ...BImgLazy.props }
-[
-  'left',
-  'right',
-  'center',
-  'block',
-  'rounded',
-  'thumbnail',
-  'fluid',
-  'fluidGrow'
-].forEach(prop => {
-  delete lazyProps[prop]
-})
+
+['left', 'right', 'center', 'block', 'rounded', 'thumbnail', 'fluid', 'fluidGrow'].forEach(
+  prop => { delete lazyProps[prop] }
+)
 
 export const props = {
   ...lazyProps,

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -1,0 +1,59 @@
+import BImgLazy from '../image/img-lazy'
+import { mergeData } from 'vue-functional-data-merge'
+
+export const props = {
+  ...BImgLazy.props,
+  top: {
+    type: Boolean,
+    default: false
+  },
+  bottom: {
+    type: Boolean,
+    default: false
+  },
+  left: {
+    type: Boolean,
+    default: false
+  },
+  start: {
+    type: Boolean,
+    default: false
+    // alias of 'left'
+  },
+  right: {
+    type: Boolean,
+    default: false
+  },
+  end: {
+    type: Boolean,
+    default: false
+    // alias of 'right'
+  }
+}
+
+// @vue/component
+export default {
+  name: 'BCardImgLazy',
+  functional: true,
+  props,
+  render(h, { props, data }) {
+    let baseClass = 'card-img'
+    if (props.top) {
+      baseClass += '-top'
+    } else if (props.right || props.end) {
+      baseClass += '-right'
+    } else if (props.bottom) {
+      baseClass += '-bottom'
+    } else if (props.left || props.start) {
+      baseClass += '-left'
+    }
+
+    return h(
+      BImgLazy,
+      mergeData(data, {
+        class: [baseClass],
+        props
+      })
+    )
+  }
+}

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -1,13 +1,19 @@
 import BImgLazy from '../image/img-lazy'
+import { omit } from '../../utils/object'
 import { mergeData } from 'vue-functional-data-merge'
 
-// Copy of b-img-lazy props, and remove conflicting/non-applicable props
-const lazyProps = { ...BImgLazy.props }
-;['left', 'right', 'center', 'block', 'rounded', 'thumbnail', 'fluid', 'fluidGrow'].forEach(
-  prop => {
-    delete lazyProps[prop]
-  }
-)
+// Copy of `<b-img-lazy>` props, and remove conflicting/non-applicable props
+// The `omit()` util creates a new object, so we can just pass the original props
+const lazyProps = omit(BImgLazy.props, [
+  'left',
+  'right',
+  'center',
+  'block',
+  'rounded',
+  'thumbnail',
+  'fluid',
+  'fluidGrow'
+])
 
 export const props = {
   ...lazyProps,

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -3,14 +3,18 @@ import { mergeData } from 'vue-functional-data-merge'
 
 // Copy of b-img-lazy props, and remove conflicting/non-applicable props
 const lazyProps = { ...BImgLazy.props }
-delete lazyProps.left
-delete lazyProps.right
-delete lazyProps.center
-delete lazyProps.block
-delete lazyProps.rounded
-delete lazyProps.thumbnail
-delete lazyProps.fluid
-delete lazyProps.fluidGrow
+[
+  'left',
+  'right',
+  'center',
+  'block',
+  'rounded',
+  'thumbnail',
+  'fluid',
+  'fluidGrow'
+].forEach(prop => {
+  delete lazyProps[prop]
+})
 
 export const props = {
   ...lazyProps,
@@ -59,11 +63,8 @@ export default {
       baseClass += '-left'
     }
 
-    // Remove the left/center/right props before passing to b-img-lazy
-    const lazyProps = { ...props }
-    delete lazyProps.left
-    delete lazyProps.right
-    delete lazyProps.center
+    // False out the left/center/right props before passing to b-img-lazy
+    const lazyProps = { ...props, left: false, right: false, center: false }
     return h(
       BImgLazy,
       mergeData(data, {

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -1,5 +1,4 @@
 import BImgLazy from '../image/img-lazy'
-import pluckProps from '../../utils/pluck-props'
 import { mergeData } from 'vue-functional-data-merge'
 
 // Copy of b-img-lazy props, and remove conflicting/non-applicable props

--- a/src/components/card/card-img-lazy.spec.js
+++ b/src/components/card/card-img-lazy.spec.js
@@ -1,0 +1,156 @@
+import CardImgLazy from './card-img-lazy'
+import { mount } from '@vue/test-utils'
+
+describe('card-image', async () => {
+  it('default has tag "img"', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.is('img')).toBe(true)
+  })
+
+  it('default has src attribute', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.attributes('src')).toBe('https://picsum.photos/600/300/?image=25')
+  })
+
+  it('default does not have attributes alt, width, or height', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.attributes('alt')).not.toBeDefined()
+    expect(wrapper.attributes('width')).not.toBeDefined()
+    expect(wrapper.attributes('height')).not.toBeDefined()
+  })
+
+  it('default has class "card-img"', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-top" when prop top=true', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          top: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-top')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-bottom" when prop bottom=true', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          bottom: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-bottom')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-top" when props top=true and bottom=true', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          top: true,
+          bottom: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-top')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-left" when prop left=true', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          left: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-left')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has class "card-img-right" when prop right=true', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          right: true
+        }
+      }
+    })
+    expect(wrapper.classes()).toContain('card-img-right')
+    expect(wrapper.classes().length).toBe(1)
+  })
+
+  it('has attribute alt when prop alt set', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          alt: 'image'
+        }
+      }
+    })
+    expect(wrapper.attributes('alt')).toBeDefined()
+    expect(wrapper.attributes('alt')).toBe('image')
+  })
+
+  it('has attribute width when prop width set', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          width: '600'
+        }
+      }
+    })
+    expect(wrapper.attributes('width')).toBeDefined()
+    expect(wrapper.attributes('width')).toBe('600')
+  })
+
+  it('has attribute heigth when prop height set', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25',
+          height: '300'
+        }
+      }
+    })
+    expect(wrapper.attributes('height')).toBeDefined()
+    expect(wrapper.attributes('height')).toBe('300')
+  })
+})

--- a/src/components/card/card-img-lazy.spec.js
+++ b/src/components/card/card-img-lazy.spec.js
@@ -13,7 +13,7 @@ describe('card-image', async () => {
     expect(wrapper.is('img')).toBe(true)
   })
 
-  it('default has src attribute', async () => {
+  it('default has data src attribute', async () => {
     const wrapper = mount(CardImgLazy, {
       context: {
         props: {
@@ -21,10 +21,10 @@ describe('card-image', async () => {
         }
       }
     })
-    expect(wrapper.attributes('src')).toBe('https://picsum.photos/600/300/?image=25')
+    expect(wrapper.attributes('src')).toContain('data:image/svg+xml')
   })
 
-  it('default does not have attributes alt, width, or height', async () => {
+  it('default does not have alt attribute', async () => {
     const wrapper = mount(CardImgLazy, {
       context: {
         props: {
@@ -33,8 +33,20 @@ describe('card-image', async () => {
       }
     })
     expect(wrapper.attributes('alt')).not.toBeDefined()
-    expect(wrapper.attributes('width')).not.toBeDefined()
-    expect(wrapper.attributes('height')).not.toBeDefined()
+  })
+
+  it('default has attributes width and height set to 1', async () => {
+    const wrapper = mount(CardImgLazy, {
+      context: {
+        props: {
+          src: 'https://picsum.photos/600/300/?image=25'
+        }
+      }
+    })
+    expect(wrapper.attributes('width')).toBeDefined()
+    expect(wrapper.attributes('width')).toBe('1')
+    expect(wrapper.attributes('height')).toBeDefined()
+    expect(wrapper.attributes('height')).toBe('1')
   })
 
   it('default has class "card-img"', async () => {
@@ -46,7 +58,6 @@ describe('card-image', async () => {
       }
     })
     expect(wrapper.classes()).toContain('card-img')
-    expect(wrapper.classes().length).toBe(1)
   })
 
   it('has class "card-img-top" when prop top=true', async () => {
@@ -59,7 +70,6 @@ describe('card-image', async () => {
       }
     })
     expect(wrapper.classes()).toContain('card-img-top')
-    expect(wrapper.classes().length).toBe(1)
   })
 
   it('has class "card-img-bottom" when prop bottom=true', async () => {
@@ -72,7 +82,6 @@ describe('card-image', async () => {
       }
     })
     expect(wrapper.classes()).toContain('card-img-bottom')
-    expect(wrapper.classes().length).toBe(1)
   })
 
   it('has class "card-img-top" when props top=true and bottom=true', async () => {
@@ -86,7 +95,6 @@ describe('card-image', async () => {
       }
     })
     expect(wrapper.classes()).toContain('card-img-top')
-    expect(wrapper.classes().length).toBe(1)
   })
 
   it('has class "card-img-left" when prop left=true', async () => {
@@ -99,7 +107,6 @@ describe('card-image', async () => {
       }
     })
     expect(wrapper.classes()).toContain('card-img-left')
-    expect(wrapper.classes().length).toBe(1)
   })
 
   it('has class "card-img-right" when prop right=true', async () => {
@@ -112,7 +119,6 @@ describe('card-image', async () => {
       }
     })
     expect(wrapper.classes()).toContain('card-img-right')
-    expect(wrapper.classes().length).toBe(1)
   })
 
   it('has attribute alt when prop alt set', async () => {

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -5,6 +5,7 @@ import BCardTitle from './card-title'
 import BCardSubTitle from './card-sub-title'
 import BCardFooter from './card-footer'
 import BCardImg from './card-img'
+import BCardImgLazy from './card-img-lazy'
 import BCardText from './card-text'
 import BCardGroup from './card-group'
 import { registerComponents } from '../../utils/plugins'
@@ -17,6 +18,7 @@ const components = {
   BCardSubTitle,
   BCardFooter,
   BCardImg,
+  BCardImgLazy,
   BCardText,
   BCardGroup
 }

--- a/src/components/card/package.json
+++ b/src/components/card/package.json
@@ -11,6 +11,7 @@
       "BCardTitle",
       "BCardSubTitle",
       "BCardImg",
+      "BCardImgLazy",
       "BCardText",
       "BCardGroup"
     ],

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -66,6 +66,10 @@ export const create = Object.create
 export const isFrozen = Object.isFrozen
 export const is = Object.is
 
-export function readonlyDescriptor() {
-  return { enumerable: true, configurable: false, writable: false }
-}
+// @link https://gist.github.com/bisubus/2da8af7e801ffd813fab7ac221aa7afc
+export const omit = (obj, props) =>
+  Object.keys(obj)
+    .filter(key => props.indexOf(key) === -1)
+    .reduce((result, key) => ({ ...result, [key]: obj[key] }), {})
+
+export const readonlyDescriptor = () => ({ enumerable: true, configurable: false, writable: false })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

New helper sub-component `<b-card-img-lazy>` which provides most of the features of `<b-img-lazy>` but tailored for use in cards. `<b-card-img-lazy>` is a functional component wrapper for `<b-img-lazy>`

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
