### PR TITLE
fix(form-radio/form-checkbox): ensure prop required propagated in group mode (fixes #2839)

### DIFF
--- a/src/components/form-checkbox/form-checkbox-group.spec.js
+++ b/src/components/form-checkbox/form-checkbox-group.spec.js
@@ -403,7 +403,8 @@ describe('form-checkbox-group', () => {
     expect(checks.length).toBe(3)
     expect(wrapper.vm.localChecked).toEqual([])
     expect(checks.is('input[type=checkbox]')).toBe(true)
-    expect(checks.is('input[disabled]')).toBe(true)
+    expect(checks.is('input[required]')).toBe(true)
+    expect(checks.is('input[aria-required="true"]')).toBe(true)
   })
 
   it('child checkboxes have class custom-control-inline when stacked=false', async () => {

--- a/src/components/form-checkbox/form-checkbox-group.spec.js
+++ b/src/components/form-checkbox/form-checkbox-group.spec.js
@@ -396,7 +396,7 @@ describe('form-checkbox-group', () => {
         name: 'group',
         options: ['one', 'two', 'three'],
         checked: [],
-        disabled: true
+        required: true
       }
     })
     const checks = wrapper.findAll('input')

--- a/src/components/form-radio/form-radio-group.spec.js
+++ b/src/components/form-radio/form-radio-group.spec.js
@@ -277,6 +277,9 @@ describe('form-radio-group', () => {
         required: true
       }
     })
+    // We need nextTick here since auto generated name is computed in a nextTick on mount
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.classes()).toBeDefined()
     const radios = wrapper.findAll('input')
     expect(radios.length).toBe(3)

--- a/src/components/form-radio/form-radio-group.spec.js
+++ b/src/components/form-radio/form-radio-group.spec.js
@@ -268,6 +268,24 @@ describe('form-radio-group', () => {
     expect(radios.at(2).attributes('disabled')).toBeDefined()
   })
 
+  it('has radios with attribute required when prop required set', async () => {
+    const wrapper = mount(Group, {
+      attachToDocument: true,
+      propsData: {
+        options: ['one', 'two', 'three'],
+        checked: '',
+        required: true
+      }
+    })
+    expect(wrapper.classes()).toBeDefined()
+    const radios = wrapper.findAll('input')
+    expect(radios.length).toBe(3)
+    expect(wrapper.vm.localChecked).toEqual('')
+    expect(radios.is('input[type=radio]')).toBe(true)
+    expect(radios.is('input[required]')).toBe(true)
+    expect(radios.is('input[aria-required="true"]')).toBe(true)
+  })
+
   it('emits change event when radio clicked', async () => {
     const wrapper = mount(Group, {
       attachToDocument: true,

--- a/src/mixins/form-radio-check.js
+++ b/src/mixins/form-radio-check.js
@@ -87,7 +87,7 @@ export default {
       // Child can only be required when parent is
       // Groups will always have a name (either user supplied or auto generated)
       return Boolean(
-        this.get_Name && (this.bvGroup.is_Group ? this.bvGroup.required : this.required)
+        this.get_Name && (this.is_Group ? this.bvGroup.required : this.required)
       )
     },
     get_Name() {

--- a/src/mixins/form-radio-check.js
+++ b/src/mixins/form-radio-check.js
@@ -86,9 +86,7 @@ export default {
       // Required only works when a name is provided for the input(s)
       // Child can only be required when parent is
       // Groups will always have a name (either user supplied or auto generated)
-      return Boolean(
-        this.get_Name && (this.is_Group ? this.bvGroup.required : this.required)
-      )
+      return Boolean(this.get_Name && (this.is_Group ? this.bvGroup.required : this.required))
     },
     get_Name() {
       // Group name preferred over local name

--- a/src/utils/dom.spec.js
+++ b/src/utils/dom.spec.js
@@ -29,7 +29,6 @@ const template1 = `
 `
 
 const App = Vue.extend({
-  template: template1,
   destroyed() {
     // Hack to remove DOM from document as vue-test-utils leaves
     // the rendered DOM in document after each test, when
@@ -41,7 +40,8 @@ const App = Vue.extend({
     if (this.$el && this.$el.parentNode && this.$el.parentNode.removeChild) {
       this.$el.parentNode.removeChild(this.$el)
     }
-  }
+  },
+  template: template1
 })
 
 describe('utils/dom', () => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

form-radios and form-checkboxes were not rendering with required attribute when prop required was set on the group. The original test was checking for the wrong attribute, and has now been corrected as well.

Fixes #2839

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [X] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
