### PR TITLE
perf(table): minor tweaks to primary key usage

### DIFF
--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -375,8 +375,8 @@ The primary key column does not need to appear in the displayed fields.
 ### Table row ID generation
 
 When provided, the `primary-key` will generate a unique ID for each item row `<tr>` element. The ID
-will be in the format of `{table-id}__row_{primary-key-value}`, where `table-id` is the unique ID of
-the `<b-table>` and `primary-key-value` is the value of the item's field value for the field
+will be in the format of `{table-id}__row_{primary-key-value}`, where `{table-id}` is the unique ID
+of the `<b-table>` and `{primary-key-value}` is the value of the item's field value for the field
 specified by `primary-key`.
 
 ### Table render and transition optimization
@@ -385,17 +385,18 @@ The `primary-key` is also used by `<b-table>` to help Vue optimize the rendering
 Internally, the value of the field key specified by the `primary-key` prop is used as the Vue `:key`
 value for each rendered item row `<tr>` element.
 
-If you are seeing rendering issue (i.e. tooltips hiding when item data changes or data is
-sorted/filtered/edited), setting the `primary-key` prop (if you have a unique identifier per row)
-can alleviate these issues.
+If you are seeing rendering issue (i.e. tooltips hiding or unexpected subcomponent re-usage when
+item data changes or data is sorted/filtered/edited), setting the `primary-key` prop (if you have
+a unique identifier per row) can alleviate these issues.
 
 Specifying the `primary-key` column is handy if you are using 3rd party table transitions or drag
 and drop plugins, as they rely on having a consistent and unique per row `:key` value.
 
-If no primary key is provided, `<b-table>` will auto-generate keys based on the serialized values of
-the row's data values plus the displayed row's index number. This may cause GUI issues if you are
-modifiying the underlying table data in-place (i.e. via a `<b-form-input>` v-model bound to the
-row's data). Specifying a `primary-key` column can alleviate this issue.
+If `primary-key` is not provided, `<b-table>` will auto-generate keys based on the displayed row's
+index number (i.e. position in the _displayed_ table rows). This may cause GUI issues such as sub
+components/elements that are rendering with previous results (i.e. being re-used by Vue's render
+patch optimization routines). Specifying a `primary-key` column can alleviate this issue (or you
+can place a unique `:key` on your element/components in your custom formatted field slots).
 
 ## Table style options
 

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1369,13 +1369,13 @@ export default {
         // See: https://github.com/bootstrap-vue/bootstrap-vue/issues/2410
         const primaryKey = this.primaryKey
         const rowKey =
-          primaryKey && item[primaryKey] !== undefined
+          primaryKey && item[primaryKey] !== undefined && item[primaryKey] !== null
             ? toString(item[primaryKey])
-            : `${rowIndex}__${recToString(item)}`
+            : String(rowIndex)
         // If primary key is provided, use it to generate a unique ID on each tbody > tr
-        // In the format of '{tableId}_row_{primaryKeyValue}'
+        // In the format of '{tableId}__row_{primaryKeyValue}'
         const rowId =
-          primaryKey && item[primaryKey] !== undefined
+          primaryKey && item[primaryKey] !== undefined && item[primaryKey] !== null
             ? this.safeId(`_row_${item[primaryKey]}`)
             : null
         // Assemble and add the row
@@ -1396,6 +1396,7 @@ export default {
               attrs: {
                 id: rowId,
                 tabindex: hasRowClickHandler ? '0' : null,
+                'data-pk': rowId ? String(item[primaryKey]) : null,
                 'aria-describedby': detailsId,
                 'aria-owns': detailsId,
                 'aria-rowindex': ariaRowIndex,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

Minor adjustments to row `:key` generation based on primary key existence.

Rather than use a serialized version of the row values as the rows `:key` value, the displayed row index value is used (unless a primary key is provided).

Users who are experiencing issues with components in cells getting re-used (and not fully updating, as in #931, and #2410) will need to specify a `primary-key` column to circumvent issues they may encounter.  This PR partially reverts #2416 as using the `primary-key` will provide better results, as the serialized string (from the rows values) could change due to mutations in row data, causing unnecessary re-renders.

Also adds a row attribute `data-pk` which will have the primary key value.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No
- [x] Partially

If yes, please describe the impact:

Partial impact to users that may experience issues with components/elements being re-used when filtering/sorting/pagination.  Providing a `primary-key` in the table data (or using keys on their components) will circumvent the issues.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
