### PR TITLE
chore: util and mixin for normalizing scoped and un-scoped slots

### DIFF
--- a/src/mixins/normalize-slot.js
+++ b/src/mixins/normalize-slot.js
@@ -1,0 +1,9 @@
+import normalizeSlot from '../utils/normalize-slot'
+
+export default {
+  methods: {
+    normalizeSlot(name, scope = {}) {
+      return normalizeSlot(name, scope, this.$scopedSlots, this.$slots)
+    }
+  }
+}

--- a/src/utils/normalize-slot.js
+++ b/src/utils/normalize-slot.js
@@ -1,0 +1,14 @@
+/**
+ * Returns vNodes for named slot either scoped or unscoped
+ *
+ * @param {String} name
+ * @param {String} scope
+ * @param {Object} scopedSlots
+ * @param {Object} slots
+ * @returns {Array|undefined} vNodes
+ */
+
+export default function normalizeSlot(name, scope = {}, $scopedSlots = {}, $slots = {}) {
+  const slot = $scopedSlots[name] || $slots[name]
+  return typeof slot === 'function' ? slot(scope) : slot
+}

--- a/src/utils/normalize-slot.spec.js
+++ b/src/utils/normalize-slot.spec.js
@@ -17,7 +17,7 @@ describe('util/normalize-slot', async () => {
     expect(result).toBe('foo')
 
     // Passes slot scope to scopedSlot
-    let result = normalizeSlot('default', { a: ' foo' }, $scoped, $slots)
+    result = normalizeSlot('default', { a: ' foo' }, $scoped, $slots)
     expect(result).toBe('foo foo')
 
     // Uses named slot if scopedSlot not found
@@ -25,11 +25,11 @@ describe('util/normalize-slot', async () => {
     expect(result).toBe('bar')
 
     // Works if only named slot found
-    result = normalizeSlot('default', { a: ' foo'}, {}, $slots)
+    result = normalizeSlot('default', { a: ' foo' }, {}, $slots)
     expect(result).toBe('bar')
 
     // Works if only scoped slot found
-    result = normalizeSlot('default', { a: ' bar'}, $scoped, {})
+    result = normalizeSlot('default', { a: ' bar' }, $scoped, {})
     expect(result).toBe('foo bar')
 
     // Returns undefined if slot name not found
@@ -37,7 +37,7 @@ describe('util/normalize-slot', async () => {
     expect(result).not.toBeDefined()
 
     // Returns undefined if slot name not found
-    let result = normalizeSlot('baz', {}, $scoped, $slots)
+    result = normalizeSlot('baz', {}, $scoped, $slots)
     expect(result).not.toBeDefined()
   })
 })

--- a/src/utils/normalize-slot.spec.js
+++ b/src/utils/normalize-slot.spec.js
@@ -1,0 +1,34 @@
+import normalizeSlot from './normalize-slot'
+
+describe('util/normalize-slot', async () => {
+  if('works', async () => {
+    const $scoped = {
+      default(slotScope) { return 'foo' + (slotScope.a || '')  }
+    }
+    const $slots = {
+      default: 'bar'
+    }
+    expect(typeof normalizeSlot).toBe('function')
+
+    let result = normalizeSlot('default', {}, $scoped, $slot)
+    expect(result).toBe('foo')
+
+    let result = normalizeSlot('default', { a: ' foo' }, $scoped, $slot)
+    expect(result).toBe('foo foo')
+
+    result = normalizeSlot('default', {}, {}, $slot)
+    expect(result).toBe('bar')
+
+    result = normalizeSlot('default', { a: ' foo'}, {}, $slot)
+    expect(result).toBe('bar')
+
+    result = normalizeSlot('default', { a: ' bar'}, $scoped, {})
+    expect(result).toBe('foo bar')
+
+    result = normalizeSlot('default', {}, {}, {})
+    expect(result).not.toBeDefined()
+
+    let result = normalizeSlot('baz', {}, $scoped, $slot)
+    expect(result).not.toBeDefined()
+  })
+})

--- a/src/utils/normalize-slot.spec.js
+++ b/src/utils/normalize-slot.spec.js
@@ -1,7 +1,7 @@
 import normalizeSlot from './normalize-slot'
 
 describe('util/normalize-slot', async () => {
-  if('works', async () => {
+  it('works', async () => {
     const $scoped = {
       default(slotScope) {
         return 'foo' + (slotScope.a || '')

--- a/src/utils/normalize-slot.spec.js
+++ b/src/utils/normalize-slot.spec.js
@@ -3,32 +3,41 @@ import normalizeSlot from './normalize-slot'
 describe('util/normalize-slot', async () => {
   if('works', async () => {
     const $scoped = {
-      default(slotScope) { return 'foo' + (slotScope.a || '')  }
+      default(slotScope) {
+        return 'foo' + (slotScope.a || '')
+      }
     }
     const $slots = {
       default: 'bar'
     }
     expect(typeof normalizeSlot).toBe('function')
 
-    let result = normalizeSlot('default', {}, $scoped, $slot)
+    // Prefers scopedSlots over slots
+    let result = normalizeSlot('default', {}, $scoped, $slots)
     expect(result).toBe('foo')
 
-    let result = normalizeSlot('default', { a: ' foo' }, $scoped, $slot)
+    // Passes slot scope to scopedSlot
+    let result = normalizeSlot('default', { a: ' foo' }, $scoped, $slots)
     expect(result).toBe('foo foo')
 
-    result = normalizeSlot('default', {}, {}, $slot)
+    // Uses named slot if scopedSlot not found
+    result = normalizeSlot('default', {}, {}, $slots)
     expect(result).toBe('bar')
 
-    result = normalizeSlot('default', { a: ' foo'}, {}, $slot)
+    // Works if only named slot found
+    result = normalizeSlot('default', { a: ' foo'}, {}, $slots)
     expect(result).toBe('bar')
 
+    // Works if only scoped slot found
     result = normalizeSlot('default', { a: ' bar'}, $scoped, {})
     expect(result).toBe('foo bar')
 
+    // Returns undefined if slot name not found
     result = normalizeSlot('default', {}, {}, {})
     expect(result).not.toBeDefined()
 
-    let result = normalizeSlot('baz', {}, $scoped, $slot)
+    // Returns undefined if slot name not found
+    let result = normalizeSlot('baz', {}, $scoped, $slots)
     expect(result).not.toBeDefined()
   })
 })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

Util and Mixin for normalizing scoped and un-scoped slots.

Util can be used in functional components, while the mixin can be used in normal components.

This will be handy where we want to be able to support both scoped or regular slots in components (i.e. optionally scoped slot).

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
