### PR TITLE
feat(table): better default rendering of unformatted object values

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -8,6 +8,7 @@ import { keys } from '../../utils/object'
 import { arrayIncludes, isArray } from '../../utils/array'
 import { htmlOrText } from '../../utils/html'
 import { closest, matches } from '../../utils/dom'
+import fieldToString from '../../utils/to-string'
 import idMixin from '../../mixins/id'
 import listenOnRootMixin from '../../mixins/listen-on-root'
 
@@ -1335,10 +1336,10 @@ export default {
           } else {
             if (this.isStacked) {
               // We wrap in a DIV to ensure rendered as a single cell when visually stacked!
-              childNodes = [h('div', formatted)]
+              childNodes = [h('div', fieldToString(formatted))]
             } else {
               // Non stacked
-              childNodes = formatted
+              childNodes = fieldToString(formatted)
             }
           }
           // Render either a td or th cell

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -53,6 +53,7 @@ function toString(v) {
 // Stringifies the values of a record, ignoring any special top level field keys
 // TODO: add option to strigify formatted/scopedSlot items, and only specific fields
 function recToString(row) {
+  /* istanbul ignore if */
   if (!(row instanceof Object)) {
     return ''
   }
@@ -117,6 +118,7 @@ const EVENT_FILTER = [
 // Returns true of we should ignore the click/dbclick/keypress event
 // Avoids having the user need to use @click.stop on the form control
 function filterEvent(evt) {
+  /* istanbul ignore if */
   if (!evt || !evt.target) {
     return
   }
@@ -147,7 +149,7 @@ export default {
   props: {
     items: {
       type: [Array, Function],
-      default() {
+      default() /* istanbul ignore next */ {
         return []
       }
     },
@@ -533,6 +535,7 @@ export default {
           f.label = typeof f.label === 'string' ? f.label : startCase(f.key)
           return true
         }
+        /* istanbul ignore next */
         return false
       })
     },
@@ -569,6 +572,7 @@ export default {
         return filterFn
       } else if (typeof filter === 'function') {
         // Deprecate setting prop filter to a function
+        /* istanbul ignore next */
         return filter
       } else {
         // no filterFunction, so signal to use internal filter function
@@ -646,6 +650,7 @@ export default {
     },
     sortDesc(newVal, oldVal) {
       if (newVal === this.localSortDesc) {
+        /* istanbul ignore next */
         return
       }
       this.localSortDesc = newVal || false

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -74,6 +74,14 @@ export const is = Object.is
  */
 export const isObject = obj => obj !== null && typeof obj === 'object'
 
+/**
+ * Strict object type check. Only returns true
+ * for plain JavaScript objects.
+ */
+export const isPlainObject = obj => {
+  return Object.prototype.toString.call(obj) === '[object Object]'
+}
+
 // @link https://gist.github.com/bisubus/2da8af7e801ffd813fab7ac221aa7afc
 export const omit = (obj, props) =>
   Object.keys(obj)

--- a/src/utils/to-string.js
+++ b/src/utils/to-string.js
@@ -4,7 +4,7 @@ import { isPlainObject } from './object'
 /**
  * Convert a value to a string that can be rendered.
  */
-export default (val) => {
+export default val => {
   return val === null || val === undefined
     ? ''
     : isArray(val) || (isPlainObject(val) && val.toString === Object.prototype.toString)

--- a/src/utils/to-string.js
+++ b/src/utils/to-string.js
@@ -4,10 +4,10 @@ import { isPlainObject } from './object'
 /**
  * Convert a value to a string that can be rendered.
  */
-export default val => {
+export default (val, spaces = 2) => {
   return val === null || val === undefined
     ? ''
     : isArray(val) || (isPlainObject(val) && val.toString === Object.prototype.toString)
-      ? JSON.stringify(val, null, 2)
+      ? JSON.stringify(val, null, spaces)
       : String(val)
 }

--- a/src/utils/to-string.js
+++ b/src/utils/to-string.js
@@ -4,7 +4,7 @@ import { isPlainObject } from './object'
 /**
  * Convert a value to a string that can be rendered.
  */
-export default = val => {
+export default (val) => {
   return val === null || val === undefined
     ? ''
     : isArray(val) || (isPlainObject(val) && val.toString === Object.prototype.toString)

--- a/src/utils/to-string.js
+++ b/src/utils/to-string.js
@@ -1,0 +1,13 @@
+import { isArray } from './array'
+import { isPlainObject } from './object'
+
+/**
+ * Convert a value to a string that can be rendered.
+ */
+export default function toString (val) {
+  return val === null || val === undefined
+    ? ''
+    : isArray(val) || (isPlainObject(val) && val.toString === Object.prototype.toString)
+      ? JSON.stringify(val, null, 2)
+      : String(val)
+}

--- a/src/utils/to-string.js
+++ b/src/utils/to-string.js
@@ -4,7 +4,7 @@ import { isPlainObject } from './object'
 /**
  * Convert a value to a string that can be rendered.
  */
-export default function toString (val) {
+export default = val => {
   return val === null || val === undefined
     ? ''
     : isArray(val) || (isPlainObject(val) && val.toString === Object.prototype.toString)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

When b-table encounters an object (including Arrays) as a field value, and no formatter or field scoped slot is provided, a blank value is typically rendered in the field cell:

```js
      items: [
        { age: 40, name: { first: 'Dickerson', last: 'Macdonald' } },
        { age: 21, name: { first: 'Larsen', last: 'Shaw' } }
      ]
```

Before:
![image](https://user-images.githubusercontent.com/2781561/53583136-55d92b00-3b57-11e9-85f8-2712117ee180.png)

This PR adds in a function to convert an object/array to a string for rendering.

This is identical to how Vue performs `{{ value }}` interpolation (actually it is very identical, as the method is borrowed from Vue's utils).

After:
![image](https://user-images.githubusercontent.com/2781561/53583815-b026bb80-3b58-11e9-9337-05e61ff84ae9.png)

This conversion is only done for the visual representation, and the raw value is still passed to the slots scope (formatted and unformatted)

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
