### PR TITLE
fix(nav-item): move listeners to link element

### DIFF
--- a/src/components/nav/nav-item.js
+++ b/src/components/nav/nav-item.js
@@ -21,7 +21,6 @@ export default {
     }
   },
   render(h, { props, data, listeners, children }) {
-    const linkAttrs = props.linkAttrs
     // We transfer the listeners to the link
     delete data.on
     return h(

--- a/src/components/nav/nav-item.js
+++ b/src/components/nav/nav-item.js
@@ -8,13 +8,25 @@ export default {
   name: 'BNavItem',
   functional: true,
   props,
-  render(h, { props, data, children }) {
+  render(h, { props, data, listeners, children }) {
+    // We transfer the listeners to the link
+    delete data.on
     return h(
       'li',
       mergeData(data, {
         staticClass: 'nav-item'
       }),
-      [h(BLink, { staticClass: 'nav-link', props }, children)]
+      [
+        h(
+          BLink,
+          {
+            staticClass: 'nav-link',
+            props,
+            on: listeners
+          },
+          children
+        )
+      ]
     )
   }
 }

--- a/src/components/nav/nav-item.js
+++ b/src/components/nav/nav-item.js
@@ -7,8 +7,21 @@ export const props = linkPropsFactory()
 export default {
   name: 'BNavItem',
   functional: true,
-  props,
+  props: {
+    ...props,
+    linksAttrs: {
+      type: Object,
+      default() {
+        return {}
+      }
+    },
+    linkClasses: {
+      type: [String, Object, Array],
+      default: null
+    }
+  },
   render(h, { props, data, listeners, children }) {
+    const linkAttrs = props.linkAttrs
     // We transfer the listeners to the link
     delete data.on
     return h(
@@ -21,6 +34,8 @@ export default {
           BLink,
           {
             staticClass: 'nav-link',
+            class: props.linkClasses,
+            attrs: props.linkAttrs,
             props,
             on: listeners
           },

--- a/src/components/nav/nav-item.js
+++ b/src/components/nav/nav-item.js
@@ -9,7 +9,7 @@ export default {
   functional: true,
   props: {
     ...props,
-    linksAttrs: {
+    linkAttrs: {
       type: Object,
       default() {
         return {}

--- a/src/components/nav/nav-item.spec.js
+++ b/src/components/nav/nav-item.spec.js
@@ -1,0 +1,77 @@
+import NavItem from './nav-item'
+import Link from '../link/link'
+import { mount } from '@vue/test-utils'
+
+describe('nav-item', async () => {
+  it('has expected default structure', async () => {
+    const wrapper = mount(NavItem)
+    expect(wrapper.is('li')).toBe(true)
+    expect(wrapper.classes()).toContain('nav-item')
+    expect(wrapper.classes().length).toBe(1)
+
+    const link = wrapper.find('a')
+    expect(link).toBeDefined()
+    expect(link.is('a')).toBe(true)
+    expect(link.is(Link)).toBe(true)
+    expect(link.classes()).toContain('nav-link')
+    expect(link.classes().length).toBe(1)
+    expect(link.attributes('href')).toBeDefined()
+    expect(link.attributes('href')).toBe('#')
+    expect(link.attributes('role')).not.toBeDefined()
+  })
+
+  it('has role on link when link-role set', async () => {
+    const wrapper = mount(NavItem, {
+      context: {
+        propsData: { role: 'tab'}
+      }
+    })
+    expect(wrapper.attribute('role')).not.toBeDefined()
+    const link = wrapper.find('a')
+    expect(link.attributes('role')).toBeDefined()
+    expect(link.attributes('role')).toBe('tab')
+  })
+
+  it('has class "disabled" on link when disabled set', async () => {
+    const wrapper = mount(NavItem, {
+      context: {
+        propsData: { disabled: true}
+      }
+    })
+    const link = wrapper.find('a')
+    expect(link.classes()).toContain('disabled')
+  })
+
+  it('emits click event when clicked', async () => {
+    const spy = jest.fn()
+    const wrapper = mount(NavItem, {
+      context: {
+        on: { click: spy }
+      }
+    })
+    expect(spy).not.toHaveBeenCalled()
+    wrapper.trigger('click')
+    expect(spy).not.toHaveBeenCalled()
+
+    const link = wrapper.find('a')
+    link.trigger('click')
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('does not emit a click event when clicked and disabled', async () => {
+    const spy = jest.fn()
+    const wrapper = mount(NavItem, {
+      context: {
+        propsData: { disabled: true },
+        on: { click: spy }
+      }
+    })
+    expect(spy).not.toHaveBeenCalled()
+    wrapper.trigger('click')
+    expect(spy).not.toHaveBeenCalled()
+
+    const link = wrapper.find('a')
+    link.trigger('click')
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/nav/nav-item.spec.js
+++ b/src/components/nav/nav-item.spec.js
@@ -38,10 +38,7 @@ describe('nav-item', async () => {
     const wrapper = mount(NavItem, {
       context: {
         propsData: {
-          linkClasses: [
-            'foo',
-            { bar: true }
-          ]
+          linkClasses: ['foo', { bar: true }]
         }
       }
     })

--- a/src/components/nav/nav-item.spec.js
+++ b/src/components/nav/nav-item.spec.js
@@ -20,16 +20,35 @@ describe('nav-item', async () => {
     expect(link.attributes('role')).not.toBeDefined()
   })
 
-  it('has role on link when link-role set', async () => {
+  it('has attrs on link when link-attrs set', async () => {
     const wrapper = mount(NavItem, {
       context: {
-        propsData: { role: 'tab' }
+        propsData: {
+          linkAttrs: { role: 'tab' }
+        }
       }
     })
     expect(wrapper.attribute('role')).not.toBeDefined()
     const link = wrapper.find('a')
     expect(link.attributes('role')).toBeDefined()
     expect(link.attributes('role')).toBe('tab')
+  })
+
+  it('has custom classes on link when link-classes set', async () => {
+    const wrapper = mount(NavItem, {
+      context: {
+        propsData: {
+          linkClasses: [
+            'foo',
+            { bar: true }
+          ]
+        }
+      }
+    })
+    const link = wrapper.find('a')
+    expect(link.classes()).toContain('foo')
+    expect(link.classes()).toContain('bar')
+    expect(link.classes()).toContain('nav-link')
   })
 
   it('has class "disabled" on link when disabled set', async () => {

--- a/src/components/nav/nav-item.spec.js
+++ b/src/components/nav/nav-item.spec.js
@@ -23,7 +23,7 @@ describe('nav-item', async () => {
   it('has role on link when link-role set', async () => {
     const wrapper = mount(NavItem, {
       context: {
-        propsData: { role: 'tab'}
+        propsData: { role: 'tab' }
       }
     })
     expect(wrapper.attribute('role')).not.toBeDefined()
@@ -35,7 +35,7 @@ describe('nav-item', async () => {
   it('has class "disabled" on link when disabled set', async () => {
     const wrapper = mount(NavItem, {
       context: {
-        propsData: { disabled: true}
+        propsData: { disabled: true }
       }
     })
     const link = wrapper.find('a')

--- a/src/components/nav/nav-item.spec.js
+++ b/src/components/nav/nav-item.spec.js
@@ -28,8 +28,9 @@ describe('nav-item', async () => {
         }
       }
     })
-    expect(wrapper.attribute('role')).not.toBeDefined()
-    const link = wrapper.find('a')
+    expect(wrapper.attributes('role')).not.toBeDefined()
+    const link = wrapper.find(Link)
+    expect(link).toBeDefined()
     expect(link.attributes('role')).toBeDefined()
     expect(link.attributes('role')).toBe('tab')
   })
@@ -42,7 +43,8 @@ describe('nav-item', async () => {
         }
       }
     })
-    const link = wrapper.find('a')
+    const link = wrapper.find(Link)
+    expect(link).toBeDefined()
     expect(link.classes()).toContain('foo')
     expect(link.classes()).toContain('bar')
     expect(link.classes()).toContain('nav-link')
@@ -54,7 +56,8 @@ describe('nav-item', async () => {
         propsData: { disabled: true }
       }
     })
-    const link = wrapper.find('a')
+    const link = wrapper.find(Link)
+    expect(link).toBeDefined()
     expect(link.classes()).toContain('disabled')
   })
 
@@ -69,7 +72,8 @@ describe('nav-item', async () => {
     wrapper.trigger('click')
     expect(spy).not.toHaveBeenCalled()
 
-    const link = wrapper.find('a')
+    const link = wrapper.find(Link)
+    expect(link).toBeDefined()
     link.trigger('click')
     expect(spy).toHaveBeenCalled()
   })

--- a/src/components/nav/nav-item.spec.js
+++ b/src/components/nav/nav-item.spec.js
@@ -23,7 +23,7 @@ describe('nav-item', async () => {
   it('has attrs on link when link-attrs set', async () => {
     const wrapper = mount(NavItem, {
       context: {
-        propsData: {
+        props: {
           linkAttrs: { role: 'tab' }
         }
       }
@@ -38,7 +38,7 @@ describe('nav-item', async () => {
   it('has custom classes on link when link-classes set', async () => {
     const wrapper = mount(NavItem, {
       context: {
-        propsData: {
+        props: {
           linkClasses: ['foo', { bar: true }]
         }
       }
@@ -53,7 +53,7 @@ describe('nav-item', async () => {
   it('has class "disabled" on link when disabled set', async () => {
     const wrapper = mount(NavItem, {
       context: {
-        propsData: { disabled: true }
+        props: { disabled: true }
       }
     })
     const link = wrapper.find(Link)
@@ -82,7 +82,7 @@ describe('nav-item', async () => {
     const spy = jest.fn()
     const wrapper = mount(NavItem, {
       context: {
-        propsData: { disabled: true },
+        props: { disabled: true },
         on: { click: spy }
       }
     })
@@ -90,7 +90,8 @@ describe('nav-item', async () => {
     wrapper.trigger('click')
     expect(spy).not.toHaveBeenCalled()
 
-    const link = wrapper.find('a')
+    const link = wrapper.find(Link)
+    expect(link).toBeDefined()
     link.trigger('click')
     expect(spy).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

When `<b-nav-item>` was set to `disabled`, it would still emit a click event, when it shouldn't.

This PR moves any registered listeners to the rendered `<b-link>` sub component.

Also adds two new props `link-attrs` and `link-classes` to pass additional attributes and classes to `a.nav-link`.


## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [ ] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
