### PR TITLE
fix(carousel): fix touchmove handler to re-enable swipe gestures

### DIFF
--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -402,7 +402,7 @@ export default {
     },
     touchMove(evt) /* istanbul ignore next: JSDOM doesn't support touch events */ {
       // ensure swiping with one touch and not pinching
-      if (evt.touches && (evt.originalEvent || evt).touches.length > 1) {
+      if (evt.touches && evt.touches.length > 1) {
         this.touchDeltaX = 0
       } else {
         this.touchDeltaX = evt.touches[0].clientX - this.touchStartX

--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -402,7 +402,7 @@ export default {
     },
     touchMove(evt) /* istanbul ignore next: JSDOM doesn't support touch events */ {
       // ensure swiping with one touch and not pinching
-      if (evt.touches && evt.originalEvent.touches.length > 1) {
+      if (evt.touches && (evt.originalEvent || evt).touches.length > 1) {
         this.touchDeltaX = 0
       } else {
         this.touchDeltaX = evt.touches[0].clientX - this.touchStartX


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

In the carousel component, there's an [event handler](https://github.com/bootstrap-vue/bootstrap-vue/blob/dev/src/components/carousel/carousel.js#L403) that references `event.originalEvent`, which appears to always be undefined in several (all?) mobile browsers. Since [line 405](https://github.com/bootstrap-vue/bootstrap-vue/blob/dev/src/components/carousel/carousel.js#L405) isn't checking for the existence of `originalEvent` first, an error is thrown for every touch.

Maybe someone more familiar with the codebase can explain why `event.originalEvent` is being used here? It seems like `event.originalEvent` is a jQuery-specific thing, so maybe it's just a hold over from some Bootstrap code? Either way, I tried to make this PR as least destructive as possible - so if `event.originalEvent` exists, it'll be used but it will fall back to just using `event.touches`. Maybe this is unnecessary and `event.originalEvent` should just be removed all together?

To replicate this issue, simply use a touch-supporting device to load [a page with a carousel component](https://bootstrap-vue.js.org/docs/components/carousel/) and tap anywhere on the carousel. Note the errors thrown in the console. I see this behavior in Mobile Safari 12, Chrome Mobile iOS 72.0.3626 & 73.0.3683, and FireFox 65 Android.

## PR checklist:

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**