### PR TITLE
fix(pagination): avoid using domProps innerText (Addresses #2744)

### DIFF
--- a/src/components/pagination-nav/README.md
+++ b/src/components/pagination-nav/README.md
@@ -207,7 +207,7 @@ below.
 
 ## Button Size
 
-Optionally change from the default button size by setting the `size` prop to either `'am` for
+Optionally change from the default button size by setting the `size` prop to either `'sm'` for
 smaller buttons or `'lg'` for larger buttons.
 
 ```html

--- a/src/components/pagination-nav/README.md
+++ b/src/components/pagination-nav/README.md
@@ -149,7 +149,7 @@ below.
 
 ```html
 <template>
-  <div>
+  <div class="overflow-auto">
     <!-- Use text in props -->
     <b-pagination-nav
       v-model="currentPage"

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -59,7 +59,7 @@ For a full list of all available slots see the [Slots](#comp-ref-b-pagination-sl
 
 ```html
 <template>
-  <div>
+  <div class="overflow-auto">
     <!-- Use text in props -->
     <b-pagination
       v-model="currentPage"
@@ -118,7 +118,7 @@ For a full list of all available slots see the [Slots](#comp-ref-b-pagination-sl
 
 ## Button Size
 
-Optionally change from the default button size by setting the `size` prop to either `'am` for
+Optionally change from the default button size by setting the `size` prop to either `'sm'` for
 smaller buttons or `'lg'` for larger buttons.
 
 ```html

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -219,7 +219,7 @@ describe('pagination', async () => {
       }
     })
     expect(wrapper.is('ul')).toBe(true)
-    let lis = wrapper.findAll('li')
+    const lis = wrapper.findAll('li')
     expect(lis).toBeDefined()
     // including bookend buttons
     expect(lis.length).toBe(11)
@@ -227,25 +227,44 @@ describe('pagination', async () => {
     // should have the last 4 page buttons with the display classes
     // When currentPage = 0
     expect(wrapper.vm.currentPage).toBe(1)
-    // Grab the page buttons (enclude bookends)
-    lis = wrapper
+    // Grab the page buttons
+    wrapper
       .findAll('li')
-      .wrappers.slice(2, 9)
-      .forEach((li, index) => {
+      .wrappers.forEach((li, index) => {
         expect(li.classes()).toContain('page-item')
         expect(li.attributes('role')).toContain('none')
         expect(li.attributes('role')).toContain('presentation')
-        if (index < 3) {
-          expect(li.classes()).not.toContain('d-none')
-          expect(li.classes()).not.toContain('d-sm-flex')
-        } else {
-          expect(li.classes()).toContain('d-none')
-          expect(li.classes()).toContain('d-sm-flex')
-        }
         if (index === 0) {
-          expect(li.classes()).toContain('active')
+          // First button
+          expect(li.classes()).toContain('disabled')
+          expect(li.find('a')).not.toBeDefined()
+        } else if (index === 1) {
+          // Prev button
+          expect(li.classes()).toContain('disabled')
+          expect(li.find('a')).not.toBeDefined()
+        } else if (index === 9) {
+          // Next buton
+          expect(li.classes()).not.toContain('disabled')
+          expect(li.find('a')).toBeDefined()
+        } else if (index === 10) {
+          // Last button
+          expect(li.classes()).not.toContain('disabled')
+          expect(li.find('a')).toBeDefined()
         } else {
-          expect(li.classes()).not.toContain('active')
+          // Page number buttons
+          expect(li.find('a')).toBeDefined()
+          if (index === 2) {
+            expect(li.classes()).toContain('active')
+          } else {
+            expect(li.classes()).not.toContain('active')
+          }
+          if (index < 5) {
+            expect(li.classes()).not.toContain('d-none')
+            expect(li.classes()).not.toContain('d-sm-flex')
+          } else if (index > 4) {
+            expect(li.classes()).toContain('d-none')
+            expect(li.classes()).toContain('d-sm-flex')
+          }
         }
       })
 
@@ -257,24 +276,43 @@ describe('pagination', async () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(4)
     // Grab the page buttons (enclude bookends)
-    lis = wrapper
+    wrapper
       .findAll('li')
-      .wrappers.slice(2, 9)
-      .forEach((li, index) => {
+      .wrappers.forEach((li, index) => {
         expect(li.classes()).toContain('page-item')
         expect(li.attributes('role')).toContain('none')
         expect(li.attributes('role')).toContain('presentation')
-        if (index > 1 && index < 5) {
-          expect(li.classes()).not.toContain('d-none')
-          expect(li.classes()).not.toContain('d-sm-flex')
+        if (index === 0) {
+          // First button
+          expect(li.classes()).not.toContain('disabled')
+          expect(li.find('a')).toBeDefined()
+        } else if (index === 1) {
+          // Prev button
+          expect(li.classes()).not.toContain('disabled')
+          expect(li.find('a')).toBeDefined()
+        } else if (index === 9) {
+          // Next buton
+          expect(li.classes()).not.toContain('disabled')
+          expect(li.find('a')).toBeDefined()
+        } else if (index === 10) {
+          // Last button
+          expect(li.classes()).not.toContain('disabled')
+          expect(li.find('a')).toBeDefined()
         } else {
-          expect(li.classes()).toContain('d-none')
-          expect(li.classes()).toContain('d-sm-flex')
-        }
-        if (index === 3) {
-          expect(li.classes()).toContain('active')
-        } else {
-          expect(li.classes()).not.toContain('active')
+          // Page number buttons
+          expect(li.find('a')).toBeDefined()
+          if (index === 5) {
+            expect(li.classes()).toContain('active')
+          } else {
+            expect(li.classes()).not.toContain('active')
+          }
+          if (index > 3 && index < 7) {
+            expect(li.classes()).not.toContain('d-none')
+            expect(li.classes()).not.toContain('d-sm-flex')
+          } else if (index < 4 || index > 6) {
+            expect(li.classes()).toContain('d-none')
+            expect(li.classes()).toContain('d-sm-flex')
+          }
         }
       })
   })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -228,8 +228,7 @@ describe('pagination', async () => {
     // When currentPage = 0
     expect(wrapper.vm.currentPage).toBe(1)
     // Grab the page buttons (enclude bookends)
-    lis = wrapper.findAll('li').wrappers.slice(2,9)
-    lis.filter(w => w.find('a')).forEach((li, index) => {
+    lis = wrapper.findAll('li').wrappers.slice(2, 9).forEach((li, index) => {
       expect(li.classes()).toContain('page-item')
       expect(li.attributes('role')).toContain('none')
       expect(li.attributes('role')).toContain('presentation')
@@ -250,8 +249,7 @@ describe('pagination', async () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(4)
     // Grab the page buttons (enclude bookends)
-    lis = wrapper.findAll('li').wrappers.slice(2,9)
-    lis.filter(w => w.find('a')).wrappers.forEach((li, index) => {
+    lis = wrapper.findAll('li').wrappers.slice(2, 9).forEach((li, index) => {
       expect(li.classes()).toContain('page-item')
       expect(li.attributes('role')).toContain('none')
       expect(li.attributes('role')).toContain('presentation')

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -1,6 +1,78 @@
-import { loadFixture, testVM } from '../../../tests/utils'
+import Pagination from './pagination'
+import { mount } from '@vue/test-utils'
 
 describe('pagination', async () => {
-  beforeEach(loadFixture(__dirname, 'pagination'))
-  testVM()
+  it('renders with correct basic structure for root element', async () => {
+    const wrapper = mount(Pagination, {
+      props: {
+        totlaRows: 1,
+        perPage: 1,
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    // Classes
+    expect(wrapper.classes()).toContain('pagination')
+    expect(wrapper.classes()).toContain('b-pagination')
+    expect(wrapper.classes()).not.toContain('pagination-sm')
+    expect(wrapper.classes()).not.toContain('pagination-lg')
+    expect(wrapper.classes()).not.toContain('justify-content-center')
+    expect(wrapper.classes()).not.toContain('justify-content-end')
+    // Attributes
+    expect(wrapper.attributes('role')).toBe('menubar')
+    expect(wrapper.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.attributes('aria-label')).toBe('Pagination')
+  })
+
+  it('renders with correct basic inner structure', async () => {
+    const wrapper = mount(Pagination, {
+      props: {
+        totlaRows: 1,
+        perPage: 1,
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    const lis = wrapper.findAll('li')
+    expect(lis).toBeDefined()
+    expect(lis.length).toBe(5)
+    
+    lis.forEach((li, index) => {
+      expect(li.classes()).toContain('page-item')
+      expect(li.attributes('role')).toContain('none')
+      expect(li.attributes('role')).toContain('presentation')
+      const pageLink = li.find('.page-link')
+      expect(pageLink).toBeDefined()
+      if (index === 2) {
+        expect(li.classes()).toContain('active')
+        expect(li.classes()).not.toContain('disabled')
+        expect(pageLink.is('a')).toBe(true)
+      } else {
+        expect(li.classes()).not.toContain('active')
+        expect(li.classes()).toContain('disabled')
+        expect(pageLink.is('span')).toBe(true)
+      }
+    })
+
+    const first = lis.at(0)
+    const prev = lis.at(1)
+    const page = lis.at(2)
+    const next = lis.at(3)
+    const last = lis.at(4)
+
+    // Button content
+    expect(first.find('.page-link').text()).toEqual('«')
+    expect(prev.find('.page-link').text()).toEqual('‹')
+    expect(page.find('.page-link').text()).toEqual('1')
+    expect(next.find('.page-link').text()).toEqual('›')
+    expect(last.find('.page-link').text()).toEqual('»')
+
+    // Page button attrs
+    expect(page.find('.page-link').attributes('href')).toEqual('#')
+    expect(page.find('.page-link').attributes('role')).toEqual('menuitemradio')
+    expect(page.find('.page-link').attributes('aria-checked')).toEqual('true')
+    expect(page.find('.page-link').attributes('aria-posinset')).toEqual('1')
+    expect(page.find('.page-link').attributes('aria-setsize')).toEqual('1')
+    expect(page.find('.page-link').attributes('tabindex')).toEqual('0')
+    expect(page.find('.page-link').attributes('aria-label')).toEqual('Go to page 1')
+    expect(page.find('.page-link').attributes('target')).toEqual('_self')
+  })
 })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -209,6 +209,35 @@ describe('pagination', async () => {
     expect(wrapper.attributes('aria-label')).toBe('Pagination')
   })
 
+  it('has atribute aria-controls on page links when prop aria-controls is set', async () => {
+    const wrapper = mount(Pagination, {
+      propsData: {
+        hideGotoEndButtons: true,
+        hideEllipsis: true,
+        totalRows: 3,
+        perPage: 1,
+        value: 1,
+        ariaControls: 'foo'
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    expect(wrapper.findAll('li').length).toBe(3)
+    expect(wrapper.findAll('a').length).toBe(3)
+    expect(wrapper.findAll('a').at(0).attributes('aria-controls')).toBe('foo')
+    expect(wrapper.findAll('a').at(1).attributes('aria-controls')).toBe('foo')
+    expect(wrapper.findAll('a').at(2).attributes('aria-controls')).toBe('foo')
+
+    wrapper.setProps({
+      ariaControls: null
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findAll('li').length).toBe(3)
+    expect(wrapper.findAll('a').length).toBe(3)
+    expect(wrapper.findAll('a').at(0).attributes('aria-controls')).not.toBeDefined()
+    expect(wrapper.findAll('a').at(1).attributes('aria-controls')).not.toBeDefined()
+    expect(wrapper.findAll('a').at(2).attributes('aria-controls')).not.toBeDefined()
+  })
+
   it('renders classes d-none and d-sm-flex when more than 3 pages', async () => {
     const wrapper = mount(Pagination, {
       propsData: {

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -228,45 +228,38 @@ describe('pagination', async () => {
     // When currentPage = 0
     expect(wrapper.vm.currentPage).toBe(1)
     // Grab the page buttons
-    wrapper
-      .findAll('li')
-      .wrappers.forEach((li, index) => {
-        expect(li.classes()).toContain('page-item')
-        expect(li.attributes('role')).toContain('none')
-        expect(li.attributes('role')).toContain('presentation')
-        if (index === 0) {
-          // First button
-          expect(li.classes()).toContain('disabled')
-          expect(li.find('a')).not.toBeDefined()
-        } else if (index === 1) {
-          // Prev button
-          expect(li.classes()).toContain('disabled')
-          expect(li.find('a')).not.toBeDefined()
-        } else if (index === 9) {
-          // Next buton
-          expect(li.classes()).not.toContain('disabled')
-          expect(li.find('a')).toBeDefined()
-        } else if (index === 10) {
-          // Last button
-          expect(li.classes()).not.toContain('disabled')
-          expect(li.find('a')).toBeDefined()
+    wrapper.findAll('li').wrappers.forEach((li, index) => {
+      expect(li.classes()).toContain('page-item')
+      expect(li.attributes('role')).toContain('none')
+      expect(li.attributes('role')).toContain('presentation')
+      if (index === 0) {
+        // First button
+        expect(li.classes()).toContain('disabled')
+      } else if (index === 1) {
+        // Prev button
+        expect(li.classes()).toContain('disabled')
+      } else if (index === 9) {
+        // Next buton
+        expect(li.classes()).not.toContain('disabled')
+      } else if (index === 10) {
+        // Last button
+        expect(li.classes()).not.toContain('disabled')
+      } else {
+        // Page number buttons
+        if (index === 2) {
+          expect(li.classes()).toContain('active')
         } else {
-          // Page number buttons
-          expect(li.find('a')).toBeDefined()
-          if (index === 2) {
-            expect(li.classes()).toContain('active')
-          } else {
-            expect(li.classes()).not.toContain('active')
-          }
-          if (index < 5) {
-            expect(li.classes()).not.toContain('d-none')
-            expect(li.classes()).not.toContain('d-sm-flex')
-          } else if (index > 4) {
-            expect(li.classes()).toContain('d-none')
-            expect(li.classes()).toContain('d-sm-flex')
-          }
+          expect(li.classes()).not.toContain('active')
         }
-      })
+        if (index < 5) {
+          expect(li.classes()).not.toContain('d-none')
+          expect(li.classes()).not.toContain('d-sm-flex')
+        } else if (index > 4) {
+          expect(li.classes()).toContain('d-none')
+          expect(li.classes()).toContain('d-sm-flex')
+        }
+      }
+    })
 
     // should have the first and last 2 pages buttons with the display classes
     // When currentPage = 4
@@ -276,44 +269,37 @@ describe('pagination', async () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(4)
     // Grab the page buttons (enclude bookends)
-    wrapper
-      .findAll('li')
-      .wrappers.forEach((li, index) => {
-        expect(li.classes()).toContain('page-item')
-        expect(li.attributes('role')).toContain('none')
-        expect(li.attributes('role')).toContain('presentation')
-        if (index === 0) {
-          // First button
-          expect(li.classes()).not.toContain('disabled')
-          expect(li.find('a')).toBeDefined()
-        } else if (index === 1) {
-          // Prev button
-          expect(li.classes()).not.toContain('disabled')
-          expect(li.find('a')).toBeDefined()
-        } else if (index === 9) {
-          // Next buton
-          expect(li.classes()).not.toContain('disabled')
-          expect(li.find('a')).toBeDefined()
-        } else if (index === 10) {
-          // Last button
-          expect(li.classes()).not.toContain('disabled')
-          expect(li.find('a')).toBeDefined()
+    wrapper.findAll('li').wrappers.forEach((li, index) => {
+      expect(li.classes()).toContain('page-item')
+      expect(li.attributes('role')).toContain('none')
+      expect(li.attributes('role')).toContain('presentation')
+      if (index === 0) {
+        // First button
+        expect(li.classes()).not.toContain('disabled')
+      } else if (index === 1) {
+        // Prev button
+        expect(li.classes()).not.toContain('disabled')
+      } else if (index === 9) {
+        // Next buton
+        expect(li.classes()).not.toContain('disabled')
+      } else if (index === 10) {
+        // Last button
+        expect(li.classes()).not.toContain('disabled')
+      } else {
+        // Page number buttons
+        if (index === 5) {
+          expect(li.classes()).toContain('active')
         } else {
-          // Page number buttons
-          expect(li.find('a')).toBeDefined()
-          if (index === 5) {
-            expect(li.classes()).toContain('active')
-          } else {
-            expect(li.classes()).not.toContain('active')
-          }
-          if (index > 3 && index < 7) {
-            expect(li.classes()).not.toContain('d-none')
-            expect(li.classes()).not.toContain('d-sm-flex')
-          } else if (index < 4 || index > 6) {
-            expect(li.classes()).toContain('d-none')
-            expect(li.classes()).toContain('d-sm-flex')
-          }
+          expect(li.classes()).not.toContain('active')
         }
-      })
+        if (index > 3 && index < 7) {
+          expect(li.classes()).not.toContain('d-none')
+          expect(li.classes()).not.toContain('d-sm-flex')
+        } else if (index < 4 || index > 6) {
+          expect(li.classes()).toContain('d-none')
+          expect(li.classes()).toContain('d-sm-flex')
+        }
+      }
+    })
   })
 })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -330,8 +330,9 @@ describe('pagination', async () => {
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(4)
+    lis = wrapper.findAll('li')
     expect(lis.length).toBe(9)
-    expect(lis.at(2).attributes('role')).not.toBe('separator')
+    expect(lis.at(2).attributes('role')).toBe('separator')
     expect(lis.at(6).attributes('role')).toBe('separator')
 
     // should have first ellipsis showing
@@ -341,6 +342,7 @@ describe('pagination', async () => {
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(5)
+    lis = wrapper.findAll('li')
     expect(lis.length).toBe(9)
     expect(lis.at(2).attributes('role')).toBe('separator')
     expect(lis.at(6).attributes('role')).not.toBe('separator')

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -228,18 +228,26 @@ describe('pagination', async () => {
     // When currentPage = 0
     expect(wrapper.vm.currentPage).toBe(1)
     // Grab the page buttons (enclude bookends)
-    lis = wrapper.findAll('li').wrappers.slice(2, 9).forEach((li, index) => {
-      expect(li.classes()).toContain('page-item')
-      expect(li.attributes('role')).toContain('none')
-      expect(li.attributes('role')).toContain('presentation')
-      if (index < 3) {
-        expect(li.classes()).not.toContain('d-none')
-        expect(li.classes()).not.toContain('d-sm-flex')
-      } else {
-        expect(li.classes()).toContain('d-none')
-        expect(li.classes()).toContain('d-sm-flex')
-      }
-    })
+    lis = wrapper
+      .findAll('li')
+      .wrappers.slice(2, 9)
+      .forEach((li, index) => {
+        expect(li.classes()).toContain('page-item')
+        expect(li.attributes('role')).toContain('none')
+        expect(li.attributes('role')).toContain('presentation')
+        if (index < 3) {
+          expect(li.classes()).not.toContain('d-none')
+          expect(li.classes()).not.toContain('d-sm-flex')
+        } else {
+          expect(li.classes()).toContain('d-none')
+          expect(li.classes()).toContain('d-sm-flex')
+        if (index === 0) {
+          expect(li.classes()).toContain('active')
+        } else {
+          expect(li.classes()).not.toContain('active')
+        }
+        }
+      })
 
     // should have the first and last 2 pages buttons with the display classes
     // When currentPage = 4
@@ -249,17 +257,25 @@ describe('pagination', async () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(4)
     // Grab the page buttons (enclude bookends)
-    lis = wrapper.findAll('li').wrappers.slice(2, 9).forEach((li, index) => {
-      expect(li.classes()).toContain('page-item')
-      expect(li.attributes('role')).toContain('none')
-      expect(li.attributes('role')).toContain('presentation')
-      if (index > 1 && index < 6) {
-        expect(li.classes()).not.toContain('d-none')
-        expect(li.classes()).not.toContain('d-sm-flex')
-      } else {
-        expect(li.classes()).toContain('d-none')
-        expect(li.classes()).toContain('d-sm-flex')
-      }
-    })
+    lis = wrapper
+      .findAll('li')
+      .wrappers.slice(2, 9)
+      .forEach((li, index) => {
+        expect(li.classes()).toContain('page-item')
+        expect(li.attributes('role')).toContain('none')
+        expect(li.attributes('role')).toContain('presentation')
+        if (index > 1 && index < 5) {
+          expect(li.classes()).not.toContain('d-none')
+          expect(li.classes()).not.toContain('d-sm-flex')
+        } else {
+          expect(li.classes()).toContain('d-none')
+          expect(li.classes()).toContain('d-sm-flex')
+        }
+        if (index === 3) {
+          expect(li.classes()).toContain('active')
+        } else {
+          expect(li.classes()).not.toContain('active')
+        }
+      })
   })
 })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -227,39 +227,37 @@ describe('pagination', async () => {
     // should have the last 4 page buttons with the display classes
     // When currentPage = 0
     expect(wrapper.vm.currentPage).toBe(1)
-    lis.filter(w => w.find('a'))
-      .wrappers.forEach((li, index) => {
-        expect(li.classes()).toContain('page-item')
-        expect(li.attributes('role')).toContain('none')
-        expect(li.attributes('role')).toContain('presentation')
-        if (index < 3) {
-          expect(li.classes()).not.toContain('d-none')
-          expect(li.classes()).not.toContain('d-sm-flex')
-        } else {
-          expect(li.classes()).toContain('d-none')
-          expect(li.classes()).toContain('d-sm-flex')
-        }
-      })
+    lis.filter(w => w.find('a')).wrappers.forEach((li, index) => {
+      expect(li.classes()).toContain('page-item')
+      expect(li.attributes('role')).toContain('none')
+      expect(li.attributes('role')).toContain('presentation')
+      if (index < 3) {
+        expect(li.classes()).not.toContain('d-none')
+        expect(li.classes()).not.toContain('d-sm-flex')
+      } else {
+        expect(li.classes()).toContain('d-none')
+        expect(li.classes()).toContain('d-sm-flex')
+      }
+    })
 
     // should have the first and last 2 pages buttons with the display classes
     // When currentPage = 4
-    wraper.setProps({
+    wrapper.setProps({
       value: '4'
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(4)
-    lis.filter(w => w.find('a'))
-      .wrappers.forEach((li, index) => {
-        expect(li.classes()).toContain('page-item')
-        expect(li.attributes('role')).toContain('none')
-        expect(li.attributes('role')).toContain('presentation')
-        if (index > 1 && index < 6) {
-          expect(li.classes()).not.toContain('d-none')
-          expect(li.classes()).not.toContain('d-sm-flex')
-        } else {
-          expect(li.classes()).toContain('d-none')
-          expect(li.classes()).toContain('d-sm-flex')
-        }
-      })
+    lis.filter(w => w.find('a')).wrappers.forEach((li, index) => {
+      expect(li.classes()).toContain('page-item')
+      expect(li.attributes('role')).toContain('none')
+      expect(li.attributes('role')).toContain('presentation')
+      if (index > 1 && index < 6) {
+        expect(li.classes()).not.toContain('d-none')
+        expect(li.classes()).not.toContain('d-sm-flex')
+      } else {
+        expect(li.classes()).toContain('d-none')
+        expect(li.classes()).toContain('d-sm-flex')
+      }
+    })
   })
 })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -238,6 +238,39 @@ describe('pagination', async () => {
     expect(wrapper.findAll('a').at(2).attributes('aria-controls')).not.toBeDefined()
   })
 
+  it('has atribute aria-label on page links', async () => {
+    const wrapper = mount(Pagination, {
+      propsData: {
+        hideGotoEndButtons: true,
+        hideEllipsis: true,
+        totalRows: 3,
+        perPage: 1,
+        value: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    expect(wrapper.findAll('li').length).toBe(3)
+    expect(wrapper.findAll('a').length).toBe(3)
+    expect(wrapper.findAll('a').at(0).attributes('aria-label')).toBe('Go to page 1')
+    expect(wrapper.findAll('a').at(1).attributes('aria-label')).toBe('Go to page 2')
+    expect(wrapper.findAll('a').at(2).attributes('aria-label')).toBe('Go to page 3')
+  })
+
+  it('has all links disabled when prop disabled set', async () => {
+    const wrapper = mount(Pagination, {
+      propsData: {
+        totalRows: 3,
+        perPage: 1,
+        value: 1,
+        disabled: true
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    expect(wrapper.findAll('li').length).toBe(7)
+    expect(wrapper.findAll('.page-link').length).toBe(7)
+    expect(wrapper.findAll('.page-link').is('span.page-link.disabled')).toBe(true)
+  })
+
   it('renders classes d-none and d-sm-flex when more than 3 pages', async () => {
     const wrapper = mount(Pagination, {
       propsData: {

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -4,7 +4,7 @@ import { mount } from '@vue/test-utils'
 describe('pagination', async () => {
   it('renders with correct basic structure for root element', async () => {
     const wrapper = mount(Pagination, {
-      props: {
+      propsData: {
         totlaRows: 1,
         perPage: 1
       }
@@ -25,7 +25,7 @@ describe('pagination', async () => {
 
   it('renders with correct basic inner structure', async () => {
     const wrapper = mount(Pagination, {
-      props: {
+      propsData: {
         totlaRows: 1,
         perPage: 1
       }
@@ -78,7 +78,7 @@ describe('pagination', async () => {
 
   it('has class "pagination-sm" when prop size="sm"', async () => {
     const wrapper = mount(Pagination, {
-      props: {
+      propsData: {
         size: 'sm',
         totlaRows: 1,
         perPage: 1
@@ -100,7 +100,7 @@ describe('pagination', async () => {
 
   it('has class "pagination-lg" when prop size="lg"', async () => {
     const wrapper = mount(Pagination, {
-      props: {
+      propsData: {
         size: 'lg',
         totlaRows: 1,
         perPage: 1
@@ -122,7 +122,7 @@ describe('pagination', async () => {
 
   it('has class "pagination-foo" when prop size="foo"', async () => {
     const wrapper = mount(Pagination, {
-      props: {
+      propsData: {
         size: 'foo',
         totlaRows: 1,
         perPage: 1
@@ -145,7 +145,7 @@ describe('pagination', async () => {
 
   it('has class "justify-content-center" when prop align="center"', async () => {
     const wrapper = mount(Pagination, {
-      props: {
+      propsData: {
         align: 'center',
         totlaRows: 1,
         perPage: 1
@@ -167,7 +167,7 @@ describe('pagination', async () => {
 
   it('has class "justify-content-end" when prop align="right"', async () => {
     const wrapper = mount(Pagination, {
-      props: {
+      propsData: {
         align: 'right',
         totlaRows: 1,
         perPage: 1
@@ -189,7 +189,7 @@ describe('pagination', async () => {
 
   it('has class "justify-content-end" when prop align="end"', async () => {
     const wrapper = mount(Pagination, {
-      props: {
+      propsData: {
         align: 'end',
         totlaRows: 1,
         perPage: 1

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -221,8 +221,8 @@ describe('pagination', async () => {
       }
     })
     expect(wrapper.is('ul')).toBe(true)
-    expect(wrapper.findAll('li').length).toBe(3)
-    expect(wrapper.findAll('a').length).toBe(3)
+    expect(wrapper.findAll('li').length).toBe(5)
+    expect(wrapper.findAll('a').length).toBe(4)
     expect(wrapper.findAll('.page-link').length).toBe(3)
     expect(wrapper.findAll('.page-link').is('a.[aria-controls="foo"]')).toBe(true)
 
@@ -230,8 +230,8 @@ describe('pagination', async () => {
       ariaControls: null
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.findAll('li').length).toBe(3)
-    expect(wrapper.findAll('a').length).toBe(3)
+    expect(wrapper.findAll('li').length).toBe(5)
+    expect(wrapper.findAll('a').length).toBe(4)
     expect(wrapper.findAll('.page-link').is('a.[aria-controls]')).toBe(false)
   })
 
@@ -246,12 +246,12 @@ describe('pagination', async () => {
       }
     })
     expect(wrapper.is('ul')).toBe(true)
-    expect(wrapper.findAll('li').length).toBe(3)
-    expect(wrapper.findAll('a').length).toBe(3)
+    expect(wrapper.findAll('li').length).toBe(5)
+    expect(wrapper.findAll('a').length).toBe(4)
     expect(
       wrapper
         .findAll('a')
-        .at(0)
+        .at(1)
         .attributes('aria-label')
     ).toBe('Go to page 1')
     expect(
@@ -266,6 +266,12 @@ describe('pagination', async () => {
         .at(2)
         .attributes('aria-label')
     ).toBe('Go to page 3')
+    expect(
+      wrapper
+        .findAll('a')
+        .at(4)
+        .attributes('aria-label')
+    ).toBe('Go to next page')
   })
 
   it('has all links disabled when prop disabled set', async () => {
@@ -279,8 +285,10 @@ describe('pagination', async () => {
     })
     expect(wrapper.is('ul')).toBe(true)
     expect(wrapper.findAll('li').length).toBe(7)
-    expect(wrapper.findAll('.page-link').length).toBe(7)
-    expect(wrapper.findAll('.page-link').is('span.page-link.disabled')).toBe(true)
+    expect(wrapper.findAll('.page-item').length).toBe(7)
+    expect(wrapper.findAll('.page-item').is('li.page-item.disabled')).toBe(true)
+    expect(wrapper.findAll('.page-link').is('span.page-link')).toBe(true)
+    expect(wrapper.findAll('.page-link').is('[aria-disabled="true"]')).toBe(true)
   })
 
   it('renders classes d-none and d-sm-flex when more than 3 pages', async () => {

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -223,9 +223,10 @@ describe('pagination', async () => {
     expect(wrapper.is('ul')).toBe(true)
     expect(wrapper.findAll('li').length).toBe(3)
     expect(wrapper.findAll('a').length).toBe(3)
-    expect(wrapper.findAll('a').at(0).attributes('aria-controls')).toBe('foo')
-    expect(wrapper.findAll('a').at(1).attributes('aria-controls')).toBe('foo')
-    expect(wrapper.findAll('a').at(2).attributes('aria-controls')).toBe('foo')
+    expect(wrapper.findAll('.page-link').length).toBe(3)
+    expect(
+      wrapper.findAll('.page-link').is('a.[aria-controls="foo"]')
+    ).toBe(true)
 
     wrapper.setProps({
       ariaControls: null
@@ -233,9 +234,9 @@ describe('pagination', async () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.findAll('li').length).toBe(3)
     expect(wrapper.findAll('a').length).toBe(3)
-    expect(wrapper.findAll('a').at(0).attributes('aria-controls')).not.toBeDefined()
-    expect(wrapper.findAll('a').at(1).attributes('aria-controls')).not.toBeDefined()
-    expect(wrapper.findAll('a').at(2).attributes('aria-controls')).not.toBeDefined()
+    expect(
+      wrapper.findAll('.page-link').is('a.[aria-controls]')
+    ).toBe(false)
   })
 
   it('has atribute aria-label on page links', async () => {

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -486,5 +486,5 @@ describe('pagination', async () => {
     expect(wrapper.vm.currentPage).toBe(2)
     expect(wrapper.emitted('input')[2][0]).toBe(2)
     expect(wrapper.emitted('change')[2][0]).toBe(2)
-  }}
+  })
 })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -456,16 +456,20 @@ describe('pagination', async () => {
     })
     expect(wrapper.is('ul')).toBe(true)
 
-    expect(wrapper.vm.currentPage).toBe(1)
     // Grab the page buttons
     let lis = wrapper.findAll('li')
     expect(lis.length).toBe(7)
     
+    expect(wrapper.vm.currentPage).toBe(1)
     expect(wrapper.emitted('input')).not.toBeDefined()
     expect(wrapper.emitted('change')).not.toBeDefined()
 
     // click on 2nd button
-    wrapper.findAll('li').at(3).find('a').trigger('click')
+    wrapper
+      .findAll('li')
+      .at(3)
+      .find('a')
+      .trigger('click')
     await wrapper.$nextTick()
     expect(wrapper.vm.currentPage).toBe(2)
     expect(wrapper.emitted('input')).toBeDefined()
@@ -474,15 +478,23 @@ describe('pagination', async () => {
     expect(wrapper.emitted('change')[0][0]).toBe(2)
 
     // click goto last button
-    wrapper.findAll('li').at(6).find('a').trigger('click')
+    wrapper
+      .findAll('li')
+      .at(6)
+      .find('a')
+      .trigger('click')
     await wrapper.$nextTick()
     expect(wrapper.vm.currentPage).toBe(3)
     expect(wrapper.emitted('input')[1][0]).toBe(3)
     expect(wrapper.emitted('change')[1][0]).toBe(3)
 
     // click prev button
-    wrapper.findAll('li').at(1).find('a').trigger('click')
-    await wrapper.$nextTick()
+    wrapper
+      .findAll('li')
+      .at(1)
+      .find('a')
+      .trigger('click')
+    await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(2)
     expect(wrapper.emitted('input')[2][0]).toBe(2)
     expect(wrapper.emitted('change')[2][0]).toBe(2)

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -6,7 +6,7 @@ describe('pagination', async () => {
     const wrapper = mount(Pagination, {
       props: {
         totlaRows: 1,
-        perPage: 1,
+        perPage: 1
       }
     })
     expect(wrapper.is('ul')).toBe(true)
@@ -27,15 +27,15 @@ describe('pagination', async () => {
     const wrapper = mount(Pagination, {
       props: {
         totlaRows: 1,
-        perPage: 1,
+        perPage: 1
       }
     })
     expect(wrapper.is('ul')).toBe(true)
     const lis = wrapper.findAll('li')
     expect(lis).toBeDefined()
     expect(lis.length).toBe(5)
-    
-    lis.forEach((li, index) => {
+
+    lis.wrappers.forEach((li, index) => {
       expect(li.classes()).toContain('page-item')
       expect(li.attributes('role')).toContain('none')
       expect(li.attributes('role')).toContain('presentation')

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -75,4 +75,137 @@ describe('pagination', async () => {
     expect(page.find('.page-link').attributes('aria-label')).toEqual('Go to page 1')
     expect(page.find('.page-link').attributes('target')).toEqual('_self')
   })
+
+  it('has class "pagination-sm" when prop size="sm"', async () => {
+    const wrapper = mount(Pagination, {
+      props: {
+        size: 'sm',
+        totlaRows: 1,
+        perPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    // Classes
+    expect(wrapper.classes()).toContain('pagination')
+    expect(wrapper.classes()).toContain('b-pagination')
+    expect(wrapper.classes()).toContain('pagination-sm')
+    expect(wrapper.classes()).not.toContain('pagination-lg')
+    expect(wrapper.classes()).not.toContain('justify-content-center')
+    expect(wrapper.classes()).not.toContain('justify-content-end')
+    // Attributes
+    expect(wrapper.attributes('role')).toBe('menubar')
+    expect(wrapper.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.attributes('aria-label')).toBe('Pagination')
+  })
+
+  it('has class "pagination-lg" when prop size="lg"', async () => {
+    const wrapper = mount(Pagination, {
+      props: {
+        size: 'lg',
+        totlaRows: 1,
+        perPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    // Classes
+    expect(wrapper.classes()).toContain('pagination')
+    expect(wrapper.classes()).toContain('b-pagination')
+    expect(wrapper.classes()).not.toContain('pagination-sm')
+    expect(wrapper.classes()).toContain('pagination-lg')
+    expect(wrapper.classes()).not.toContain('justify-content-center')
+    expect(wrapper.classes()).not.toContain('justify-content-end')
+    // Attributes
+    expect(wrapper.attributes('role')).toBe('menubar')
+    expect(wrapper.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.attributes('aria-label')).toBe('Pagination')
+  })
+
+  it('has class "pagination-foo" when prop size="foo"', async () => {
+    const wrapper = mount(Pagination, {
+      props: {
+        size: 'foo',
+        totlaRows: 1,
+        perPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    // Classes
+    expect(wrapper.classes()).toContain('pagination-foo')
+    expect(wrapper.classes()).toContain('pagination')
+    expect(wrapper.classes()).toContain('b-pagination')
+    expect(wrapper.classes()).not.toContain('pagination-sm')
+    expect(wrapper.classes()).not.toContain('pagination-lg')
+    expect(wrapper.classes()).not.toContain('justify-content-center')
+    expect(wrapper.classes()).not.toContain('justify-content-end')
+    // Attributes
+    expect(wrapper.attributes('role')).toBe('menubar')
+    expect(wrapper.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.attributes('aria-label')).toBe('Pagination')
+  })
+
+  it('has class "justify-content-center" when prop align="center"', async () => {
+    const wrapper = mount(Pagination, {
+      props: {
+        align: 'center',
+        totlaRows: 1,
+        perPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    // Classes
+    expect(wrapper.classes()).toContain('pagination')
+    expect(wrapper.classes()).toContain('b-pagination')
+    expect(wrapper.classes()).not.toContain('pagination-sm')
+    expect(wrapper.classes()).not.toContain('pagination-lg')
+    expect(wrapper.classes()).toContain('justify-content-center')
+    expect(wrapper.classes()).not.toContain('justify-content-end')
+    // Attributes
+    expect(wrapper.attributes('role')).toBe('menubar')
+    expect(wrapper.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.attributes('aria-label')).toBe('Pagination')
+  })
+
+  it('has class "justify-content-end" when prop align="right"', async () => {
+    const wrapper = mount(Pagination, {
+      props: {
+        align: 'right',
+        totlaRows: 1,
+        perPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    // Classes
+    expect(wrapper.classes()).toContain('pagination')
+    expect(wrapper.classes()).toContain('b-pagination')
+    expect(wrapper.classes()).not.toContain('pagination-sm')
+    expect(wrapper.classes()).not.toContain('pagination-lg')
+    expect(wrapper.classes()).not.toContain('justify-content-center')
+    expect(wrapper.classes()).toContain('justify-content-end')
+    // Attributes
+    expect(wrapper.attributes('role')).toBe('menubar')
+    expect(wrapper.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.attributes('aria-label')).toBe('Pagination')
+  })
+
+  it('has class "justify-content-end" when prop align="end"', async () => {
+    const wrapper = mount(Pagination, {
+      props: {
+        align: 'end',
+        totlaRows: 1,
+        perPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    // Classes
+    expect(wrapper.classes()).toContain('pagination')
+    expect(wrapper.classes()).toContain('b-pagination')
+    expect(wrapper.classes()).not.toContain('pagination-sm')
+    expect(wrapper.classes()).not.toContain('pagination-lg')
+    expect(wrapper.classes()).not.toContain('justify-content-center')
+    expect(wrapper.classes()).toContain('justify-content-end')
+    // Attributes
+    expect(wrapper.attributes('role')).toBe('menubar')
+    expect(wrapper.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.attributes('aria-label')).toBe('Pagination')
+  })
 })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -459,7 +459,7 @@ describe('pagination', async () => {
     // Grab the page buttons
     let lis = wrapper.findAll('li')
     expect(lis.length).toBe(7)
-    
+
     expect(wrapper.vm.currentPage).toBe(1)
     expect(wrapper.emitted('input')).not.toBeDefined()
     expect(wrapper.emitted('change')).not.toBeDefined()
@@ -470,7 +470,7 @@ describe('pagination', async () => {
       .at(3)
       .find('a')
       .trigger('click')
-    await wrapper.$nextTick()
+    await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(2)
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('change')).toBeDefined()
@@ -483,7 +483,7 @@ describe('pagination', async () => {
       .at(6)
       .find('a')
       .trigger('click')
-    await wrapper.$nextTick()
+    await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(3)
     expect(wrapper.emitted('input')[1][0]).toBe(3)
     expect(wrapper.emitted('change')[1][0]).toBe(3)

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -208,4 +208,58 @@ describe('pagination', async () => {
     expect(wrapper.attributes('aria-disabled')).toBe('false')
     expect(wrapper.attributes('aria-label')).toBe('Pagination')
   })
+
+  it('renders classes d-none and d-sm-flex when more than 3 pages', async () => {
+    const wrapper = mount(Pagination, {
+      propsData: {
+        totlaRows: 70,
+        perPage: 10,
+        limit: 7,
+        currentPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+    const lis = wrapper.findAll('li')
+    expect(lis).toBeDefined()
+    // including bookend buttons
+    expect(lis.length).toBe(11)
+
+    // should have the last 4 page buttons with the display classes
+    // When currentPage = 0
+    expect(wrapper.vm.currentPage).toBe(1)
+    lis.filter(w => w.find('a'))
+      .wrappers.forEach((li, index) => {
+        expect(li.classes()).toContain('page-item')
+        expect(li.attributes('role')).toContain('none')
+        expect(li.attributes('role')).toContain('presentation')
+        if (index < 3) {
+          expect(li.classes()).not.toContain('d-none')
+          expect(li.classes()).not.toContain('d-sm-flex')
+        } else {
+          expect(li.classes()).toContain('d-none')
+          expect(li.classes()).toContain('d-sm-flex')
+        }
+      })
+
+    // should have the first and last 2 pages buttons with the display classes
+    // When currentPage = 4
+    wraper.setProps({
+      value: '4'
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.currentPage).toBe(4)
+    lis.filter(w => w.find('a'))
+      .wrappers.forEach((li, index) => {
+        expect(li.classes()).toContain('page-item')
+        expect(li.attributes('role')).toContain('none')
+        expect(li.attributes('role')).toContain('presentation')
+        if (index > 1 && index < 6) {
+          expect(li.classes()).not.toContain('d-none')
+          expect(li.classes()).not.toContain('d-sm-flex')
+        } else {
+          expect(li.classes()).toContain('d-none')
+          expect(li.classes()).toContain('d-sm-flex')
+        }
+      })
+  })
 })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -219,7 +219,7 @@ describe('pagination', async () => {
       }
     })
     expect(wrapper.is('ul')).toBe(true)
-    const lis = wrapper.findAll('li')
+    let lis = wrapper.findAll('li')
     expect(lis).toBeDefined()
     // including bookend buttons
     expect(lis.length).toBe(11)
@@ -227,7 +227,9 @@ describe('pagination', async () => {
     // should have the last 4 page buttons with the display classes
     // When currentPage = 0
     expect(wrapper.vm.currentPage).toBe(1)
-    lis.filter(w => w.find('a')).wrappers.forEach((li, index) => {
+    // Grab the page buttons (enclude bookends)
+    lis = wrapper.findAll('li').wrappers.slice(2,9)
+    lis.filter(w => w.find('a')).forEach((li, index) => {
       expect(li.classes()).toContain('page-item')
       expect(li.attributes('role')).toContain('none')
       expect(li.attributes('role')).toContain('presentation')
@@ -247,6 +249,8 @@ describe('pagination', async () => {
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentPage).toBe(4)
+    // Grab the page buttons (enclude bookends)
+    lis = wrapper.findAll('li').wrappers.slice(2,9)
     lis.filter(w => w.find('a')).wrappers.forEach((li, index) => {
       expect(li.classes()).toContain('page-item')
       expect(li.attributes('role')).toContain('none')

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -224,9 +224,7 @@ describe('pagination', async () => {
     expect(wrapper.findAll('li').length).toBe(3)
     expect(wrapper.findAll('a').length).toBe(3)
     expect(wrapper.findAll('.page-link').length).toBe(3)
-    expect(
-      wrapper.findAll('.page-link').is('a.[aria-controls="foo"]')
-    ).toBe(true)
+    expect(wrapper.findAll('.page-link').is('a.[aria-controls="foo"]')).toBe(true)
 
     wrapper.setProps({
       ariaControls: null
@@ -234,9 +232,7 @@ describe('pagination', async () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.findAll('li').length).toBe(3)
     expect(wrapper.findAll('a').length).toBe(3)
-    expect(
-      wrapper.findAll('.page-link').is('a.[aria-controls]')
-    ).toBe(false)
+    expect(wrapper.findAll('.page-link').is('a.[aria-controls]')).toBe(false)
   })
 
   it('has atribute aria-label on page links', async () => {
@@ -252,9 +248,24 @@ describe('pagination', async () => {
     expect(wrapper.is('ul')).toBe(true)
     expect(wrapper.findAll('li').length).toBe(3)
     expect(wrapper.findAll('a').length).toBe(3)
-    expect(wrapper.findAll('a').at(0).attributes('aria-label')).toBe('Go to page 1')
-    expect(wrapper.findAll('a').at(1).attributes('aria-label')).toBe('Go to page 2')
-    expect(wrapper.findAll('a').at(2).attributes('aria-label')).toBe('Go to page 3')
+    expect(
+      wrapper
+        .findAll('a')
+        .at(0)
+        .attributes('aria-label')
+    ).toBe('Go to page 1')
+    expect(
+      wrapper
+        .findAll('a')
+        .at(1)
+        .attributes('aria-label')
+    ).toBe('Go to page 2')
+    expect(
+      wrapper
+        .findAll('a')
+        .at(2)
+        .attributes('aria-label')
+    ).toBe('Go to page 3')
   })
 
   it('has all links disabled when prop disabled set', async () => {

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -445,4 +445,46 @@ describe('pagination', async () => {
     expect(lis.at(2).attributes('role')).toBe('separator')
     expect(lis.at(6).attributes('role')).not.toBe('separator')
   })
+
+  it('places ellipsis in correct places', async () => {
+    const wrapper = mount(Pagination, {
+      propsData: {
+        totalRows: 3,
+        perPage: 1,
+        currentPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+
+    expect(wrapper.vm.currentPage).toBe(1)
+    // Grab the page buttons
+    let lis = wrapper.findAll('li')
+    expect(lis.length).toBe(7)
+    
+    expect(wrapper.emitted('input')).not.toBeDefined()
+    expect(wrapper.emitted('change')).not.toBeDefined()
+
+    // click on 2nd button
+    wrapper.findAll('li').at(3).find('a').trigger('click')
+    await wrapper.$nextTick()
+    expect(wrapper.vm.currentPage).toBe(2)
+    expect(wrapper.emitted('input')).toBeDefined()
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('input')[0][0]).toBe(2)
+    expect(wrapper.emitted('change')[0][0]).toBe(2)
+
+    // click goto last button
+    wrapper.findAll('li').at(6).find('a').trigger('click')
+    await wrapper.$nextTick()
+    expect(wrapper.vm.currentPage).toBe(3)
+    expect(wrapper.emitted('input')[1][0]).toBe(3)
+    expect(wrapper.emitted('change')[1][0]).toBe(3)
+
+    // click prev button
+    wrapper.findAll('li').at(1).find('a').trigger('click')
+    await wrapper.$nextTick()
+    expect(wrapper.vm.currentPage).toBe(2)
+    expect(wrapper.emitted('input')[2][0]).toBe(2)
+    expect(wrapper.emitted('change')[2][0]).toBe(2)
+  }}
 })

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -241,11 +241,11 @@ describe('pagination', async () => {
         } else {
           expect(li.classes()).toContain('d-none')
           expect(li.classes()).toContain('d-sm-flex')
+        }
         if (index === 0) {
           expect(li.classes()).toContain('active')
         } else {
           expect(li.classes()).not.toContain('active')
-        }
         }
       })
 

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -222,17 +222,16 @@ describe('pagination', async () => {
     })
     expect(wrapper.is('ul')).toBe(true)
     expect(wrapper.findAll('li').length).toBe(5)
-    expect(wrapper.findAll('a').length).toBe(4)
-    expect(wrapper.findAll('.page-link').length).toBe(3)
-    expect(wrapper.findAll('.page-link').is('a.[aria-controls="foo"]')).toBe(true)
+    expect(wrapper.findAll('a.page-link').length).toBe(4)
+    expect(wrapper.findAll('a.page-link').is('[aria-controls="foo"]')).toBe(true)
 
     wrapper.setProps({
       ariaControls: null
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.findAll('li').length).toBe(5)
-    expect(wrapper.findAll('a').length).toBe(4)
-    expect(wrapper.findAll('.page-link').is('a.[aria-controls]')).toBe(false)
+    expect(wrapper.findAll('a.page-link').length).toBe(4)
+    expect(wrapper.findAll('a.page-link').is('[aria-controls]')).toBe(false)
   })
 
   it('has atribute aria-label on page links', async () => {
@@ -251,7 +250,7 @@ describe('pagination', async () => {
     expect(
       wrapper
         .findAll('a')
-        .at(1)
+        .at(0)
         .attributes('aria-label')
     ).toBe('Go to page 1')
     expect(
@@ -269,7 +268,7 @@ describe('pagination', async () => {
     expect(
       wrapper
         .findAll('a')
-        .at(4)
+        .at(3)
         .attributes('aria-label')
     ).toBe('Go to next page')
   })
@@ -288,7 +287,24 @@ describe('pagination', async () => {
     expect(wrapper.findAll('.page-item').length).toBe(7)
     expect(wrapper.findAll('.page-item').is('li.page-item.disabled')).toBe(true)
     expect(wrapper.findAll('.page-link').is('span.page-link')).toBe(true)
-    expect(wrapper.findAll('.page-link').is('[aria-disabled="true"]')).toBe(true)
+    expect(
+      wrapper
+        .findAll('.page-link')
+        .at(2)
+        .attributes('aria-disabled')
+    ).toBe('true')
+    expect(
+      wrapper
+        .findAll('.page-link')
+        .at(3)
+        .attributes('aria-disabled')
+    ).toBe('true')
+    expect(
+      wrapper
+        .findAll('.page-link')
+        .at(4)
+        .attributes('aria-disabled')
+    ).toBe('true')
   })
 
   it('renders classes d-none and d-sm-flex when more than 3 pages', async () => {

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -5,7 +5,7 @@ describe('pagination', async () => {
   it('renders with correct basic structure for root element', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
-        totlaRows: 1,
+        totalRows: 1,
         perPage: 1
       }
     })
@@ -26,7 +26,7 @@ describe('pagination', async () => {
   it('renders with correct basic inner structure', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
-        totlaRows: 1,
+        totalRows: 1,
         perPage: 1
       }
     })
@@ -80,7 +80,7 @@ describe('pagination', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
         size: 'sm',
-        totlaRows: 1,
+        totalRows: 1,
         perPage: 1
       }
     })
@@ -102,7 +102,7 @@ describe('pagination', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
         size: 'lg',
-        totlaRows: 1,
+        totalRows: 1,
         perPage: 1
       }
     })
@@ -124,7 +124,7 @@ describe('pagination', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
         size: 'foo',
-        totlaRows: 1,
+        totalRows: 1,
         perPage: 1
       }
     })
@@ -147,7 +147,7 @@ describe('pagination', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
         align: 'center',
-        totlaRows: 1,
+        totalRows: 1,
         perPage: 1
       }
     })
@@ -169,7 +169,7 @@ describe('pagination', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
         align: 'right',
-        totlaRows: 1,
+        totalRows: 1,
         perPage: 1
       }
     })
@@ -191,7 +191,7 @@ describe('pagination', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
         align: 'end',
-        totlaRows: 1,
+        totalRows: 1,
         perPage: 1
       }
     })
@@ -212,7 +212,7 @@ describe('pagination', async () => {
   it('renders classes d-none and d-sm-flex when more than 3 pages', async () => {
     const wrapper = mount(Pagination, {
       propsData: {
-        totlaRows: 70,
+        totalRows: 70,
         perPage: 10,
         limit: 7,
         currentPage: 1

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -302,4 +302,47 @@ describe('pagination', async () => {
       }
     })
   })
+
+  it('places ellipsis in correct places', async () => {
+    const wrapper = mount(Pagination, {
+      propsData: {
+        totalRows: 70,
+        perPage: 10,
+        limit: 5,
+        currentPage: 1
+      }
+    })
+    expect(wrapper.is('ul')).toBe(true)
+
+    // Should have ellipsis in place of last button
+    // When currentPage = 0
+    expect(wrapper.vm.currentPage).toBe(1)
+    // Grab the page buttons
+    let lis = wrapper.findAll('li')
+    expect(lis.length).toBe(9)
+    expect(lis.at(2).attributes('role')).not.toBe('separator')
+    expect(lis.at(6).attributes('role')).toBe('separator')
+
+    // should have both ellipsis showing
+    // When currentPage = 4
+    wrapper.setProps({
+      value: '4'
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.currentPage).toBe(4)
+    expect(lis.length).toBe(9)
+    expect(lis.at(2).attributes('role')).not.toBe('separator')
+    expect(lis.at(6).attributes('role')).toBe('separator')
+
+    // should have first ellipsis showing
+    // When currentPage = 5
+    wrapper.setProps({
+      value: 5
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.currentPage).toBe(5)
+    expect(lis.length).toBe(9)
+    expect(lis.at(2).attributes('role')).toBe('separator')
+    expect(lis.at(6).attributes('role')).not.toBe('separator')
+  })
 })

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -359,9 +359,9 @@ export default {
         'aria-hidden': disabled ? 'true' : null
       }
       if (disabled || isActivePage(pageTest) || linkTo < 1 || linkTo > numberOfPages) {
-        button = h('li', { key, attrs, staticClass: 'page-item', class: ['disabled'] },
-          [h('span', { staticClass: 'page-link' }, [btnContent])]
-        )
+        button = h('li', { key, attrs, staticClass: 'page-item', class: ['disabled'] }, [
+          h('span', { staticClass: 'page-link' }, [btnContent])
+        ])
       } else {
         button = h('li', { key, attrs, staticClass: 'page-item' }, [
           h(

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -359,10 +359,9 @@ export default {
         'aria-hidden': disabled ? 'true' : null
       }
       if (disabled || isActivePage(pageTest) || linkTo < 1 || linkTo > numberOfPages) {
-        button = h(
-          'li',
-          { key, attrs, staticClass: 'page-item', class: ['disabled'] },
-          [h('span', { staticClass: 'page-link' }, [btnContent])])
+        button = h('li', { key, attrs, staticClass: 'page-item', class: ['disabled'] },
+          [h('span', { staticClass: 'page-link' }, [btnContent])]
+        )
       } else {
         button = h('li', { key, attrs, staticClass: 'page-item' }, [
           h(

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -438,8 +438,6 @@ export default {
 
     // Individual Page links
     this.pageList.forEach(page => {
-      let inner
-      const pageText = this.makePage(page.number)
       const active = isActivePage(page.number)
       const staticClass = 'page-link'
       const attrs = {
@@ -453,34 +451,21 @@ export default {
         // ARIA "roving tabindex" method
         tabindex: disabled ? null : active ? '0' : '-1'
       }
-      if (disabled) {
-        inner = h(
-          'span',
-          {
-            key: `page-${page.number}-link-disabled`,
-            staticClass,
-            attrs
-          },
-          pageText
-        )
-      } else {
-        inner = h(
-          'b-link',
-          {
-            key: `page-${page.number}-link`,
-            props: this.linkProps(page.number),
-            staticClass,
-            attrs,
-            on: {
-              click: evt => {
-                this.onClick(page.number, evt)
-              },
-              keydown: onSpaceKey
-            }
-          },
-          pageText
-        )
-      }
+      const inner = h(
+        disabled ? 'span' : `b-link`,
+        {
+          props: disabled ? {} : this.linkProps(page.number),
+          staticClass,
+          attrs,
+          on: disabled
+            ? {}
+            : {
+                click: evt => { this.onClick(page.number, evt) },
+                keydown: onSpaceKey
+              }
+        },
+        toString(this.makePage(page.number))
+      )
       buttons.push(
         h(
           'li',

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -6,7 +6,7 @@ import warn from '../utils/warn'
 import range from '../utils/range'
 import KeyCodes from '../utils/key-codes'
 import { isVisible, isDisabled, selectAll, getAttr } from '../utils/dom'
-import { stripTags } from '../utils/html'
+import toString from '../utils/to-string'
 import BLink from '../components/link/link'
 
 // Threshold of limit size when we start/stop showing ellipsis
@@ -353,18 +353,18 @@ export default {
     // Factory function for prev/next/first/last buttons
     const makeEndBtn = (linkTo, ariaLabel, btnSlot, btnText, pageTest, key) => {
       let button
-      const domProps = btnSlot ? {} : { textContent: btnText }
-      const staticClass = 'page-item'
+      const btnContent = btnSlot || toString(btnText) || h(false)
       const attrs = {
         role: 'none presentation',
         'aria-hidden': disabled ? 'true' : null
       }
       if (disabled || isActivePage(pageTest) || linkTo < 1 || linkTo > numberOfPages) {
-        button = h('li', { key, attrs, staticClass, class: ['disabled'] }, [
-          h('span', { staticClass: 'page-link', domProps }, [btnSlot])
-        ])
+        button = h(
+          'li',
+          { key, attrs, staticClass: 'page-item', class: ['disabled'] },
+          [h('span', { staticClass: 'page-link' }, [btnContent])])
       } else {
-        button = h('li', { key, attrs, staticClass }, [
+        button = h('li', { key, attrs, staticClass: 'page-item' }, [
           h(
             'b-link',
             {
@@ -383,7 +383,7 @@ export default {
                 keydown: onSpaceKey
               }
             },
-            [h('span', { domProps }, [btnSlot])]
+            [btnContent]
           )
         ])
       }
@@ -402,7 +402,7 @@ export default {
         },
         [
           h('div', { staticClass: 'page-link' }, [
-            this.$slots['ellipsis-text'] || this.ellipsisText || h(false)
+            this.$slots['ellipsis-text'] || toString(this.ellipsisText) || h(false))
           ])
         ]
       )
@@ -416,7 +416,7 @@ export default {
             1,
             this.labelFirstPage,
             this.$slots['first-text'],
-            stripTags(this.firstText),
+            this.firstText,
             1,
             'bookend-goto-first'
           )
@@ -428,7 +428,7 @@ export default {
         this.currentPage - 1,
         this.labelPrevPage,
         this.$slots['prev-text'],
-        stripTags(this.prevText),
+        this.prevText,
         1,
         'bookend-goto-prev'
       )

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -402,7 +402,7 @@ export default {
         },
         [
           h('div', { staticClass: 'page-link' }, [
-            this.$slots['ellipsis-text'] || toString(this.ellipsisText) || h(false))
+            this.$slots['ellipsis-text'] || toString(this.ellipsisText) || h(false)
           ])
         ]
       )

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -460,7 +460,9 @@ export default {
           on: disabled
             ? {}
             : {
-                click: evt => { this.onClick(page.number, evt) },
+                click: evt => {
+                  this.onClick(page.number, evt)
+                },
                 keydown: onSpaceKey
               }
         },


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

`innerText` may cause some SSR hydration issues.

Instead, it now passes the text as a String to the last argument of `$createElement`

Addresses #2744

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
