### PR TITLE
feat(table): make some slots available either as scoped or unscoped

### DIFF
--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -758,6 +758,7 @@ the table's busy state is `true`. The slot will be placed in a `<tr>` element wi
 
     <b-table :items="items" :busy="isBusy" class="mt-3" outlined>
       <div slot="table-busy" class="text-center text-danger my-2">
+        <b-spinner class="align-middle" />
         <strong>Loading...</strong>
       </div>
     </b-table>

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -717,6 +717,13 @@ grouping and styling of table columns. Note the styles available via `<col>` ele
 Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup) for details and
 usage of `<colgroup>`
 
+Slot `table-colgroup` can be optionally scoped, receiving an object with the following properties:
+
+| Property  | Type   | Description                                                                  |
+| --------- | ------ | ---------------------------------------------------------------------------- |
+| `columns` | Number | The number of columns in the rendered table                                  |
+| `fields`  | Array  | Array of field defintion objects (normalized to the array of objects format) |
+
 ## Table busy state
 
 `<b-table>` provides a `busy` prop that will flag the table as busy, which you can set to `true`
@@ -1045,7 +1052,8 @@ slot is provided, then the footer will use the `HEAD_` slot content.
 </div>
 ```
 
-The slot's scope variable (`data` in the above example) will have the following properties:
+The slots can be optionally scoped (`data` in the above example), and will have the following
+properties:
 
 | Property | Type   | Description                                                   |
 | -------- | ------ | ------------------------------------------------------------- |
@@ -1109,6 +1117,14 @@ This slot is inserted before the header cells row, and is not encapsulated by `<
 
 <!-- b-table-thead-top-slot.vue -->
 ```
+
+Slot `thead-top` can be optionally scoped, receiving an object with the following properties:
+
+| Property  | Type   | Description                                                                  |
+| --------- | ------ | ---------------------------------------------------------------------------- |
+| `columns` | Number | The number of columns in the rendered table                                  |
+| `fields`  | Array  | Array of field defintion objects (normalized to the array of objects format) |
+
 
 ## Row select support
 

--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -197,7 +197,7 @@
           },
           {
             "name": "table-colgroup",
-            "description": "Slot to place custom colgroup and col elements"
+            "description": "Slot to place custom colgroup and col elements (optionally scoped: columns - number of columns, fields - array of field definition objects)"
           },
           {
             "name": "table-busy",
@@ -221,23 +221,23 @@
           },
           {
             "name": "empty",
-            "description": "Content to display when no items are present in the `items` array"
+            "description": "Content to display when no items are present in the `items` array (optionally scoped: see docs for details)"
           },
           {
             "name": "emptyfiltered",
-            "description": "Content to display when no items are present in the filtered `items` array"
+            "description": "Content to display when no items are present in the filtered `items` array (optionally scoped: see docs for details)"
           },
           {
             "name": "thead-top",
-            "description": "Slot above the column headers in the `thead` element for user-supplied rows (ex: in the case of extra header labels / group labels). Scoped data: columns - number of TDs to provide, fields - fields object"
+            "description": "Slot above the column headers in the `thead` element for user-supplied rows (optionally scoped: columns - number of TDs to provide, fields - array of field definition objects)"
           },
           {
             "name": "top-row",
-            "description": "Fixed top row slot for user supplied TD cells. Scoped data: columns - number of TDs to provide, fields - fields object"
+            "description": "Fixed top row slot for user supplied TD cells (Optionally scoped: columns - number of TDs to provide, fields - array of field definition objects)"
           },
           {
             "name": "bottom-row",
-            "description": "Fixed bottom row slot for user supplied TD cells. Scoped data: columns - number of TDs to provide, fields - fields object"
+            "description": "Fixed bottom row slot for user supplied TD cells (Optionally Scoped: columns - number of TDs to provide, fields - array of field definition objects)"
           }
         ]
       }

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1218,10 +1218,9 @@ export default {
           }
         }
         let fieldScope = { label: field.label, column: field.key, field: field }
-        let slot =
-          isFoot && (this.hasNormalizedSlot(`FOOT_${field.key}`))
-            ? this.normalizeSlot(`FOOT_${field.key}`, fieldScope)
-            : this.normalizeSlot(`HEAD_${field.key}`, fieldScope)
+        let slot = isFoot && this.hasNormalizedSlot(`FOOT_${field.key}`)
+          ? this.normalizeSlot(`FOOT_${field.key}`, fieldScope)
+          : this.normalizeSlot(`HEAD_${field.key}`, fieldScope)
         if (slot) {
           slot = [slot]
         } else {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1159,7 +1159,9 @@ export default {
     // Build the colgroup
     let colgroup = h(false)
     if ($scoped['table-colgroup'] || $slots['table-colgroup']) {
-      colgroup = h('colgroup', { key: 'colgroup' },
+      colgroup = h(
+        'colgroup',
+        { key: 'colgroup' },
         this.normalizeSlot('table-colgroup', { columns: fields.length, fields: fields })
       )
     }
@@ -1234,7 +1236,9 @@ export default {
       const theadChildren = []
 
       if ($scoped['thead-top'] || $slots['thead-top']) {
-        theadChildren.push(this.normalizeSlot('thead-top', { columns: fields.length, fields: fields }))
+        theadChildren.push(
+          this.normalizeSlot('thead-top', { columns: fields.length, fields: fields })
+        )
       } else {
         theadChildren.push(h(false))
       }

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1160,7 +1160,7 @@ export default {
 
     // Build the colgroup
     let colgroup = h(false)
-    if ($scoped['table-colgroup'] || $slots['table-colgroup']) {
+    if (this.hasNormalizedSlot('table-colgroup')) {
       colgroup = h(
         'colgroup',
         { key: 'colgroup' },
@@ -1219,7 +1219,7 @@ export default {
         }
         let fieldScope = { label: field.label, column: field.key, field: field }
         let slot =
-          isFoot && ($scoped[`FOOT_${field.key}`] || $slots[`FOOT_${field.key}`])
+          isFoot && (this.hasNormalizedSlot(`FOOT_${field.key}`))
             ? this.normalizeSlot(`FOOT_${field.key}`, fieldScope)
             : this.normalizeSlot(`HEAD_${field.key}`, fieldScope)
         if (slot) {
@@ -1237,7 +1237,7 @@ export default {
       // If in always stacked mode (this.isStacked === true), then we don't bother rendering the thead
       const theadChildren = []
 
-      if ($scoped['thead-top'] || $slots['thead-top']) {
+      if (this.hasNormalizedSlot('thead-top')) {
         theadChildren.push(
           this.normalizeSlot('thead-top', { columns: fields.length, fields: fields })
         )
@@ -1264,7 +1264,7 @@ export default {
 
     // Add static Top Row slot (hidden in visibly stacked mode as we can't control the data-label)
     // If in always stacked mode, we don't bother rendering the row
-    if (($scoped['top-row'] || $slots['top-row']) && this.isStacked !== true) {
+    if (this.hasNormalizedSlot('top-row') && this.isStacked !== true) {
       rows.push(
         h(
           'tr',
@@ -1368,9 +1368,9 @@ export default {
         if (this.currentPage && this.perPage && this.perPage > 0) {
           ariaRowIndex = String((this.currentPage - 1) * this.perPage + rowIndex + 1)
         }
-        // Create a unique key based on the record content, to ensure that sub components are
-        // re-rendered rather than re-used, which can cause issues. If a primary key is not provided
-        // we concatinate the row number and stringified record (in case there are duplicate records).
+        // Create a unique :key to help ensure that sub components are re-rendered rather than
+        // re-used, which can cause issues. If a primary key is not provided we use the rendered
+        // rows index within the tbody.
         // See: https://github.com/bootstrap-vue/bootstrap-vue/issues/2410
         const primaryKey = this.primaryKey
         const rowKey =
@@ -1554,7 +1554,7 @@ export default {
 
     // Static bottom row slot (hidden in visibly stacked mode as we can't control the data-label)
     // If in always stacked mode, we don't bother rendering the row
-    if (($scoped['bottom-row'] || $slots['bottom-row']) && this.isStacked !== true) {
+    if (this.hasNormalizedSlot('bottom-row') && this.isStacked !== true) {
       rows.push(
         h(
           'tr',
@@ -1567,7 +1567,7 @@ export default {
                 : this.tbodyTrClass
             ]
           },
-          [this.normalizeSlot('bottom-row', { columns: fields.length, fields: fields })]
+          this.normalizeSlot('bottom-row', { columns: fields.length, fields: fields })
         )
       )
     } else {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1118,9 +1118,11 @@ export default {
             // Check number of arguments provider function requested
             // Provider not using callback (didn't request second argument), so we clear
             // busy state as most likely there was an error in the provider function
+            /* istanbul ignore next */
             warn(
               "b-table provider function didn't request calback and did not return a promise or data"
             )
+            /* istanbul ignore next */
             this.localBusy = false
           }
         } catch (e) /* istanbul ignore next */ {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1218,9 +1218,10 @@ export default {
           }
         }
         let fieldScope = { label: field.label, column: field.key, field: field }
-        let slot = isFoot && this.hasNormalizedSlot(`FOOT_${field.key}`)
-          ? this.normalizeSlot(`FOOT_${field.key}`, fieldScope)
-          : this.normalizeSlot(`HEAD_${field.key}`, fieldScope)
+        let slot =
+          isFoot && this.hasNormalizedSlot(`FOOT_${field.key}`)
+            ? this.normalizeSlot(`FOOT_${field.key}`, fieldScope)
+            : this.normalizeSlot(`HEAD_${field.key}`, fieldScope)
         if (slot) {
           slot = [slot]
         } else {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -144,7 +144,7 @@ function filterEvent(evt) {
 // @vue/component
 export default {
   name: 'BTable',
-  mixins: [idMixin, listenOnRootMixin],
+  mixins: [idMixin, listenOnRootMixin, normalizeSlotMixin],
   // Don't place ATTRS on root element automatically, as table could be wrapped in responsive div
   inheritAttrs: false,
   props: {

--- a/src/mixins/normalize-slot.js
+++ b/src/mixins/normalize-slot.js
@@ -1,5 +1,5 @@
 import normalizeSlot from '../utils/normalize-slot'
-import { concat } from './array'
+import { concat } from '../utils/array'
 
 export default {
   methods: {

--- a/src/mixins/normalize-slot.js
+++ b/src/mixins/normalize-slot.js
@@ -1,9 +1,17 @@
 import normalizeSlot from '../utils/normalize-slot'
+import concat from './array'
 
 export default {
   methods: {
-    normalizeSlot(name, scope = {}) {
-      return normalizeSlot(name, scope, this.$scopedSlots, this.$slots)
+    hasNormalizedSlot (name) {
+      // Returns true if the eitehr a $scopedSlot or $slot exists with the specified name
+      return Boolean(this.$scopedSlots[name] || this.$slots[name])
+    },
+    normalizeSlot (name, scope = {}) {
+      // Returns an array of rendered vNodes if slot found.
+      // Returns undefined if not found.
+      const vNodes = normalizeSlot(name, scope, this.$scopedSlots, this.$slots)
+      return vNodes ? concat(vNodes) : vNodes
     }
   }
 }

--- a/src/mixins/normalize-slot.js
+++ b/src/mixins/normalize-slot.js
@@ -4,7 +4,7 @@ import { concat } from '../utils/array'
 export default {
   methods: {
     hasNormalizedSlot(name) {
-      // Returns true if the eitehr a $scopedSlot or $slot exists with the specified name
+      // Returns true if the either a $scopedSlot or $slot exists with the specified name
       return Boolean(this.$scopedSlots[name] || this.$slots[name])
     },
     normalizeSlot(name, scope = {}) {

--- a/src/mixins/normalize-slot.js
+++ b/src/mixins/normalize-slot.js
@@ -1,13 +1,13 @@
 import normalizeSlot from '../utils/normalize-slot'
-import concat from './array'
+import { concat } from './array'
 
 export default {
   methods: {
-    hasNormalizedSlot (name) {
+    hasNormalizedSlot(name) {
       // Returns true if the eitehr a $scopedSlot or $slot exists with the specified name
       return Boolean(this.$scopedSlots[name] || this.$slots[name])
     },
-    normalizeSlot (name, scope = {}) {
+    normalizeSlot(name, scope = {}) {
       // Returns an array of rendered vNodes if slot found.
       // Returns undefined if not found.
       const vNodes = normalizeSlot(name, scope, this.$scopedSlots, this.$slots)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

In versions of Vue prior to 2.6, scoped slots and un-scoped slots were separate entities.  Now all regular names (un-scoped) slots are also available in the `$scopedSlots` as functions (which provide render speed optimizations, over regular $slots).  This PR makes optionally scoped slots work with Vue 2.5.x.

The following slots are now all available as optionally scoped:

- `colgroup`
- `thead-top`
- `HEAD_<field_key>`
- `FOOT_<field_key>`
- `empty`
- `emptyfiltered`
- `top-row`
- `bottom-row`

When the user provides a slot-scope, these slots will be called as $scopedSlots, and passed a slot scope context.

Uses the new normalize-slots mixin.

Will also introduce optional scoped slots into other components (such as modal) for passing methods to the slots in a separate PR.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
