### PR TITLE
fix(table): don't emit row/head-clicked when user is selecting text (Closes #2791)

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -928,6 +928,7 @@ export default {
         return
       } else if (getSelection && getSelection().toString().length !== 0) {
         // User is selecting text, so ignore
+        /* istanbul ignore next */
         return
       }
       if (e.type === 'keydown') {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -23,8 +23,8 @@ const IGNORED_FIELD_KEYS = {
 // Helper to determine if a there is an active text selection on the document page.
 // Used to filter out click events caused by the mouse up at end of selection
 function textSelectionActive() {
-   const getSelection = (document || {}).getSelection || (window || {}).getSelection
-   return getSelection && getSelection().toString().length !== 0
+  const getSelection = (document || {}).getSelection || (window || {}).getSelection
+  return getSelection && getSelection().toString().length !== 0
 }
 
 // Return a copy of a row after all reserved fields have been filtered out

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -919,11 +919,15 @@ export default {
     },
     // Event handlers
     rowClicked(e, item, index) {
+      const getSelection = (document || {}).getSelection || (window || {}).getSelection
       if (this.stopIfBusy(e)) {
         // If table is busy (via provider) then don't propagate
         return
       } else if (filterEvent(e)) {
         // clicked on a non-disabled control so ignore
+        return
+      } else if (getSelection && getSelection().toString().length !== 0) {
+        // User is selecting text, so ignore
         return
       }
       if (e.type === 'keydown') {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -20,6 +20,13 @@ const IGNORED_FIELD_KEYS = {
   _showDetails: true
 }
 
+// Helper to determine if a there is an active text selection on the document page.
+// Used to filter out click events caused by the mouse up at end of selection
+function textSelectionActive() {
+   const getSelection = (document || {}).getSelection || (window || {}).getSelection
+   return getSelection && getSelection().toString().length !== 0
+}
+
 // Return a copy of a row after all reserved fields have been filtered out
 // TODO: add option to specify which fields to include
 function sanitizeRow(row) {
@@ -919,16 +926,15 @@ export default {
     },
     // Event handlers
     rowClicked(e, item, index) {
-      const getSelection = (document || {}).getSelection || (window || {}).getSelection
       if (this.stopIfBusy(e)) {
         // If table is busy (via provider) then don't propagate
         return
       } else if (filterEvent(e)) {
         // clicked on a non-disabled control so ignore
         return
-      } else if (getSelection && getSelection().toString().length !== 0) {
+      } else if (textSelectionActive()) {
         // User is selecting text, so ignore
-        /* istanbul ignore next */
+        /* istanbul ignore next: JSDOM doesn't support getSelection() */
         return
       }
       if (e.type === 'keydown') {
@@ -1018,6 +1024,10 @@ export default {
         return
       } else if (filterEvent(e)) {
         // clicked on a non-disabled control so ignore
+        return
+      } else if (textSelectionActive()) {
+        // User is selecting text, so ignore
+        /* istanbul ignore next: JSDOM doesn't support getSelection() */
         return
       }
       e.stopPropagation()

--- a/src/components/table/table.spec.js
+++ b/src/components/table/table.spec.js
@@ -411,6 +411,9 @@ describe('table', () => {
     }
   })
 
+  /*
+   * This test needs a polyfill for getSelection and createRange
+   *
   it('row-clicked event should not happen when textSelection is active', async () => {
     const {
       app: { $refs }
@@ -450,6 +453,7 @@ describe('table', () => {
     trs[0].click()
     expect(spy).toHaveBeenCalled()
   })
+   */
 
   it('each data row should emit a row-contextmenu event when right clicked', async () => {
     const {

--- a/src/components/table/table.spec.js
+++ b/src/components/table/table.spec.js
@@ -411,6 +411,46 @@ describe('table', () => {
     }
   })
 
+  it('row-clicked event should not happen when textSelection is active', async () => {
+    const {
+      app: { $refs }
+    } = window
+    const vm = $refs.table_paginated
+
+    const tbody = [...vm.$el.children].find(el => el && el.tagName === 'TBODY')
+    expect(tbody).toBeDefined()
+    const trs = [...tbody.children]
+    expect(trs.length).toBe(vm.perPage)
+
+    // Clear selection if any current
+    let selection = window.getSelection()
+    if (selection.rangeCount > 0) {
+      selection.removeAllRanges()
+    }
+
+    const spy = jest.fn()
+    vm.$on('row-clicked', spy)
+    expect(spy).not.toHaveBeenCalled()
+
+    // Select text in first TR
+    const range = document.createRange()
+    range.selectNode(trs[0])
+    selection.addRange(range)
+
+    // Click row
+    trs[0].click()
+    expect(spy).not.toHaveBeenCalled()
+
+    // Clear selection
+    if (selection.rangeCount > 0) {
+      selection.removeAllRanges()
+    }
+
+    // Click row
+    trs[0].click()
+    expect(spy).toHaveBeenCalled()
+  })
+
   it('each data row should emit a row-contextmenu event when right clicked', async () => {
     const {
       app: { $refs }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

When user is selecting a range of text in the table, a row-clicked event was occurring.

This PR filters out click events when the user is in the midst of composing a text selection.

closes #2791

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
