### PR TITLE
chore(tests): call wrapper.destroy() after each test to release DOM and memory

### DIFF
--- a/src/components/carousel/carousel-slide.spec.js
+++ b/src/components/carousel/carousel-slide.spec.js
@@ -5,39 +5,53 @@ describe('carousel-slide', () => {
   it('has root element "div"', async () => {
     const wrapper = mount(CarouselSlide)
     expect(wrapper.is('div')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('has class carousel-item', async () => {
     const wrapper = mount(CarouselSlide)
     expect(wrapper.classes()).toContain('carousel-item')
     expect(wrapper.classes().length).toBe(1)
+
+    wrapper.destroy()
   })
 
   it('has role=listitem', async () => {
     const wrapper = mount(CarouselSlide)
     expect(wrapper.attributes('role')).toBeDefined()
     expect(wrapper.attributes('role')).toBe('listitem')
+
+    wrapper.destroy()
   })
 
   it('has child div.carousel-caption by default', async () => {
     const wrapper = mount(CarouselSlide)
     expect(wrapper.find('.carousel-caption').exists()).toBe(true)
     expect(wrapper.find('.carousel-caption').is('div')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('does not have image by default', async () => {
     const wrapper = mount(CarouselSlide)
     expect(wrapper.find('img').exists()).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('does not have caption tag h3 by default', async () => {
     const wrapper = mount(CarouselSlide)
     expect(wrapper.find('h3').exists()).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('does not have text tag p by default', async () => {
     const wrapper = mount(CarouselSlide)
     expect(wrapper.find('p').exists()).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('renders default slot inside carousel-caption', async () => {
@@ -48,6 +62,8 @@ describe('carousel-slide', () => {
     })
     expect(wrapper.find('.carousel-caption').exists()).toBe(true)
     expect(wrapper.find('.carousel-caption').text()).toContain('foobar')
+
+    wrapper.destroy()
   })
 
   it('has caption tag h3 when prop caption is set', async () => {
@@ -59,6 +75,8 @@ describe('carousel-slide', () => {
     const content = wrapper.find('.carousel-caption')
     expect(content.find('h3').exists()).toBe(true)
     expect(content.find('h3').text()).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('has text tag p when prop text is set', async () => {
@@ -70,6 +88,8 @@ describe('carousel-slide', () => {
     const content = wrapper.find('.carousel-caption')
     expect(content.find('p').exists()).toBe(true)
     expect(content.find('p').text()).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('has custom content tag when prop contentTag is set', async () => {
@@ -80,6 +100,8 @@ describe('carousel-slide', () => {
     })
     expect(wrapper.find('.carousel-caption').exists()).toBe(true)
     expect(wrapper.find('.carousel-caption').is('span')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('has display classes on .carousel-caption when prop contentVisibleUp is set', async () => {
@@ -92,6 +114,8 @@ describe('carousel-slide', () => {
     expect(wrapper.find('.carousel-caption').classes()).toContain('d-none')
     expect(wrapper.find('.carousel-caption').classes()).toContain('d-lg-block')
     expect(wrapper.find('.carousel-caption').classes().length).toBe(3)
+
+    wrapper.destroy()
   })
 
   it('does not have style background when prop background not set', async () => {
@@ -103,6 +127,8 @@ describe('carousel-slide', () => {
       // But just in case that changes in the future
       expect(true).toBe(true)
     }
+
+    wrapper.destroy()
   })
 
   it('has style background when prop background is set', async () => {
@@ -114,6 +140,8 @@ describe('carousel-slide', () => {
     expect(wrapper.attributes('style')).toBeDefined()
     expect(wrapper.attributes('style')).toContain('background:')
     expect(wrapper.attributes('style')).toContain('rgb(')
+
+    wrapper.destroy()
   })
 
   it('has style background inherited from carousel parent', async () => {
@@ -127,6 +155,8 @@ describe('carousel-slide', () => {
     expect(wrapper.attributes('style')).toBeDefined()
     expect(wrapper.attributes('style')).toContain('background:')
     expect(wrapper.attributes('style')).toContain('rgb(')
+
+    wrapper.destroy()
   })
 
   it('has custom caption tag when prop captionTag is set', async () => {
@@ -139,6 +169,8 @@ describe('carousel-slide', () => {
     const content = wrapper.find('.carousel-caption')
     expect(content.find('h1').exists()).toBe(true)
     expect(content.find('h1').text()).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('has custom text tag when prop textTag is set', async () => {
@@ -151,6 +183,8 @@ describe('carousel-slide', () => {
     const content = wrapper.find('.carousel-caption')
     expect(content.find('span').exists()).toBe(true)
     expect(content.find('span').text()).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('has image when prop img-src is set', async () => {
@@ -162,6 +196,8 @@ describe('carousel-slide', () => {
     expect(wrapper.find('img').exists()).toBe(true)
     expect(wrapper.find('img').attributes('src')).toBeDefined()
     expect(wrapper.find('img').attributes('src')).toBe('https://picsum.photos/1024/480/?image=52')
+
+    wrapper.destroy()
   })
 
   it('has image when prop img-blank is set', async () => {
@@ -173,6 +209,8 @@ describe('carousel-slide', () => {
     expect(wrapper.find('img').exists()).toBe(true)
     expect(wrapper.find('img').attributes('src')).toBeDefined()
     expect(wrapper.find('img').attributes('src')).toContain('data:')
+
+    wrapper.destroy()
   })
 
   it('has image with alt attribute when prop img-alt is set', async () => {
@@ -186,6 +224,8 @@ describe('carousel-slide', () => {
     expect(wrapper.find('img').attributes('src')).toBeDefined()
     expect(wrapper.find('img').attributes('alt')).toBeDefined()
     expect(wrapper.find('img').attributes('alt')).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('has image with width and height attrs when props img-width and img-height are set', async () => {
@@ -202,6 +242,8 @@ describe('carousel-slide', () => {
     expect(wrapper.find('img').attributes('width')).toBe('1024')
     expect(wrapper.find('img').attributes('height')).toBeDefined()
     expect(wrapper.find('img').attributes('height')).toBe('480')
+
+    wrapper.destroy()
   })
 
   it('has image with width and height attrs inherited from carousel parent', async () => {
@@ -223,5 +265,7 @@ describe('carousel-slide', () => {
     expect(wrapper.find('img').attributes('width')).toBe('1024')
     expect(wrapper.find('img').attributes('height')).toBeDefined()
     expect(wrapper.find('img').attributes('height')).toBe('480')
+
+    wrapper.destroy()
   })
 })

--- a/src/components/dropdown/dropdown-item-button.spec.js
+++ b/src/components/dropdown/dropdown-item-button.spec.js
@@ -6,12 +6,16 @@ describe('dropdown-item-button', () => {
     const wrapper = mount(DropdownItemBtn)
     expect(wrapper.is('button')).toBe(true)
     expect(wrapper.attributes('type')).toBe('button')
+
+    wrapper.destroy()
   })
 
   it('has class "dropdown-item"', async () => {
     const wrapper = mount(DropdownItemBtn)
     expect(wrapper.classes()).toContain('dropdown-item')
     expect(wrapper.classes()).not.toContain('active')
+
+    wrapper.destroy()
   })
 
   it('has class "active" when active=true', async () => {
@@ -20,6 +24,8 @@ describe('dropdown-item-button', () => {
     })
     expect(wrapper.classes()).toContain('active')
     expect(wrapper.classes()).toContain('dropdown-item')
+
+    wrapper.destroy()
   })
 
   it('has attribute "disabled" when disabled=true', async () => {
@@ -27,6 +33,8 @@ describe('dropdown-item-button', () => {
       propsData: { disabled: true }
     })
     expect(wrapper.attributes('disabled')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('calls dropdown hide(true) method when clicked', async () => {
@@ -48,6 +56,8 @@ describe('dropdown-item-button', () => {
     await wrapper.vm.$nextTick()
     expect(called).toBe(true)
     expect(refocus).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('does not call dropdown hide(true) method when clicked and disabled', async () => {
@@ -70,5 +80,7 @@ describe('dropdown-item-button', () => {
     await wrapper.vm.$nextTick()
     expect(called).toBe(false)
     expect(refocus).toBe(null)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/dropdown/dropdown-item.spec.js
+++ b/src/components/dropdown/dropdown-item.spec.js
@@ -6,12 +6,16 @@ describe('dropdown-item', () => {
     const wrapper = mount(DropdownItem)
     expect(wrapper.is('a')).toBe(true)
     expect(wrapper.attributes('href')).toBe('#')
+
+    wrapper.destroy()
   })
 
   it('has class "dropdown-item"', async () => {
     const wrapper = mount(DropdownItem)
     expect(wrapper.classes()).toContain('dropdown-item')
     expect(wrapper.attributes('href')).toBe('#')
+
+    wrapper.destroy()
   })
 
   it('calls dropdown hide(true) method when clicked', async () => {
@@ -33,6 +37,8 @@ describe('dropdown-item', () => {
     await wrapper.vm.$nextTick()
     expect(called).toBe(true)
     expect(refocus).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('does not call dropdown hide(true) method when clicked and disabled', async () => {
@@ -55,5 +61,7 @@ describe('dropdown-item', () => {
     await wrapper.vm.$nextTick()
     expect(called).toBe(false)
     expect(refocus).toBe(null)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/form-checkbox/form-checkbox-group.spec.js
+++ b/src/components/form-checkbox/form-checkbox-group.spec.js
@@ -12,11 +12,15 @@ describe('form-checkbox-group', () => {
     expect(wrapper.is('div')).toBe(true)
     const children = wrapper.element.children
     expect(children.length).toEqual(0)
+
+    wrapper.destroy()
   })
 
   it('default has no classes on wrapper', async () => {
     const wrapper = mount(Group)
     expect(wrapper.classes().length).toEqual(0)
+
+    wrapper.destroy()
   })
 
   it('default has auto ID set', async () => {
@@ -26,28 +30,38 @@ describe('form-checkbox-group', () => {
     await wrapper.vm.$nextTick()
     // Auto ID not generated until after mount
     expect(wrapper.attributes('id')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has tabindex set to -1', async () => {
     const wrapper = mount(Group)
     expect(wrapper.attributes('tabindex')).toBeDefined()
     expect(wrapper.attributes('tabindex')).toBe('-1')
+
+    wrapper.destroy()
   })
 
   it('default does not have aria-required set', async () => {
     const wrapper = mount(Group)
     expect(wrapper.attributes('aria-required')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default does not have aria-invalid set', async () => {
     const wrapper = mount(Group)
     expect(wrapper.attributes('aria-invalid')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has attribute role=group', async () => {
     const wrapper = mount(Group)
     expect(wrapper.attributes('role')).toBeDefined()
     expect(wrapper.attributes('role')).toBe('group')
+
+    wrapper.destroy()
   })
 
   it('default has user provided ID', async () => {
@@ -59,6 +73,8 @@ describe('form-checkbox-group', () => {
     })
     expect(wrapper.attributes('id')).toBeDefined()
     expect(wrapper.attributes('id')).toBe('test')
+
+    wrapper.destroy()
   })
 
   it('default has class was-validated when validated=true', async () => {
@@ -70,6 +86,8 @@ describe('form-checkbox-group', () => {
     })
     expect(wrapper.classes()).toBeDefined()
     expect(wrapper.classes()).toContain('was-validated')
+
+    wrapper.destroy()
   })
 
   it('default has attribute aria-invalid=true when state=false', async () => {
@@ -81,6 +99,8 @@ describe('form-checkbox-group', () => {
     })
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('default does not have attribute aria-invalid when state=true', async () => {
@@ -91,6 +111,8 @@ describe('form-checkbox-group', () => {
       }
     })
     expect(wrapper.attributes('aria-invalid')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default does not have attribute aria-invalid when state=null', async () => {
@@ -101,6 +123,8 @@ describe('form-checkbox-group', () => {
       }
     })
     expect(wrapper.attributes('aria-invalid')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid=true', async () => {
@@ -112,6 +136,8 @@ describe('form-checkbox-group', () => {
     })
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid="true"', async () => {
@@ -123,6 +149,8 @@ describe('form-checkbox-group', () => {
     })
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid=""', async () => {
@@ -134,6 +162,8 @@ describe('form-checkbox-group', () => {
     })
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   /* button mode structure */
@@ -149,6 +179,8 @@ describe('form-checkbox-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('btn-group-toggle')
+
+    wrapper.destroy()
   })
 
   it('button mode has classes button-group-vertical and button-group-toggle when stacked=true', async () => {
@@ -163,6 +195,8 @@ describe('form-checkbox-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('btn-group-vertical')
     expect(wrapper.classes()).toContain('btn-group-toggle')
+
+    wrapper.destroy()
   })
 
   it('button mode has size class when size prop set', async () => {
@@ -178,6 +212,8 @@ describe('form-checkbox-group', () => {
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('btn-group-toggle')
     expect(wrapper.classes()).toContain('btn-group-lg')
+
+    wrapper.destroy()
   })
 
   it('button mode has size class when size prop set and stacked', async () => {
@@ -194,6 +230,8 @@ describe('form-checkbox-group', () => {
     expect(wrapper.classes()).toContain('btn-group-vertical')
     expect(wrapper.classes()).toContain('btn-group-toggle')
     expect(wrapper.classes()).toContain('btn-group-lg')
+
+    wrapper.destroy()
   })
 
   it('button mode button variant works', async () => {
@@ -231,6 +269,8 @@ describe('form-checkbox-group', () => {
     expect(btns.at(0).classes()).toContain('btn-primary')
     expect(btns.at(1).classes()).toContain('btn-primary')
     expect(btns.at(2).classes()).toContain('btn-danger')
+
+    wrapper.destroy()
   })
 
   /* functionality testing */
@@ -248,6 +288,8 @@ describe('form-checkbox-group', () => {
     expect(checks.length).toBe(3)
     expect(wrapper.vm.localChecked).toEqual([])
     expect(checks.is('input[type=checkbox]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('has checkboxes via options array which respect disabled', async () => {
@@ -266,6 +308,8 @@ describe('form-checkbox-group', () => {
     expect(checks.at(0).attributes('disabled')).not.toBeDefined()
     expect(checks.at(1).attributes('disabled')).not.toBeDefined()
     expect(checks.at(2).attributes('disabled')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('emits change event when checkbox clicked', async () => {
@@ -310,6 +354,8 @@ describe('form-checkbox-group', () => {
     expect(wrapper.emitted('change')[3][0]).toEqual(['three', 'two'])
     expect(wrapper.emitted('input').length).toBe(4)
     expect(wrapper.emitted('input')[3][0]).toEqual(['three', 'two'])
+
+    wrapper.destroy()
   })
 
   it('checkboxes reflect group checked v-model', async () => {
@@ -338,6 +384,8 @@ describe('form-checkbox-group', () => {
     expect(checks.at(0).element.checked).toBe(true)
     expect(checks.at(1).element.checked).toBe(false)
     expect(checks.at(2).element.checked).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('child checkboxes have is-valid classes when group state set to valid', async () => {
@@ -355,6 +403,8 @@ describe('form-checkbox-group', () => {
     expect(wrapper.vm.localChecked).toEqual([])
     expect(checks.is('input[type=checkbox]')).toBe(true)
     expect(checks.is('input.is-valid')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('child checkboxes have is-invalid classes when group state set to invalid', async () => {
@@ -371,6 +421,8 @@ describe('form-checkbox-group', () => {
     expect(wrapper.vm.localChecked).toEqual([])
     expect(checks.is('input[type=checkbox]')).toBe(true)
     expect(checks.is('input.is-invalid')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('child checkboxes have disabled attribute when group disabled', async () => {
@@ -387,6 +439,8 @@ describe('form-checkbox-group', () => {
     expect(wrapper.vm.localChecked).toEqual([])
     expect(checks.is('input[type=checkbox]')).toBe(true)
     expect(checks.is('input[disabled]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('child checkboxes have required attribute when group required', async () => {
@@ -405,6 +459,8 @@ describe('form-checkbox-group', () => {
     expect(checks.is('input[type=checkbox]')).toBe(true)
     expect(checks.is('input[required]')).toBe(true)
     expect(checks.is('input[aria-required="true"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('child checkboxes have class custom-control-inline when stacked=false', async () => {
@@ -420,6 +476,8 @@ describe('form-checkbox-group', () => {
     const checks = wrapper.findAll('.custom-control')
     expect(checks.length).toBe(3)
     expect(checks.is('div.custom-control-inline')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('child checkboxes do not have class custom-control-inline when stacked=true', async () => {
@@ -435,5 +493,7 @@ describe('form-checkbox-group', () => {
     const checks = wrapper.findAll('.custom-control')
     expect(checks.length).toBe(3)
     expect(checks.is('div.custom-control-inline')).toBe(false)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/form-checkbox/form-checkbox.spec.js
+++ b/src/components/form-checkbox/form-checkbox.spec.js
@@ -20,6 +20,8 @@ describe('form-checkbox', () => {
     expect(children.length).toEqual(2)
     expect(children[0].tagName).toEqual('INPUT')
     expect(children[1].tagName).toEqual('LABEL')
+
+    wrapper.destroy()
   })
 
   it('default has wrapper class custom-control and custom-checkbox', async () => {
@@ -35,6 +37,8 @@ describe('form-checkbox', () => {
     expect(wrapper.classes().length).toEqual(2)
     expect(wrapper.classes()).toContain('custom-control')
     expect(wrapper.classes()).toContain('custom-checkbox')
+
+    wrapper.destroy()
   })
 
   it('default has input type checkbox', async () => {
@@ -50,6 +54,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('checkbox')
+
+    wrapper.destroy()
   })
 
   it('default has input class custom-control-input', async () => {
@@ -64,6 +70,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('custom-control-input')
+
+    wrapper.destroy()
   })
 
   it('default has label class custom-control-label', async () => {
@@ -78,6 +86,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('label')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('custom-control-label')
+
+    wrapper.destroy()
   })
 
   it('has default slot content in label', async () => {
@@ -91,6 +101,8 @@ describe('form-checkbox', () => {
     })
     const label = wrapper.find('label')
     expect(label.text()).toEqual('foobar')
+
+    wrapper.destroy()
   })
 
   it('default has no disabled attribute on input', async () => {
@@ -104,6 +116,8 @@ describe('form-checkbox', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('disabled')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has disabled attribute on input when prop disabled set', async () => {
@@ -118,6 +132,8 @@ describe('form-checkbox', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('disabled')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has no required attribute on input', async () => {
@@ -131,6 +147,8 @@ describe('form-checkbox', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('required')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('does not have required attribute on input when prop required set and name prop not provided', async () => {
@@ -145,6 +163,8 @@ describe('form-checkbox', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('required')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has required attribute on input when prop required and name set', async () => {
@@ -160,6 +180,8 @@ describe('form-checkbox', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('required')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has no name attribute on input', async () => {
@@ -173,6 +195,8 @@ describe('form-checkbox', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('name')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has name attribute on input when name prop set', async () => {
@@ -188,6 +212,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input.attributes('name')).toBeDefined()
     expect(input.attributes('name')).toEqual('test')
+
+    wrapper.destroy()
   })
 
   it('default has no form attribute on input', async () => {
@@ -201,6 +227,8 @@ describe('form-checkbox', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('form')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has form attribute on input when form prop set', async () => {
@@ -216,6 +244,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input.attributes('form')).toBeDefined()
     expect(input.attributes('form')).toEqual('test')
+
+    wrapper.destroy()
   })
 
   it('default has class custom-control-inline when prop inline=true', async () => {
@@ -232,6 +262,8 @@ describe('form-checkbox', () => {
     expect(wrapper.classes()).toContain('custom-checkbox')
     expect(wrapper.classes()).toContain('custom-control')
     expect(wrapper.classes()).toContain('custom-control-inline')
+
+    wrapper.destroy()
   })
 
   it('default has no input validation classes by default', async () => {
@@ -247,6 +279,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has no input validation classes when state=null', async () => {
@@ -263,6 +297,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has input validation class is-valid when state=true', async () => {
@@ -279,6 +315,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has input validation class is-valid when state="valid"', async () => {
@@ -295,6 +333,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has input validation class is-invalid when state=false', async () => {
@@ -311,6 +351,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has input validation class is-invalid when state="invalid"', async () => {
@@ -327,6 +369,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   /* plain styling */
@@ -348,6 +392,8 @@ describe('form-checkbox', () => {
     expect(children.length).toEqual(2)
     expect(children[0].tagName).toEqual('INPUT')
     expect(children[1].tagName).toEqual('LABEL')
+
+    wrapper.destroy()
   })
 
   it('plain has wrapper class form-check', async () => {
@@ -363,6 +409,8 @@ describe('form-checkbox', () => {
     })
     expect(wrapper.classes().length).toEqual(1)
     expect(wrapper.classes()).toContain('form-check')
+
+    wrapper.destroy()
   })
 
   it('plain has input type checkbox', async () => {
@@ -379,6 +427,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('checkbox')
+
+    wrapper.destroy()
   })
 
   it('plain has input class form-check-input', async () => {
@@ -394,6 +444,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('form-check-input')
+
+    wrapper.destroy()
   })
 
   it('plain has label class form-check-label', async () => {
@@ -409,6 +461,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('label')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('form-check-label')
+
+    wrapper.destroy()
   })
 
   it('plain has default slot content in label', async () => {
@@ -423,6 +477,8 @@ describe('form-checkbox', () => {
     })
     const label = wrapper.find('label')
     expect(label.text()).toEqual('foobar')
+
+    wrapper.destroy()
   })
 
   it('plain has no input validation classes by default', async () => {
@@ -439,6 +495,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has no input validation classes when state=null', async () => {
@@ -456,6 +514,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has input validation class is-valid when state=true', async () => {
@@ -473,6 +533,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has input validation class is-valid when state="valid"', async () => {
@@ -490,6 +552,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has input validation class is-invalid when state=false', async () => {
@@ -507,6 +571,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has input validation class is-invalid when state="invalid"', async () => {
@@ -524,6 +590,8 @@ describe('form-checkbox', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   /* switch styling - stand alone */
@@ -545,6 +613,8 @@ describe('form-checkbox', () => {
     expect(children.length).toEqual(2)
     expect(children[0].tagName).toEqual('INPUT')
     expect(children[1].tagName).toEqual('LABEL')
+
+    wrapper.destroy()
   })
 
   it('switch has wrapper classes custom-control and custom-switch', async () => {
@@ -561,6 +631,8 @@ describe('form-checkbox', () => {
     expect(wrapper.classes().length).toEqual(2)
     expect(wrapper.classes()).toContain('custom-control')
     expect(wrapper.classes()).toContain('custom-switch')
+
+    wrapper.destroy()
   })
 
   it('switch has input type checkbox', async () => {
@@ -577,6 +649,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('checkbox')
+
+    wrapper.destroy()
   })
 
   it('switch has input class custom-control-input', async () => {
@@ -592,6 +666,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('custom-control-input')
+
+    wrapper.destroy()
   })
 
   it('switch has label class custom-control-label', async () => {
@@ -607,6 +683,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('label')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('custom-control-label')
+
+    wrapper.destroy()
   })
 
   /* button styling - stand-alone mode */
@@ -630,6 +708,8 @@ describe('form-checkbox', () => {
     const input = label[0].children
     expect(input.length).toEqual(1)
     expect(input[0].tagName).toEqual('INPUT')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has wrapper classes btn-group-toggle and d-inline-block', async () => {
@@ -646,6 +726,8 @@ describe('form-checkbox', () => {
     expect(wrapper.classes().length).toEqual(2)
     expect(wrapper.classes()).toContain('btn-group-toggle')
     expect(wrapper.classes()).toContain('d-inline-block')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label classes btn and btn-secondary when uchecked', async () => {
@@ -666,6 +748,8 @@ describe('form-checkbox', () => {
     expect(label.classes()).not.toContain('focus')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label classes btn, btn-secondary and active when checked by default', async () => {
@@ -686,6 +770,8 @@ describe('form-checkbox', () => {
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
     expect(label.classes()).toContain('active')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label class active when clicked (checked)', async () => {
@@ -713,6 +799,8 @@ describe('form-checkbox', () => {
     expect(label.classes()).toContain('active')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label class focus when input focused', async () => {
@@ -741,6 +829,8 @@ describe('form-checkbox', () => {
     input.trigger('blur')
     expect(label.classes().length).toEqual(2)
     expect(label.classes()).not.toContain('focus')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label btn-primary when prop btn-variant set to primary', async () => {
@@ -763,6 +853,8 @@ describe('form-checkbox', () => {
     expect(label.classes()).not.toContain('btn-secondary')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-primary')
+
+    wrapper.destroy()
   })
 
   /* indeterminate testing */
@@ -779,6 +871,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input).toBeDefined()
     expect(input.element.indeterminate).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('has input indeterminate set by when indetermnate=true', async () => {
@@ -794,6 +888,8 @@ describe('form-checkbox', () => {
     const input = wrapper.find('input')
     expect(input).toBeDefined()
     expect(input.element.indeterminate).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('has input indeterminate set by when indetermnate set to true after mount', async () => {
@@ -817,6 +913,8 @@ describe('form-checkbox', () => {
       indeterminate: false
     })
     expect(input.element.indeterminate).toBe(false)
+
+    wrapper.destroy()
   })
 
   /* functionality testing */
@@ -833,6 +931,8 @@ describe('form-checkbox', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.localChecked).toBeDefined()
     expect(wrapper.vm.localChecked).toEqual(false)
+
+    wrapper.destroy()
   })
 
   it('default has internal localChecked=true when prop checked=true', async () => {
@@ -847,6 +947,8 @@ describe('form-checkbox', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.localChecked).toBeDefined()
     expect(wrapper.vm.localChecked).toEqual(true)
+
+    wrapper.destroy()
   })
 
   it('default has internal localChecked null', async () => {
@@ -862,6 +964,8 @@ describe('form-checkbox', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.localChecked).toBeDefined()
     expect(wrapper.vm.localChecked).toBe(null)
+
+    wrapper.destroy()
   })
 
   it('default has internal localChecked set to checked prop', async () => {
@@ -878,6 +982,8 @@ describe('form-checkbox', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.localChecked).toBeDefined()
     expect(wrapper.vm.localChecked).toEqual('')
+
+    wrapper.destroy()
   })
 
   it('default has internal localChecked set to value when checked=value', async () => {
@@ -894,6 +1000,8 @@ describe('form-checkbox', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.localChecked).toBeDefined()
     expect(wrapper.vm.localChecked).toEqual('bar')
+
+    wrapper.destroy()
   })
 
   it('default has internal localChecked set to value when checked changed to value', async () => {
@@ -917,6 +1025,8 @@ describe('form-checkbox', () => {
     const last = wrapper.emitted('input').length - 1
     expect(wrapper.emitted('input')[last]).toBeDefined()
     expect(wrapper.emitted('input')[last][0]).toEqual('bar')
+
+    wrapper.destroy()
   })
 
   it('emits a change event when clicked', async () => {
@@ -946,6 +1056,8 @@ describe('form-checkbox', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual('foo')
+
+    wrapper.destroy()
   })
 
   it('works when v-model bound to an array', async () => {
@@ -993,6 +1105,8 @@ describe('form-checkbox', () => {
     input.trigger('click')
     expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
     expect(wrapper.vm.localChecked.length).toBe(0)
+
+    wrapper.destroy()
   })
 
   it('works when value is an object', async () => {
@@ -1024,6 +1138,8 @@ describe('form-checkbox', () => {
     expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
     expect(wrapper.vm.localChecked.length).toBe(1)
     expect(wrapper.vm.localChecked[0]).toEqual('foo')
+
+    wrapper.destroy()
   })
 
   it('focus() and blur() methods work', async () => {
@@ -1056,5 +1172,7 @@ describe('form-checkbox', () => {
     wrapper.vm.blur()
     wrapper.vm.$nextTick()
     expect(input.element).not.toBe(document.activeElement)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/form-file/form-file.spec.js
+++ b/src/components/form-file/form-file.spec.js
@@ -34,6 +34,8 @@ describe('form-file', () => {
     expect(label.classes()).toContain('custom-file-label')
     expect(label.attributes('for')).toBeDefined()
     expect(label.attributes('for')).toBe('foo')
+
+    wrapper.destroy()
   })
 
   it('default has input attribute multiple when multiple=true', async () => {
@@ -45,6 +47,8 @@ describe('form-file', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('multiple')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has input attribute required when required=true', async () => {
@@ -58,6 +62,8 @@ describe('form-file', () => {
     expect(input.attributes('required')).toBeDefined()
     expect(input.attributes('aria-required')).toBeDefined()
     expect(input.attributes('aria-required')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('default has input attribute disabled when disabled=true', async () => {
@@ -69,6 +75,8 @@ describe('form-file', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('disabled')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has input attribute capture when capture=true', async () => {
@@ -80,6 +88,8 @@ describe('form-file', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('capture')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has input attribute accept when accept is set', async () => {
@@ -92,6 +102,8 @@ describe('form-file', () => {
     const input = wrapper.find('input')
     expect(input.attributes('accept')).toBeDefined()
     expect(input.attributes('accept')).toBe('image/*')
+
+    wrapper.destroy()
   })
 
   it('default has input attribute name when name is set', async () => {
@@ -104,6 +116,8 @@ describe('form-file', () => {
     const input = wrapper.find('input')
     expect(input.attributes('name')).toBeDefined()
     expect(input.attributes('name')).toBe('bar')
+
+    wrapper.destroy()
   })
 
   it('default has input attribute form when form is set', async () => {
@@ -116,6 +130,8 @@ describe('form-file', () => {
     const input = wrapper.find('input')
     expect(input.attributes('form')).toBeDefined()
     expect(input.attributes('form')).toBe('bar')
+
+    wrapper.destroy()
   })
 
   it('default has class focus when input focused', async () => {
@@ -136,6 +152,8 @@ describe('form-file', () => {
     input.trigger('focusout')
     await wrapper.vm.$nextTick()
     expect(input.classes()).not.toContain('focus')
+
+    wrapper.destroy()
   })
 
   it('has no wrapper div or label when plain=true', async () => {
@@ -151,6 +169,8 @@ describe('form-file', () => {
     expect(wrapper.attributes('id')).toBeDefined()
     expect(wrapper.attributes('id')).toBe('foo')
     expect(wrapper.attributes('multiple')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('emits input event when file changed', async () => {
@@ -174,6 +194,8 @@ describe('form-file', () => {
     wrapper.vm.setFiles([file])
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input').length).toEqual(1)
+
+    wrapper.destroy()
   })
 
   it('emits input event when files changed in multiple mode', async () => {
@@ -211,6 +233,8 @@ describe('form-file', () => {
     // Setting to array of new files should emit event
     wrapper.vm.setFiles(files.slice().reverse())
     expect(wrapper.emitted('input').length).toEqual(2)
+
+    wrapper.destroy()
   })
 
   it('native change event works', async () => {
@@ -237,6 +261,8 @@ describe('form-file', () => {
     expect(wrapper.emitted('change').length).toEqual(1)
     expect(wrapper.emitted('input').length).toEqual(2)
     expect(wrapper.emitted('input')[1][0]).toEqual(null)
+
+    wrapper.destroy()
   })
 
   it('reset() method works in single mode', async () => {
@@ -261,6 +287,8 @@ describe('form-file', () => {
     wrapper.vm.reset()
     expect(wrapper.emitted('input').length).toEqual(2)
     expect(wrapper.emitted('input')[1][0]).toEqual(null)
+
+    wrapper.destroy()
   })
 
   it('reset() method works in multiple mode', async () => {
@@ -289,6 +317,8 @@ describe('form-file', () => {
     wrapper.vm.reset()
     expect(wrapper.emitted('input').length).toEqual(2)
     expect(wrapper.emitted('input')[1][0]).toEqual([])
+
+    wrapper.destroy()
   })
 
   it('reset works in single mode by setting value', async () => {
@@ -315,6 +345,8 @@ describe('form-file', () => {
 
     expect(wrapper.emitted('input').length).toEqual(2)
     expect(wrapper.emitted('input')[1][0]).toEqual(null)
+
+    wrapper.destroy()
   })
 
   it('reset works in multiple mode by setting value', async () => {
@@ -356,6 +388,8 @@ describe('form-file', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.emitted('input').length).toEqual(4)
     expect(wrapper.emitted('input')[3][0]).toEqual([])
+
+    wrapper.destroy()
   })
 
   it('native reset event works', async () => {
@@ -381,5 +415,7 @@ describe('form-file', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.emitted('input').length).toEqual(2)
     expect(wrapper.emitted('input')[1][0]).toEqual(null)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/form-input/form-input.spec.js
+++ b/src/components/form-input/form-input.spec.js
@@ -129,9 +129,8 @@ describe('form-input', () => {
       attachToDocument: true
     })
     const input = wrapper.find('input')
-    return wrapper.vm.$nextTick().then(function() {
-      expect(input.attributes('id')).toBeDefined()
-    })
+    await wrapper.vm.$nextTick()
+    expect(input.attributes('id')).toBeDefined()
 
     wrapper.destroy()
   })

--- a/src/components/form-input/form-input.spec.js
+++ b/src/components/form-input/form-input.spec.js
@@ -7,6 +7,8 @@ describe('form-input', () => {
     const wrapper = mount(Input)
     const input = wrapper.find('input')
     expect(input.classes()).toContain('form-control')
+
+    wrapper.destroy()
   })
 
   it('has class form-control-lg when size=lg and plane=false', async () => {
@@ -17,6 +19,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.classes()).toContain('form-control-lg')
+
+    wrapper.destroy()
   })
 
   it('has class form-control-sm when size=lg and plain=false', async () => {
@@ -27,6 +31,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.classes()).toContain('form-control-sm')
+
+    wrapper.destroy()
   })
 
   it('does not have class form-control-plaintext when plaintext not set', async () => {
@@ -34,6 +40,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).not.toContain('form-control-plaintext')
     expect(input.attributes('readonly')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has class form-control-plaintext when plaintext=true', async () => {
@@ -44,6 +52,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.classes()).toContain('form-control-plaintext')
+
+    wrapper.destroy()
   })
 
   it('has attribute read-only when plaintext=true', async () => {
@@ -55,6 +65,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).toContain('form-control-plaintext')
     expect(input.attributes('readonly')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has class custom-range instead of form-control when type=range', async () => {
@@ -66,6 +78,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).toContain('custom-range')
     expect(input.classes()).not.toContain('form-control')
+
+    wrapper.destroy()
   })
 
   it('does not have class form-control-plaintext when type=range and plaintext=true', async () => {
@@ -79,6 +93,8 @@ describe('form-input', () => {
     expect(input.classes()).toContain('custom-range')
     expect(input.classes()).not.toContain('form-control')
     expect(input.classes()).not.toContain('form-control-plaintext')
+
+    wrapper.destroy()
   })
 
   it('does not have class form-control-plaintext when type=color and plaintext=true', async () => {
@@ -92,6 +108,8 @@ describe('form-input', () => {
     expect(input.classes()).not.toContain('custom-range')
     expect(input.classes()).not.toContain('form-control-plaintext')
     expect(input.classes()).toContain('form-control')
+
+    wrapper.destroy()
   })
 
   it('has user supplied id', async () => {
@@ -102,6 +120,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('id')).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('has safeId after mount when no id provided', async () => {
@@ -112,6 +132,8 @@ describe('form-input', () => {
     return wrapper.vm.$nextTick().then(function() {
       expect(input.attributes('id')).toBeDefined()
     })
+
+    wrapper.destroy()
   })
 
   it('has form attribute when form prop set', async () => {
@@ -122,12 +144,16 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('form')).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('does not have list attribute when list prop not set', async () => {
     const wrapper = mount(Input)
     const input = wrapper.find('input')
     expect(input.attributes('list')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has list attribute when list prop set', async () => {
@@ -138,6 +164,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('list')).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('does not have list attribute when list prop set and type=password', async () => {
@@ -149,12 +177,16 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('list')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('renders text input by default', async () => {
     const wrapper = mount(Input)
     const input = wrapper.find('input')
     expect(input.attributes('type')).toBe('text')
+
+    wrapper.destroy()
   })
 
   it('renders number input when type set to number', async () => {
@@ -165,6 +197,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('type')).toBe('number')
+
+    wrapper.destroy()
   })
 
   it('renders text input when type not supported', async () => {
@@ -183,6 +217,8 @@ describe('form-input', () => {
 
     expect(Vue.config.warnHandler).toHaveBeenCalled()
     Vue.config.warnHandler = warnHandler
+
+    wrapper.destroy()
   })
 
   it('does not have is-valid or is-invalid classes when state is default', async () => {
@@ -190,6 +226,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).not.toContain('is-valid')
     expect(input.classes()).not.toContain('is-invalid')
+
+    wrapper.destroy()
   })
 
   it('does not have is-valid or is-invalid classes when state=""', async () => {
@@ -201,6 +239,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).not.toContain('is-valid')
     expect(input.classes()).not.toContain('is-invalid')
+
+    wrapper.destroy()
   })
 
   it('has class is-valid when state=true', async () => {
@@ -212,6 +252,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).toContain('is-valid')
     expect(input.classes()).not.toContain('is-invalid')
+
+    wrapper.destroy()
   })
 
   it('has class is-valid when state="valid"', async () => {
@@ -223,6 +265,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).toContain('is-valid')
     expect(input.classes()).not.toContain('is-invalid')
+
+    wrapper.destroy()
   })
 
   it('has class is-invalid when state=false', async () => {
@@ -234,6 +278,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('has class is-invalid when state="invalid"', async () => {
@@ -245,11 +291,15 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('does not have aria-invalid attribute by default', async () => {
     const wrapper = mount(Input)
     expect(wrapper.contains('[aria-invalid]')).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('does not have aria-invalid attribute when state is true', async () => {
@@ -259,6 +309,8 @@ describe('form-input', () => {
       }
     })
     expect(wrapper.contains('[aria-invalid]')).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('has aria-invalid attribute when state=false', async () => {
@@ -269,6 +321,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('has aria-invalid attribute when aria-invalid="true"', async () => {
@@ -279,6 +333,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('has aria-invalid attribute when aria-invalid=true', async () => {
@@ -289,6 +345,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('has aria-invalid attribute when aria-invalid="spelling"', async () => {
@@ -299,6 +357,8 @@ describe('form-input', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('aria-invalid')).toBe('spelling')
+
+    wrapper.destroy()
   })
 
   it('is disabled when disabled=true', async () => {
@@ -310,6 +370,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(!!input.attributes('disabled')).toBe(true)
     expect(input.element.disabled).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('is not disabled when disabled=false', async () => {
@@ -321,6 +383,8 @@ describe('form-input', () => {
     const input = wrapper.find('input')
     expect(!!input.attributes('disabled')).toBe(false)
     expect(input.element.disabled).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('emits an input event', async () => {
@@ -333,6 +397,8 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted().input[0].length).toEqual(1)
     expect(wrapper.emitted().input[0][0]).toEqual('test')
+
+    wrapper.destroy()
   })
 
   it('emits a native focus event', async () => {
@@ -347,6 +413,8 @@ describe('form-input', () => {
 
     expect(wrapper.emitted()).toMatchObject({})
     expect(spy).toHaveBeenCalled()
+
+    wrapper.destroy()
   })
 
   it('emits a blur event with native event as only arg', async () => {
@@ -362,6 +430,8 @@ describe('form-input', () => {
     expect(wrapper.emitted('blur')[0].length).toEqual(1)
     expect(wrapper.emitted('blur')[0][0] instanceof Event).toBe(true)
     expect(wrapper.emitted('blur')[0][0].type).toEqual('blur')
+
+    wrapper.destroy()
   })
 
   it('applies formatter on input when not lazy', async () => {
@@ -386,6 +456,8 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')[0][0]).toEqual('test')
 
     expect(input.vm.localValue).toEqual('test')
+
+    wrapper.destroy()
   })
 
   it('does not apply formatter on input when lazy', async () => {
@@ -410,6 +482,8 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')[0][0]).toEqual('TEST')
     expect(wrapper.emitted('change')).not.toBeDefined()
     expect(input.vm.localValue).toEqual('TEST')
+
+    wrapper.destroy()
   })
 
   it('applies formatter on blur when lazy', async () => {
@@ -444,6 +518,8 @@ describe('form-input', () => {
     expect(wrapper.emitted('blur')).toBeDefined()
     expect(wrapper.emitted('blur').length).toEqual(1)
     expect(input.vm.localValue).toEqual('test')
+
+    wrapper.destroy()
   })
 
   it('does not apply formatter when value supplied on mount and not lazy', async () => {
@@ -463,6 +539,8 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).not.toBeDefined()
     expect(wrapper.emitted('change')).not.toBeDefined()
     expect(wrapper.emitted('blur')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('does not apply formatter when value prop updated and not lazy', async () => {
@@ -484,6 +562,8 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).not.toBeDefined()
     expect(wrapper.emitted('change')).not.toBeDefined()
     expect(wrapper.emitted('blur')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('does not apply formatter when value prop updated and lazy', async () => {
@@ -505,6 +585,8 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).not.toBeDefined()
     expect(wrapper.emitted('change')).not.toBeDefined()
     expect(wrapper.emitted('blur')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('does not update value when non-lazy formatter returns false', async () => {
@@ -525,6 +607,8 @@ describe('form-input', () => {
     // value in input should remain the same as entered
     expect(input.element.value).toEqual('TEST')
     expect(wrapper.vm.localValue).toBe('abc')
+
+    wrapper.destroy()
   })
 
   it('focused number input with no-wheel set to true works', async () => {
@@ -550,6 +634,8 @@ describe('form-input', () => {
 
     // no-wheel=true will fire a blur event on the input when wheel fired
     expect(spy).toHaveBeenCalled()
+
+    wrapper.destroy()
   })
 
   it('focused number input with no-wheel set to false works', async () => {
@@ -575,6 +661,8 @@ describe('form-input', () => {
 
     // no-wheel=false will not fire a blur event on the input when wheel fired
     expect(spy).not.toHaveBeenCalled()
+
+    wrapper.destroy()
   })
 
   it('changing no-wheel after mount works', async () => {
@@ -610,6 +698,8 @@ describe('form-input', () => {
 
     // no-wheel=true will fire a blur event on the input when wheel fired
     expect(spy).toHaveBeenCalled()
+
+    wrapper.destroy()
   })
 
   it('"number" modifier prop works', async () => {
@@ -656,6 +746,8 @@ describe('form-input', () => {
     })
     await wrapper.vm.$nextTick()
     expect(input.element.value).toBe('45.6')
+
+    wrapper.destroy()
   })
 
   it('focus() and blur() methods work', async () => {
@@ -672,5 +764,7 @@ describe('form-input', () => {
     expect(document.activeElement).toBe(input.element)
     wrapper.vm.blur()
     expect(document.activeElement).not.toBe(input.element)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/form-radio/form-radio-group.spec.js
+++ b/src/components/form-radio/form-radio-group.spec.js
@@ -12,11 +12,15 @@ describe('form-radio-group', () => {
     expect(wrapper.is('div')).toBe(true)
     const children = wrapper.element.children
     expect(children.length).toEqual(0)
+
+    wrapper.destroy()
   })
 
   it('default has no classes on wrapper', async () => {
     const wrapper = mount(Group)
     expect(wrapper.classes().length).toEqual(0)
+
+    wrapper.destroy()
   })
 
   it('default has auto ID set', async () => {
@@ -26,28 +30,38 @@ describe('form-radio-group', () => {
     await wrapper.vm.$nextTick()
     // Auto ID not generated until after mount
     expect(wrapper.attributes('id')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has tabindex set to -1', async () => {
     const wrapper = mount(Group)
     expect(wrapper.attributes('tabindex')).toBeDefined()
     expect(wrapper.attributes('tabindex')).toBe('-1')
+
+    wrapper.destroy()
   })
 
   it('default does not have aria-required set', async () => {
     const wrapper = mount(Group)
     expect(wrapper.attributes('aria-required')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default does not have aria-invalid set', async () => {
     const wrapper = mount(Group)
     expect(wrapper.attributes('aria-invalid')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has attribute role=radiogroup', async () => {
     const wrapper = mount(Group)
     expect(wrapper.attributes('role')).toBeDefined()
     expect(wrapper.attributes('role')).toBe('radiogroup')
+
+    wrapper.destroy()
   })
 
   it('default has user provided ID', async () => {
@@ -59,6 +73,8 @@ describe('form-radio-group', () => {
     })
     expect(wrapper.attributes('id')).toBeDefined()
     expect(wrapper.attributes('id')).toBe('test')
+
+    wrapper.destroy()
   })
 
   it('default has class was-validated when validated=true', async () => {
@@ -70,6 +86,8 @@ describe('form-radio-group', () => {
     })
     expect(wrapper.classes()).toBeDefined()
     expect(wrapper.classes()).toContain('was-validated')
+
+    wrapper.destroy()
   })
 
   it('default has attribute aria-invalid=true when state=false', async () => {
@@ -81,6 +99,8 @@ describe('form-radio-group', () => {
     })
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('default does not have attribute aria-invalid when state=true', async () => {
@@ -91,6 +111,8 @@ describe('form-radio-group', () => {
       }
     })
     expect(wrapper.attributes('aria-invalid')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default does not have attribute aria-invalid when state=null', async () => {
@@ -101,6 +123,8 @@ describe('form-radio-group', () => {
       }
     })
     expect(wrapper.attributes('aria-invalid')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid=true', async () => {
@@ -112,6 +136,8 @@ describe('form-radio-group', () => {
     })
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid="true"', async () => {
@@ -123,6 +149,8 @@ describe('form-radio-group', () => {
     })
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid=""', async () => {
@@ -134,6 +162,8 @@ describe('form-radio-group', () => {
     })
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
+
+    wrapper.destroy()
   })
 
   /* button mode structure */
@@ -149,6 +179,8 @@ describe('form-radio-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('btn-group-toggle')
+
+    wrapper.destroy()
   })
 
   it('button mode has classes button-group-vertical and button-group-toggle when stacked=true', async () => {
@@ -163,6 +195,8 @@ describe('form-radio-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('btn-group-vertical')
     expect(wrapper.classes()).toContain('btn-group-toggle')
+
+    wrapper.destroy()
   })
 
   it('button mode has size class when size prop set', async () => {
@@ -178,6 +212,8 @@ describe('form-radio-group', () => {
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('btn-group-toggle')
     expect(wrapper.classes()).toContain('btn-group-lg')
+
+    wrapper.destroy()
   })
 
   it('button mode has size class when size prop set and stacked', async () => {
@@ -194,6 +230,8 @@ describe('form-radio-group', () => {
     expect(wrapper.classes()).toContain('btn-group-vertical')
     expect(wrapper.classes()).toContain('btn-group-toggle')
     expect(wrapper.classes()).toContain('btn-group-lg')
+
+    wrapper.destroy()
   })
 
   it('button mode button-variant works', async () => {
@@ -231,6 +269,8 @@ describe('form-radio-group', () => {
     expect(btns.at(0).classes()).toContain('btn-primary')
     expect(btns.at(1).classes()).toContain('btn-primary')
     expect(btns.at(2).classes()).toContain('btn-danger')
+
+    wrapper.destroy()
   })
 
   /* functionality testing */
@@ -248,6 +288,8 @@ describe('form-radio-group', () => {
     expect(radios.length).toBe(3)
     expect(wrapper.vm.localChecked).toEqual('')
     expect(radios.is('input[type=radio]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('has radios via options array which respect disabled', async () => {
@@ -266,6 +308,8 @@ describe('form-radio-group', () => {
     expect(radios.at(0).attributes('disabled')).not.toBeDefined()
     expect(radios.at(1).attributes('disabled')).not.toBeDefined()
     expect(radios.at(2).attributes('disabled')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has radios with attribute required when prop required set', async () => {
@@ -287,6 +331,8 @@ describe('form-radio-group', () => {
     expect(radios.is('input[type=radio]')).toBe(true)
     expect(radios.is('input[required]')).toBe(true)
     expect(radios.is('input[aria-required="true"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('emits change event when radio clicked', async () => {
@@ -324,6 +370,8 @@ describe('form-radio-group', () => {
     expect(wrapper.emitted('change')[2][0]).toEqual('one')
     expect(wrapper.emitted('input').length).toBe(3)
     expect(wrapper.emitted('input')[2][0]).toEqual('one')
+
+    wrapper.destroy()
   })
 
   it('radios reflect group checked v-model', async () => {
@@ -352,5 +400,7 @@ describe('form-radio-group', () => {
     expect(radios.at(0).element.checked).toBe(true)
     expect(radios.at(1).element.checked).toBe(false)
     expect(radios.at(2).element.checked).toBe(false)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/form-radio/form-radio.spec.js
+++ b/src/components/form-radio/form-radio.spec.js
@@ -20,6 +20,8 @@ describe('form-radio', () => {
     expect(children.length).toEqual(2)
     expect(children[0].tagName).toEqual('INPUT')
     expect(children[1].tagName).toEqual('LABEL')
+
+    wrapper.destroy()
   })
 
   it('default has wrapper class custom-control and custom-radio', async () => {
@@ -35,6 +37,8 @@ describe('form-radio', () => {
     expect(wrapper.classes().length).toEqual(2)
     expect(wrapper.classes()).toContain('custom-control')
     expect(wrapper.classes()).toContain('custom-radio')
+
+    wrapper.destroy()
   })
 
   it('default has input type radio', async () => {
@@ -50,6 +54,8 @@ describe('form-radio', () => {
     const input = wrapper.find('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('radio')
+
+    wrapper.destroy()
   })
 
   it('default has input class custom-control-input', async () => {
@@ -65,6 +71,8 @@ describe('form-radio', () => {
     const input = wrapper.find('input')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('custom-control-input')
+
+    wrapper.destroy()
   })
 
   it('default has label class custom-control-label', async () => {
@@ -80,6 +88,8 @@ describe('form-radio', () => {
     const input = wrapper.find('label')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('custom-control-label')
+
+    wrapper.destroy()
   })
 
   it('has default slot content in label', async () => {
@@ -94,6 +104,8 @@ describe('form-radio', () => {
     })
     const label = wrapper.find('label')
     expect(label.text()).toEqual('foobar')
+
+    wrapper.destroy()
   })
 
   it('default has no disabled attribute on input', async () => {
@@ -108,6 +120,8 @@ describe('form-radio', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('disabled')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has disabled attribute on input when prop disabled set', async () => {
@@ -123,6 +137,8 @@ describe('form-radio', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('disabled')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has no required attribute on input', async () => {
@@ -137,6 +153,8 @@ describe('form-radio', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('required')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('does not have required attribute on input when prop required set and name prop not provided', async () => {
@@ -152,6 +170,8 @@ describe('form-radio', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('required')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has required attribute on input when prop required and name set', async () => {
@@ -168,6 +188,8 @@ describe('form-radio', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('required')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has no name attribute on input', async () => {
@@ -182,6 +204,8 @@ describe('form-radio', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('name')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has name attribute on input when name prop set', async () => {
@@ -198,6 +222,8 @@ describe('form-radio', () => {
     const input = wrapper.find('input')
     expect(input.attributes('name')).toBeDefined()
     expect(input.attributes('name')).toEqual('test')
+
+    wrapper.destroy()
   })
 
   it('default has no form attribute on input', async () => {
@@ -212,6 +238,8 @@ describe('form-radio', () => {
     })
     const input = wrapper.find('input')
     expect(input.attributes('form')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has form attribute on input when form prop set', async () => {
@@ -228,6 +256,8 @@ describe('form-radio', () => {
     const input = wrapper.find('input')
     expect(input.attributes('form')).toBeDefined()
     expect(input.attributes('form')).toEqual('test')
+
+    wrapper.destroy()
   })
 
   it('default has class custom-control-inline when prop inline=true', async () => {
@@ -245,6 +275,8 @@ describe('form-radio', () => {
     expect(wrapper.classes()).toContain('custom-radio')
     expect(wrapper.classes()).toContain('custom-control')
     expect(wrapper.classes()).toContain('custom-control-inline')
+
+    wrapper.destroy()
   })
 
   it('default has no input validation classes by default', async () => {
@@ -261,6 +293,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has no input validation classes when state=null', async () => {
@@ -278,6 +312,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has input validation class is-valid when state=true', async () => {
@@ -295,6 +331,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has input validation class is-valid when state="valid"', async () => {
@@ -312,6 +350,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has input validation class is-invalid when state=false', async () => {
@@ -329,6 +369,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('default has input validation class is-invalid when state="invalid"', async () => {
@@ -346,6 +388,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   /* plain styling */
@@ -367,6 +411,8 @@ describe('form-radio', () => {
     expect(children.length).toEqual(2)
     expect(children[0].tagName).toEqual('INPUT')
     expect(children[1].tagName).toEqual('LABEL')
+
+    wrapper.destroy()
   })
 
   it('plain has wrapper class form-check', async () => {
@@ -382,6 +428,8 @@ describe('form-radio', () => {
     })
     expect(wrapper.classes().length).toEqual(1)
     expect(wrapper.classes()).toContain('form-check')
+
+    wrapper.destroy()
   })
 
   it('plain has input type radio', async () => {
@@ -398,6 +446,8 @@ describe('form-radio', () => {
     const input = wrapper.find('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('radio')
+
+    wrapper.destroy()
   })
 
   it('plain has input class form-check-input', async () => {
@@ -414,6 +464,8 @@ describe('form-radio', () => {
     const input = wrapper.find('input')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('form-check-input')
+
+    wrapper.destroy()
   })
 
   it('plain has label class form-check-label', async () => {
@@ -430,6 +482,8 @@ describe('form-radio', () => {
     const input = wrapper.find('label')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('form-check-label')
+
+    wrapper.destroy()
   })
 
   it('plain has default slot content in label', async () => {
@@ -445,6 +499,8 @@ describe('form-radio', () => {
     })
     const label = wrapper.find('label')
     expect(label.text()).toEqual('foobar')
+
+    wrapper.destroy()
   })
 
   it('plain has no input validation classes by default', async () => {
@@ -462,6 +518,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has no input validation classes when state=null', async () => {
@@ -480,6 +538,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has input validation class is-valid when state=true', async () => {
@@ -498,6 +558,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has input validation class is-valid when state="valid"', async () => {
@@ -516,6 +578,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has input validation class is-invalid when state=false', async () => {
@@ -534,6 +598,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('plain has input validation class is-invalid when state="invalid"', async () => {
@@ -552,6 +618,8 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   /* button styling - stand-alone mode */
@@ -575,6 +643,8 @@ describe('form-radio', () => {
     const input = label[0].children
     expect(input.length).toEqual(1)
     expect(input[0].tagName).toEqual('INPUT')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has wrapper classes btn-group-toggle and d-inline-block', async () => {
@@ -591,6 +661,8 @@ describe('form-radio', () => {
     expect(wrapper.classes().length).toEqual(2)
     expect(wrapper.classes()).toContain('btn-group-toggle')
     expect(wrapper.classes()).toContain('d-inline-block')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label classes btn and btn-secondary when uchecked', async () => {
@@ -611,6 +683,8 @@ describe('form-radio', () => {
     expect(label.classes()).not.toContain('focus')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label classes btn, btn-secondary and active when checked by default', async () => {
@@ -631,6 +705,8 @@ describe('form-radio', () => {
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
     expect(label.classes()).toContain('active')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label class active when clicked (checked)', async () => {
@@ -658,6 +734,8 @@ describe('form-radio', () => {
     expect(label.classes()).toContain('active')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label class focus when input focused', async () => {
@@ -686,6 +764,8 @@ describe('form-radio', () => {
     input.trigger('blur')
     expect(label.classes().length).toEqual(2)
     expect(label.classes()).not.toContain('focus')
+
+    wrapper.destroy()
   })
 
   it('stand-alone button has label btn-primary when prop btn-variant set to primary', async () => {
@@ -708,6 +788,8 @@ describe('form-radio', () => {
     expect(label.classes()).not.toContain('btn-secondary')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-primary')
+
+    wrapper.destroy()
   })
 
   /* functionality testing */
@@ -725,6 +807,8 @@ describe('form-radio', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.localChecked).toBeDefined()
     expect(wrapper.vm.localChecked).toBe('')
+
+    wrapper.destroy()
   })
 
   it('default has internal localChecked set to value when checked=value', async () => {
@@ -740,6 +824,8 @@ describe('form-radio', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.localChecked).toBeDefined()
     expect(wrapper.vm.localChecked).toEqual('bar')
+
+    wrapper.destroy()
   })
 
   it('default has internal localChecked set to value when checked changed to value', async () => {
@@ -763,6 +849,8 @@ describe('form-radio', () => {
     const last = wrapper.emitted('input').length - 1
     expect(wrapper.emitted('input')[last]).toBeDefined()
     expect(wrapper.emitted('input')[last][0]).toEqual('bar')
+
+    wrapper.destroy()
   })
 
   it('emits a change event when clicked', async () => {
@@ -787,6 +875,8 @@ describe('form-radio', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
     expect(wrapper.emitted('change')[0][0]).toEqual('bar')
+
+    wrapper.destroy()
   })
 
   it('works when value is an object', async () => {
@@ -808,6 +898,8 @@ describe('form-radio', () => {
 
     input.trigger('click')
     expect(wrapper.vm.localChecked).toEqual({ bar: 1, baz: 2 })
+
+    wrapper.destroy()
   })
 
   it('focus() and blur() methods work', async () => {
@@ -840,5 +932,7 @@ describe('form-radio', () => {
     wrapper.vm.blur()
     wrapper.vm.$nextTick()
     expect(input.element).not.toBe(document.activeElement)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/form-textarea/form-textarea.spec.js
+++ b/src/components/form-textarea/form-textarea.spec.js
@@ -865,7 +865,7 @@ describe('form-textarea', () => {
     await keepalive.vm.$nextTick()
     expect(textarea.vm.dontResize).toEqual(false)
 
-    input.destroy()
+    keepalive.destroy()
   })
 
   it('trim modifier prop works', async () => {

--- a/src/components/form-textarea/form-textarea.spec.js
+++ b/src/components/form-textarea/form-textarea.spec.js
@@ -3,182 +3,226 @@ import { mount } from '@vue/test-utils'
 
 describe('form-textarea', () => {
   it('root element is textarea', async () => {
-    const input = mount(Textarea)
-    expect(input.element.type).toBe('textarea')
+    const wrapper = mount(Textarea)
+    expect(wrapper.element.type).toBe('textarea')
+
+    wrapper.destroy()
   })
 
   it('does not have attribute disabled by default', async () => {
-    const input = mount(Textarea)
-    expect(input.attributes('disabled')).not.toBeDefined()
+    const wrapper = mount(Textarea)
+    expect(wrapper.attributes('disabled')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has attribute disabled when disabled=true', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         disabled: true
       }
     })
-    expect(input.attributes('disabled')).toBeDefined()
+    expect(wrapper.attributes('disabled')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('does not have attribute readonly by default', async () => {
-    const input = mount(Textarea)
-    expect(input.attributes('readonly')).not.toBeDefined()
+    const wrapper = mount(Textarea)
+    expect(wrapper.attributes('readonly')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has attribute readonly when readonly=true', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         readonly: true
       }
     })
-    expect(input.attributes('readonly')).toBeDefined()
+    expect(wrapper.attributes('readonly')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('inherits non-prop attributes', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       attrs: {
         foo: 'bar'
       }
     })
-    expect(input.attributes('foo')).toBeDefined()
-    expect(input.attributes('foo')).toBe('bar')
+    expect(wrapper.attributes('foo')).toBeDefined()
+    expect(wrapper.attributes('foo')).toBe('bar')
+
+    wrapper.destroy()
   })
 
   it('has class form-control by default', async () => {
-    const input = mount(Textarea)
-    expect(input.classes()).toContain('form-control')
+    const wrapper = mount(Textarea)
+    expect(wrapper.classes()).toContain('form-control')
+
+    wrapper.destroy()
   })
 
   it('does not have class form-control-plaintext by default', async () => {
-    const input = mount(Textarea)
-    expect(input.classes()).not.toContain('form-control-plaintext')
+    const wrapper = mount(Textarea)
+    expect(wrapper.classes()).not.toContain('form-control-plaintext')
+
+    wrapper.destroy()
   })
 
   it('does not have size classes by default', async () => {
-    const input = mount(Textarea)
-    expect(input.classes()).not.toContain('form-control-sm')
-    expect(input.classes()).not.toContain('form-control-lg')
+    const wrapper = mount(Textarea)
+    expect(wrapper.classes()).not.toContain('form-control-sm')
+    expect(wrapper.classes()).not.toContain('form-control-lg')
+
+    wrapper.destroy()
   })
 
   it('has size class when size prop is set', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         size: 'sm'
       }
     })
-    expect(input.classes()).toContain('form-control-sm')
-    input.setProps({ size: 'lg' })
-    expect(input.classes()).toContain('form-control-lg')
-    input.setProps({ size: 'foobar' })
-    expect(input.classes()).toContain('form-control-foobar')
-    input.setProps({ size: '' })
-    expect(input.classes()).not.toContain('form-control-')
+    expect(wrapper.classes()).toContain('form-control-sm')
+    wrapper.setProps({ size: 'lg' })
+    expect(wrapper.classes()).toContain('form-control-lg')
+    wrapper.setProps({ size: 'foobar' })
+    expect(wrapper.classes()).toContain('form-control-foobar')
+    wrapper.setProps({ size: '' })
+    expect(wrapper.classes()).not.toContain('form-control-')
+
+    wrapper.destroy()
   })
 
   it('has class form-control-plaintext when plaintext=true', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         plaintext: true
       }
     })
-    expect(input.classes()).toContain('form-control-plaintext')
+    expect(wrapper.classes()).toContain('form-control-plaintext')
+
+    wrapper.destroy()
   })
 
   it('does not have class form-control when plaintext=true', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         plaintext: true
       }
     })
-    expect(input.classes()).not.toContain('form-control')
+    expect(wrapper.classes()).not.toContain('form-control')
+
+    wrapper.destroy()
   })
 
   it('has attribute readonly when plaintext=true', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         plaintext: true
       }
     })
-    expect(input.attributes('readonly')).toBeDefined()
+    expect(wrapper.attributes('readonly')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('has user supplied id', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         id: 'foobar'
       }
     })
-    expect(input.attributes('id')).toBe('foobar')
+    expect(wrapper.attributes('id')).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('does not have is-valid or is-invalid classes by default', async () => {
-    const input = mount(Textarea)
-    expect(input.classes()).not.toContain('is-valid')
-    expect(input.classes()).not.toContain('is-invalid')
+    const wrapper = mount(Textarea)
+    expect(wrapper.classes()).not.toContain('is-valid')
+    expect(wrapper.classes()).not.toContain('is-invalid')
+
+    wrapper.destroy()
   })
 
   it('has class is-valid when state=true', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         state: true
       }
     })
-    expect(input.classes()).toContain('is-valid')
-    expect(input.classes()).not.toContain('is-invalid')
+    expect(wrapper.classes()).toContain('is-valid')
+    expect(wrapper.classes()).not.toContain('is-invalid')
+
+    wrapper.destroy()
   })
 
   it('has class is-valid when state=valid', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         state: 'valid'
       }
     })
-    expect(input.classes()).toContain('is-valid')
-    expect(input.classes()).not.toContain('is-invalid')
+    expect(wrapper.classes()).toContain('is-valid')
+    expect(wrapper.classes()).not.toContain('is-invalid')
+
+    wrapper.destroy()
   })
 
   it('has class is-invalid when state=false', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         state: false
       }
     })
-    expect(input.classes()).toContain('is-invalid')
-    expect(input.classes()).not.toContain('is-valid')
+    expect(wrapper.classes()).toContain('is-invalid')
+    expect(wrapper.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('has class is-invalid when state=invalid', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         state: 'invalid'
       }
     })
-    expect(input.classes()).toContain('is-invalid')
-    expect(input.classes()).not.toContain('is-valid')
+    expect(wrapper.classes()).toContain('is-invalid')
+    expect(wrapper.classes()).not.toContain('is-valid')
+
+    wrapper.destroy()
   })
 
   it('does not have aria-invalid attribute by default', async () => {
-    const input = mount(Textarea)
-    expect(input.contains('[aria-invalid]')).toBe(false)
+    const wrapper = mount(Textarea)
+    expect(wrapper.contains('[aria-invalid]')).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('does not have aria-invalid attribute when state=true', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         state: true
       }
     })
-    expect(input.contains('[aria-invalid]')).toBe(false)
+    expect(wrapper.contains('[aria-invalid]')).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('does not have aria-invalid attribute when state=valid', async () => {
-    const input = mount(Textarea, {
+    const wrapper = mount(Textarea, {
       propsData: {
         state: 'valid'
       }
     })
-    expect(input.contains('[aria-invalid]')).toBe(false)
+    expect(wrapper.contains('[aria-invalid]')).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('has aria-invalid attribute when state=false', async () => {
@@ -188,6 +232,8 @@ describe('form-textarea', () => {
       }
     })
     expect(input.attributes('aria-invalid')).toBe('true')
+
+    input.destroy()
   })
 
   it('has aria-invalid attribute when state=invalid', async () => {
@@ -197,6 +243,8 @@ describe('form-textarea', () => {
       }
     })
     expect(input.attributes('aria-invalid')).toBe('true')
+
+    input.destroy()
   })
 
   it('has aria-invalid attribute when aria-invalid=true', async () => {
@@ -208,6 +256,8 @@ describe('form-textarea', () => {
     expect(input.attributes('aria-invalid')).toBe('true')
     input.setProps({ ariaInvalid: 'true' })
     expect(input.attributes('aria-invalid')).toBe('true')
+
+    input.destroy()
   })
 
   it('has aria-invalid attribute when aria-invalid="spelling"', async () => {
@@ -217,11 +267,15 @@ describe('form-textarea', () => {
       }
     })
     expect(input.attributes('aria-invalid')).toBe('spelling')
+
+    input.destroy()
   })
 
   it('does not emit an update event on mount when value not set', async () => {
     const input = mount(Textarea)
     expect(input.emitted('update')).not.toBeDefined()
+
+    input.destroy()
   })
 
   it('does mot emit an update event on mount when value is set and no formatter', async () => {
@@ -229,6 +283,8 @@ describe('form-textarea', () => {
       value: 'foobar'
     })
     expect(input.emitted('update')).not.toBeDefined()
+
+    input.destroy()
   })
 
   it('emits an input event with single arg of value', async () => {
@@ -240,6 +296,8 @@ describe('form-textarea', () => {
     expect(input.emitted('input')).toBeDefined()
     expect(input.emitted('input')[0].length).toEqual(1)
     expect(input.emitted('input')[0][0]).toEqual('test')
+
+    input.destroy()
   })
 
   it('emits an change event with single arg of value', async () => {
@@ -254,6 +312,8 @@ describe('form-textarea', () => {
     expect(input.emitted('change')).toBeDefined()
     expect(input.emitted('change')[0].length).toEqual(1)
     expect(input.emitted('change')[0][0]).toEqual('test')
+
+    input.destroy()
   })
 
   it('emits an update event with one arg on input', async () => {
@@ -264,6 +324,8 @@ describe('form-textarea', () => {
     expect(input.emitted('update')).toBeDefined()
     expect(input.emitted('update')[0].length).toEqual(1)
     expect(input.emitted('update')[0][0]).toEqual('test')
+
+    input.destroy()
   })
 
   it('does not emit an update event on change when value not changed', async () => {
@@ -276,6 +338,8 @@ describe('form-textarea', () => {
     expect(input.emitted('update')[0][0]).toEqual('test')
     input.trigger('change')
     expect(input.emitted('update').length).toEqual(1)
+
+    input.destroy()
   })
 
   it('emits an update event with one arg on change when input text changed', async () => {
@@ -290,6 +354,8 @@ describe('form-textarea', () => {
     input.trigger('change')
     expect(input.emitted('update').length).toEqual(2)
     expect(input.emitted('update')[1][0]).toEqual('TEST')
+
+    input.destroy()
   })
 
   it('does not emit an update, input or change event when value prop changed', async () => {
@@ -304,6 +370,8 @@ describe('form-textarea', () => {
     expect(input.emitted('update')).not.toBeDefined()
     expect(input.emitted('input')).not.toBeDefined()
     expect(input.emitted('change')).not.toBeDefined()
+
+    input.destroy()
   })
 
   it('emits a native focus event', async () => {
@@ -316,18 +384,24 @@ describe('form-textarea', () => {
     input.trigger('focus')
     expect(input.emitted('focus')).not.toBeDefined()
     expect(spy).toHaveBeenCalled()
+
+    input.destroy()
   })
 
   it('emits a blur event when blurred', async () => {
     const input = mount(Textarea)
     input.trigger('blur')
     expect(input.emitted('blur')).toBeDefined()
+
+    input.destroy()
   })
 
   it('has attribute rows set to 2 by default', async () => {
     const input = mount(Textarea)
     expect(input.attributes('rows')).toBeDefined()
     expect(input.attributes('rows')).toEqual('2')
+
+    input.destroy()
   })
 
   it('has attribute rows when rows set and max-rows not set', async () => {
@@ -349,6 +423,8 @@ describe('form-textarea', () => {
     input.setProps({ rows: -10 })
     expect(input.attributes('rows')).toBeDefined()
     expect(input.attributes('rows')).toEqual('2')
+
+    input.destroy()
   })
 
   it('has attribute rows set when rows and max-rows are equal', async () => {
@@ -364,6 +440,8 @@ describe('form-textarea', () => {
     input.setProps({ rows: '10', maxRows: '10' })
     expect(input.attributes('rows')).toBeDefined()
     expect(input.attributes('rows')).toEqual('10')
+
+    input.destroy()
   })
 
   it('does not have rows set when rows and max-rows set', async () => {
@@ -374,6 +452,8 @@ describe('form-textarea', () => {
       }
     })
     expect(input.attributes('rows')).not.toBeDefined()
+
+    input.destroy()
   })
 
   it('has attribute rows set when max-rows less than rows', async () => {
@@ -385,6 +465,8 @@ describe('form-textarea', () => {
     })
     expect(input.attributes('rows')).toBeDefined()
     expect(input.attributes('rows')).toEqual('10')
+
+    input.destroy()
   })
 
   it('does not have style resize by default', async () => {
@@ -393,6 +475,8 @@ describe('form-textarea', () => {
     })
     expect(input.element.style).toBeDefined()
     expect(input.element.style.resize).toEqual('')
+
+    input.destroy()
   })
 
   it('does not have style resize when no-resize is set', async () => {
@@ -404,6 +488,8 @@ describe('form-textarea', () => {
     })
     expect(input.element.style).toBeDefined()
     expect(input.element.style.resize).toEqual('none')
+
+    input.destroy()
   })
 
   it('does not have style resize when max-rows not set', async () => {
@@ -415,6 +501,8 @@ describe('form-textarea', () => {
     })
     expect(input.element.style).toBeDefined()
     expect(input.element.style.resize).toEqual('')
+
+    input.destroy()
   })
 
   it('does not have style resize when max-rows less than rows', async () => {
@@ -427,6 +515,8 @@ describe('form-textarea', () => {
     })
     expect(input.element.style).toBeDefined()
     expect(input.element.style.resize).toEqual('')
+
+    input.destroy()
   })
 
   it('has style resize:none when max-rows greater than rows', async () => {
@@ -440,6 +530,8 @@ describe('form-textarea', () => {
     expect(input.element.style).toBeDefined()
     expect(input.element.style.resize).toBeDefined()
     expect(input.element.style.resize).toEqual('none')
+
+    input.destroy()
   })
 
   it('does not have style height by default', async () => {
@@ -449,6 +541,8 @@ describe('form-textarea', () => {
     expect(input.element.style).toBeDefined()
     expect(input.element.style.height).toBeDefined()
     expect(input.element.style.height).toEqual('')
+
+    input.destroy()
   })
 
   it('does not have style height when rows and max-rows equal', async () => {
@@ -462,6 +556,8 @@ describe('form-textarea', () => {
     expect(input.element.style).toBeDefined()
     expect(input.element.style.height).toBeDefined()
     expect(input.element.style.height).toEqual('')
+
+    input.destroy()
   })
 
   it('does not have style height when max-rows not set', async () => {
@@ -474,6 +570,8 @@ describe('form-textarea', () => {
     expect(input.element.style).toBeDefined()
     expect(input.element.style.height).toBeDefined()
     expect(input.element.style.height).toEqual('')
+
+    input.destroy()
   })
 
   /*
@@ -494,6 +592,8 @@ describe('form-textarea', () => {
     expect(input.element.style).toBeDefined()
     expect(input.element.style.height).toBeDefined()
     expect(input.element.style.height).not.toEqual('')
+
+    input.destroy()
   })
 
   it('auto height should work', async () => {
@@ -523,6 +623,8 @@ describe('form-textarea', () => {
     expect(input.element.style.height).not.toEqual('')
     const thirdHeight = parseFloat(input.element.style.height)
     expect(thirdHeight).toBeLessThan(secondHeight)
+
+    input.destroy()
   })
   */
 
@@ -549,6 +651,8 @@ describe('form-textarea', () => {
     expect(input.emitted('input')[0][0]).toEqual('test')
     // And no change event
     expect(input.emitted('change')).not.toBeDefined()
+
+    input.destroy()
   })
 
   it('Formats on change when not lazy', async () => {
@@ -574,6 +678,8 @@ describe('form-textarea', () => {
     expect(input.emitted('change')[0][0]).toEqual('test')
     // And no input event
     expect(input.emitted('input')).not.toBeDefined()
+
+    input.destroy()
   })
 
   it('Formats on blur when lazy', async () => {
@@ -627,6 +733,8 @@ describe('form-textarea', () => {
     expect(input.emitted('change').length).toEqual(1)
     expect(input.emitted('blur').length).toEqual(1)
     expect(input.emitted('update').length).toEqual(2)
+
+    input.destroy()
   })
 
   it('Does not format value on mount when not lazy', async () => {
@@ -643,6 +751,8 @@ describe('form-textarea', () => {
     expect(input.emitted('change')).not.toBeDefined()
     expect(input.emitted('update')).not.toBeDefined()
     expect(input.vm.localValue).toEqual('TEST')
+
+    input.destroy()
   })
 
   it('Does not format value on mount when lazy', async () => {
@@ -660,6 +770,8 @@ describe('form-textarea', () => {
     expect(input.emitted('change')).not.toBeDefined()
     expect(input.emitted('update')).not.toBeDefined()
     expect(input.vm.localValue).toEqual('TEST')
+
+    input.destroy()
   })
 
   it('Does not format on prop "value" change when not lazy', async () => {
@@ -681,6 +793,8 @@ describe('form-textarea', () => {
     expect(input.emitted('input')).not.toBeDefined()
     expect(input.emitted('change')).not.toBeDefined()
     expect(input.vm.localValue).toEqual('TEST')
+
+    input.destroy()
   })
 
   it('Does not format on value prop change when lazy', async () => {
@@ -704,6 +818,8 @@ describe('form-textarea', () => {
     expect(input.emitted('input')).not.toBeDefined()
     expect(input.emitted('change')).not.toBeDefined()
     expect(input.vm.localValue).toEqual('TEST')
+
+    input.destroy()
   })
 
   it('activate and deactivate hooks work (keepalive)', async () => {
@@ -748,6 +864,8 @@ describe('form-textarea', () => {
     // Check that the internal dontResize flag is now false
     await keepalive.vm.$nextTick()
     expect(textarea.vm.dontResize).toEqual(false)
+
+    input.destroy()
   })
 
   it('trim modifier prop works', async () => {
@@ -810,6 +928,8 @@ describe('form-textarea', () => {
     expect(input.emitted('change')).toBeDefined()
     expect(input.emitted('change').length).toEqual(1)
     expect(input.emitted('change')[0][0]).toEqual('  TEST  ')
+
+    input.destroy()
   })
 
   it('number modifier prop works', async () => {
@@ -873,5 +993,7 @@ describe('form-textarea', () => {
     expect(input.emitted('input').length).toEqual(4)
     expect(input.emitted('input')[3][0]).toEqual('0123 450')
     expect(typeof input.emitted('input')[3][0]).toEqual('string')
+
+    input.destroy()
   })
 })

--- a/src/components/table/table-bottom-row.spec.js
+++ b/src/components/table/table-bottom-row.spec.js
@@ -18,6 +18,8 @@ describe('table bottom-row slot', () => {
     expect(wrapper.find('tbody').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(testItems.length)
+
+    wrapper.destroy()
   })
 
   it('should render named slot `bottom-row`', async () => {
@@ -47,6 +49,8 @@ describe('table bottom-row slot', () => {
         .at(testItems.length)
         .classes()
     ).toContain('b-table-bottom-row')
+
+    wrapper.destroy()
   })
 
   it('should render scoped slot `bottom-row`', async () => {
@@ -84,5 +88,7 @@ describe('table bottom-row slot', () => {
         .at(testItems.length)
         .classes()
     ).toContain('b-table-bottom-row')
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-busy.spec.js
+++ b/src/components/table/table-busy.spec.js
@@ -12,6 +12,8 @@ describe('b-table busy state', () => {
     })
     expect(wrapper.attributes('aria-busy')).toBeDefined()
     expect(wrapper.attributes('aria-busy')).toEqual('false')
+
+    wrapper.destroy()
   })
 
   it('default should have item rows rendered', async () => {
@@ -28,6 +30,8 @@ describe('b-table busy state', () => {
         .exists()
     ).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+
+    wrapper.destroy()
   })
 
   it('should have attribute aria-busy=true when prop busy=true', async () => {
@@ -39,6 +43,8 @@ describe('b-table busy state', () => {
     })
     expect(wrapper.attributes('aria-busy')).toBeDefined()
     expect(wrapper.attributes('aria-busy')).toEqual('true')
+
+    wrapper.destroy()
   })
 
   it('should have attribute aria-busy=true when data localBusy=true', async () => {
@@ -56,6 +62,8 @@ describe('b-table busy state', () => {
 
     expect(wrapper.attributes('aria-busy')).toBeDefined()
     expect(wrapper.attributes('aria-busy')).toEqual('true')
+
+    wrapper.destroy()
   })
 
   it('should emit update:busy event when data localBusy is toggled', async () => {
@@ -72,6 +80,8 @@ describe('b-table busy state', () => {
 
     expect(wrapper.emitted('update:busy')).toBeDefined()
     expect(wrapper.emitted('update:busy')[0][0]).toEqual(true)
+
+    wrapper.destroy()
   })
 
   it('should render table-busy slot when prop busy=true and slot provided', async () => {
@@ -134,5 +144,7 @@ describe('b-table busy state', () => {
         .exists()
     ).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-caption.spec.js
+++ b/src/components/table/table-caption.spec.js
@@ -15,6 +15,8 @@ describe('table caption', () => {
     expect(wrapper).toBeDefined()
     expect(wrapper.is('table')).toBe(true)
     expect(wrapper.find('caption').exists()).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('should render named slot `table-caption`', async () => {
@@ -33,6 +35,8 @@ describe('table caption', () => {
     expect(wrapper.find('caption').text()).toBe('foobar')
     expect(wrapper.find('caption').attributes('id')).not.toBeDefined()
     expect(wrapper.find('caption').classes()).not.toContain('b-table-caption-top')
+
+    wrapper.destroy()
   })
 
   it('should render scoped slot `table-caption`', async () => {
@@ -60,6 +64,8 @@ describe('table caption', () => {
         .exists()
     ).toBe(true)
     expect(wrapper.find('caption').text()).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('should render `caption` when prop caption is set', async () => {
@@ -76,6 +82,8 @@ describe('table caption', () => {
     expect(wrapper.find('caption').text()).toBe('foobar')
     expect(wrapper.find('caption').attributes('id')).not.toBeDefined()
     expect(wrapper.find('caption').classes()).not.toContain('b-table-caption-top')
+
+    wrapper.destroy()
   })
 
   it('should render `caption` when prop caption-html is set', async () => {
@@ -98,6 +106,8 @@ describe('table caption', () => {
     expect(wrapper.find('caption').text()).toBe('foobar')
     expect(wrapper.find('caption').attributes('id')).not.toBeDefined()
     expect(wrapper.find('caption').classes()).not.toContain('b-table-caption-top')
+
+    wrapper.destroy()
   })
 
   it('should render `caption` with class when prop caption-top is set', async () => {
@@ -115,6 +125,8 @@ describe('table caption', () => {
     expect(wrapper.find('caption').text()).toBe('foobar')
     expect(wrapper.find('caption').attributes('id')).not.toBeDefined()
     expect(wrapper.find('caption').classes()).toContain('b-table-caption-top')
+
+    wrapper.destroy()
   })
 
   it('should render `caption` with id attribute when prop stacked is true', async () => {
@@ -135,6 +147,8 @@ describe('table caption', () => {
     expect(wrapper.find('caption').text()).toBe('foobar')
     expect(wrapper.find('caption').attributes('id')).toBeDefined()
     expect(wrapper.find('caption').attributes('id')).toBe('zzz__caption_')
+
+    wrapper.destroy()
   })
 
   it('should render `caption` with id attribute when prop stacked is sm', async () => {
@@ -155,5 +169,7 @@ describe('table caption', () => {
     expect(wrapper.find('caption').text()).toBe('foobar')
     expect(wrapper.find('caption').attributes('id')).toBeDefined()
     expect(wrapper.find('caption').attributes('id')).toBe('zzz__caption_')
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-colgroup.spec.js
+++ b/src/components/table/table-colgroup.spec.js
@@ -16,6 +16,8 @@ describe('table colgroup', () => {
     expect(wrapper).toBeDefined()
     expect(wrapper.is('table')).toBe(true)
     expect(wrapper.find('colgroup').exists()).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('should render named slot `table-colgroup`', async () => {
@@ -38,6 +40,8 @@ describe('table colgroup', () => {
         .exists()
     ).toBe(true)
     expect(wrapper.find('colgroup').findAll('col').length).toBe(3)
+
+    wrapper.destroy()
   })
 
   it('should render scoped slot `table-colgroup`', async () => {
@@ -70,5 +74,7 @@ describe('table colgroup', () => {
     ).toBe(true)
     expect(wrapper.findAll('col').length).toBe(1)
     expect(wrapper.find('col').attributes('span')).toBe('3')
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-primarykey.spec.js
+++ b/src/components/table/table-primarykey.spec.js
@@ -24,6 +24,8 @@ describe('b-table primary key', () => {
     expect(trs.at(0).attributes('id')).not.toBeDefined()
     expect(trs.at(1).attributes('id')).not.toBeDefined()
     expect(trs.at(2).attributes('id')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should have ids on table rows when primary key set to field', async () => {
@@ -50,6 +52,8 @@ describe('b-table primary key', () => {
     expect(trs.at(1).attributes('id')).toBe(`foo__row_${testItems[1].a}`)
     expect(trs.at(2).attributes('id')).toBeDefined()
     expect(trs.at(2).attributes('id')).toBe(`foo__row_${testItems[2].a}`)
+
+    wrapper.destroy()
   })
 
   it('should not have ids on table rows when primary key set to nonexistent field', async () => {
@@ -73,5 +77,7 @@ describe('b-table primary key', () => {
     expect(trs.at(0).attributes('id')).not.toBeDefined()
     expect(trs.at(1).attributes('id')).not.toBeDefined()
     expect(trs.at(2).attributes('id')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -38,6 +38,8 @@ describe('b-table provider functions', () => {
         .exists()
     ).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+
+    wrapper.destroy()
   })
 
   it('promise items provider works', async () => {
@@ -85,6 +87,8 @@ describe('b-table provider functions', () => {
         .exists()
     ).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+
+    wrapper.destroy()
   })
 
   it('callback items provider works', async () => {
@@ -130,6 +134,8 @@ describe('b-table provider functions', () => {
         .exists()
     ).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(testItems.length)
+
+    wrapper.destroy()
   })
 
   it('callback items provider expects 2 arguments', async () => {
@@ -173,6 +179,8 @@ describe('b-table provider functions', () => {
         .exists()
     ).toBe(true)
     expect(wrapper.find('tbody').findAll('tr').length).toBe(1)
+
+    wrapper.destroy()
   })
 
   it('provider refreshing works', async () => {
@@ -203,6 +211,8 @@ describe('b-table provider functions', () => {
     wrapper.vm.$root.$emit('bv::refresh::table', 'thetable')
     await Vue.nextTick()
     expect(wrapper.emitted('refreshed').length).toBe(3)
+
+    wrapper.destroy()
   })
 
   it('refresh debouncing works', async () => {
@@ -250,5 +260,7 @@ describe('b-table provider functions', () => {
     expect(wrapper.emitted('refreshed').length).toBe(1)
     await Vue.nextTick()
     expect(wrapper.emitted('refreshed').length).toBe(1)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-row-details.spec.js
+++ b/src/components/table/table-row-details.spec.js
@@ -23,6 +23,8 @@ describe('table row details', () => {
     expect($trs.at(0).is('tr.b-table-details')).toBe(false)
     expect($trs.at(1).is('tr.b-table-details')).toBe(false)
     expect($trs.at(2).is('tr.b-table-details')).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('expected rows have details showing', async () => {
@@ -52,6 +54,8 @@ describe('table row details', () => {
     expect($trs.at(2).is('tr.b-table-details')).toBe(false)
     expect($trs.at(3).is('tr.b-table-details')).toBe(false)
     expect($trs.at(1).text()).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('should show details slot when _showDetails changed', async () => {
@@ -86,6 +90,8 @@ describe('table row details', () => {
     expect($trs.at(3).is('tr.b-table-details')).toBe(false)
     expect($trs.at(4).is('tr.b-table-details')).toBe(true)
     expect($trs.at(4).text()).toBe('foobar')
+
+    wrapper.destroy()
   })
 
   it('should hide details slot when _showDetails changed', async () => {
@@ -123,6 +129,8 @@ describe('table row details', () => {
     expect($trs.at(0).is('tr.b-table-details')).toBe(false)
     expect($trs.at(1).is('tr.b-table-details')).toBe(false)
     expect($trs.at(2).is('tr.b-table-details')).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('should have extra spacer tr when details showing and striped=true', async () => {
@@ -159,5 +167,7 @@ describe('table row details', () => {
     expect($trs.at(3).is('tr.d-none')).toBe(false)
     expect($trs.at(4).is('tr.b-table-details')).toBe(false)
     expect($trs.at(4).is('tr.d-none')).toBe(false)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-selectable.spec.js
+++ b/src/components/table/table-selectable.spec.js
@@ -15,6 +15,8 @@ describe('table row select', () => {
     expect(wrapper).toBeDefined()
     await wrapper.vm.$nextTick()
     expect(wrapper.emitted('row-selected')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should not have aria-selected/tabindex attribute when not selctable and no row-clicked listener', async () => {
@@ -32,6 +34,8 @@ describe('table row select', () => {
     expect($rows.is('tr[aria-selected]')).toBe(false)
     // Doesn't have tabindex attribute on all TRs
     expect($rows.is('tr[tabindex]')).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('should have tabindex but not aria-selected when not selectable and has row-clicked listener', async () => {
@@ -52,6 +56,8 @@ describe('table row select', () => {
     expect($rows.is('tr[aria-selected]')).toBe(false)
     // Does have tabindex attribute on all TRs
     expect($rows.is('tr[tabindex]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('select mode single works', async () => {
@@ -118,6 +124,8 @@ describe('table row select', () => {
     expect($rows.at(1).is('[aria-selected="false"]')).toBe(true)
     expect($rows.at(2).is('[aria-selected="false"]')).toBe(true)
     expect($rows.at(3).is('[aria-selected="false"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('select mode multi works', async () => {
@@ -194,6 +202,8 @@ describe('table row select', () => {
     expect($rows.at(1).is('[aria-selected="false"]')).toBe(true)
     expect($rows.at(2).is('[aria-selected="false"]')).toBe(true)
     expect($rows.at(3).is('[aria-selected="false"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('select mode range works', async () => {
@@ -337,6 +347,8 @@ describe('table row select', () => {
     expect($rows.at(1).is('[aria-selected="false"]')).toBe(true)
     expect($rows.at(2).is('[aria-selected="false"]')).toBe(true)
     expect($rows.at(3).is('[aria-selected="false"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('sort change clears selection', async () => {
@@ -382,6 +394,8 @@ describe('table row select', () => {
     $rows = wrapper.findAll('tbody > tr')
     expect($rows.is('[tabindex="0"]')).toBe(true)
     expect($rows.is('[aria-selected="false"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('filter change clears selection', async () => {
@@ -427,6 +441,8 @@ describe('table row select', () => {
     $rows = wrapper.findAll('tbody > tr')
     expect($rows.is('[tabindex="0"]')).toBe(true)
     expect($rows.is('[aria-selected="false"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('pagination change clears selection', async () => {
@@ -478,6 +494,8 @@ describe('table row select', () => {
     expect($rows.length).toBe(1)
     expect($rows.is('[tabindex="0"]')).toBe(true)
     expect($rows.is('[aria-selected="false"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('change in select mode clears selection', async () => {
@@ -521,6 +539,8 @@ describe('table row select', () => {
     $rows = wrapper.findAll('tbody > tr')
     expect($rows.is('[tabindex="0"]')).toBe(true)
     expect($rows.is('[aria-selected="false"]')).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('disabling selectable clears selection', async () => {
@@ -564,5 +584,7 @@ describe('table row select', () => {
     // Should remove tabindex and aria-selected attributes
     expect($rows.is('[tabindex]')).toBe(false)
     expect($rows.is('[aria-selected]')).toBe(false)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-sort.spec.js
+++ b/src/components/table/table-sort.spec.js
@@ -36,6 +36,8 @@ describe('table sorting', () => {
     expect(columnA[0]).toBe('3')
     expect(columnA[1]).toBe('1')
     expect(columnA[2]).toBe('2')
+
+    wrapper.destroy()
   })
 
   it('should sort column descending when sortBy set and sortDesc changed', async () => {
@@ -107,6 +109,8 @@ describe('table sorting', () => {
     expect(columnA[0]).toBe('3')
     expect(columnA[1]).toBe('1')
     expect(columnA[2]).toBe('2')
+
+    wrapper.destroy()
   })
 
   it('should accept custom sort compare', async () => {
@@ -143,6 +147,8 @@ describe('table sorting', () => {
     expect(columnA[0]).toBe('1')
     expect(columnA[1]).toBe('2')
     expect(columnA[2]).toBe('3')
+
+    wrapper.destroy()
   })
 
   it('should sort columns when clicking headers', async () => {
@@ -256,5 +262,7 @@ describe('table sorting', () => {
     expect(columnA[0]).toBe('3')
     expect(columnA[1]).toBe('1')
     expect(columnA[2]).toBe('2')
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-tbody-row-events.spec.js
+++ b/src/components/table/table-tbody-row-events.spec.js
@@ -22,6 +22,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-clicked')[0][0]).toEqual(testItems[1]) /* row item */
     expect(wrapper.emitted('row-clicked')[0][1]).toEqual(1) /* row index */
     expect(wrapper.emitted('row-clicked')[0][2]).toBeInstanceOf(MouseEvent) /* event */
+
+    wrapper.destroy()
   })
 
   it('should not emit row-clicked event when prop busy is set', async () => {
@@ -39,6 +41,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-clicked')).not.toBeDefined()
     $rows.at(1).trigger('click')
     expect(wrapper.emitted('row-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should not emit row-clicked event when vm.localBusy is true', async () => {
@@ -57,6 +61,8 @@ describe('table tbody row events', () => {
     })
     $rows.at(1).trigger('click')
     expect(wrapper.emitted('row-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should emit row-dblclicked event when a row is dblclicked', async () => {
@@ -76,6 +82,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-dblclicked')[0][0]).toEqual(testItems[1]) /* row item */
     expect(wrapper.emitted('row-dblclicked')[0][1]).toEqual(1) /* row index */
     expect(wrapper.emitted('row-dblclicked')[0][2]).toBeInstanceOf(MouseEvent) /* event */
+
+    wrapper.destroy()
   })
 
   it('should not emit row-dblclicked event when a row is dblclicked and table busy', async () => {
@@ -92,6 +100,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-dblclicked')).not.toBeDefined()
     $rows.at(1).trigger('dblclick')
     expect(wrapper.emitted('row-dblclicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should emit row-middle-clicked event when a row is middle clicked', async () => {
@@ -112,6 +122,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-middle-clicked')[0][1]).toEqual(1) /* row index */
     // expect(wrapper.emitted('row-middle-clicked')[0][2]).toBeInstanceOf(MouseEvent) /* event */
     expect(wrapper.emitted('row-middle-clicked')[0][2]).toBeInstanceOf(Event) /* event */
+
+    wrapper.destroy()
   })
 
   it('should not emit row-middle-clicked event when a row is middle clicked and table busy', async () => {
@@ -128,6 +140,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-middle-clicked')).not.toBeDefined()
     $rows.at(1).trigger('auxclick', { which: 2 })
     expect(wrapper.emitted('row-middle-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should emit row-contextmenu event when a row is right clicked', async () => {
@@ -148,6 +162,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-contextmenu')[0][1]).toEqual(1) /* row index */
     // expect(wrapper.emitted('row-middle-clicked')[0][2]).toBeInstanceOf(MouseEvent) /* event */
     expect(wrapper.emitted('row-contextmenu')[0][2]).toBeInstanceOf(Event) /* event */
+
+    wrapper.destroy()
   })
 
   it('should not emit row-contextmenu event when a row is right clicked and table busy', async () => {
@@ -164,6 +180,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-contextmenu')).not.toBeDefined()
     $rows.at(1).trigger('contextmenu')
     expect(wrapper.emitted('row-contextmenu')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should emit row-hovered event when a row is hovered', async () => {
@@ -183,6 +201,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-hovered')[0][0]).toEqual(testItems[1]) /* row item */
     expect(wrapper.emitted('row-hovered')[0][1]).toEqual(1) /* row index */
     expect(wrapper.emitted('row-hovered')[0][2]).toBeInstanceOf(MouseEvent) /* event */
+
+    wrapper.destroy()
   })
 
   it('should not emit row-hovered event when a row is hovered and table busy', async () => {
@@ -199,6 +219,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-hovered')).not.toBeDefined()
     $rows.at(1).trigger('mouseenter')
     expect(wrapper.emitted('row-hovered')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should emit row-unhovered event when a row is unhovered', async () => {
@@ -218,6 +240,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-unhovered')[0][0]).toEqual(testItems[1]) /* row item */
     expect(wrapper.emitted('row-unhovered')[0][1]).toEqual(1) /* row index */
     expect(wrapper.emitted('row-unhovered')[0][2]).toBeInstanceOf(MouseEvent) /* event */
+
+    wrapper.destroy()
   })
 
   it('should not emit row-unhovered event when a row is unhovered and table busy', async () => {
@@ -234,6 +258,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-uhovered')).not.toBeDefined()
     $rows.at(1).trigger('mouseleave')
     expect(wrapper.emitted('row-unhovered')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should emit row-clicked event when a row is focusable and enter pressed', async () => {
@@ -259,6 +285,8 @@ describe('table tbody row events', () => {
     expect(wrapper.emitted('row-clicked')[0][1]).toEqual(1) /* row index */
     // Note: the KeyboardEvent is forwarded to the click handler
     expect(wrapper.emitted('row-clicked')[0][2]).toBeInstanceOf(KeyboardEvent) /* event */
+
+    wrapper.destroy()
   })
 
   it('should not emit row-clicked event when a row is focusable, enter pressed, and table busy', async () => {
@@ -276,6 +304,8 @@ describe('table tbody row events', () => {
     $rows.at(1).element.focus() /* event only works when the tr is focused */
     $rows.at(1).trigger('keydown.enter')
     expect(wrapper.emitted('row-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should not emit row-clicked event when clicking on a button or other interactive element', async () => {
@@ -325,5 +355,7 @@ describe('table tbody row events', () => {
     expect($label.exists()).toBe(true)
     $label.trigger('click')
     expect(wrapper.emitted('row-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-tbody-transition.spec.js
+++ b/src/components/table/table-tbody-transition.spec.js
@@ -7,6 +7,7 @@ const testFields = ['a', 'b', 'c']
 describe('table body transition', () => {
   it('tbody should not be a transition-group component by default', async () => {
     const wrapper = mount(Table, {
+      attachToDocument: true,
       propsData: {
         fields: testFields,
         items: testItems
@@ -20,10 +21,13 @@ describe('table body transition', () => {
     expect(wrapper.find('tbody').exists()).toBe(true)
     expect(wrapper.find('tbody').is('tbody')).toBe(true)
     expect(wrapper.find(TransitionGroupStub).exists()).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('tbody should be a transition-group component when tbody-transition-props set', async () => {
     const wrapper = mount(Table, {
+      attachToDocument: true,
       propsData: {
         fields: testFields,
         items: testItems,
@@ -40,10 +44,13 @@ describe('table body transition', () => {
     expect(wrapper.find(TransitionGroupStub).exists()).toBe(true)
     // Transition-group stub doesn't render itself with the specified tag
     expect(wrapper.find('tbody').exists()).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('tbody should be a transition-group component when tbody-transition-handlers set', async () => {
     const wrapper = mount(Table, {
+      attachToDocument: true,
       propsData: {
         fields: testFields,
         items: testItems,
@@ -63,5 +70,7 @@ describe('table body transition', () => {
     expect(wrapper.find(TransitionGroupStub).exists()).toBe(true)
     // Transition-group stub doesn't render itself with the specified tag
     expect(wrapper.find('tbody').exists()).toBe(false)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-tfoot-events.spec.js
+++ b/src/components/table/table-tfoot-events.spec.js
@@ -33,6 +33,8 @@ describe('table tfoot events', () => {
     expect(wrapper.emitted('head-clicked')[1][1]).toEqual(testFields[2]) /* field def */
     expect(wrapper.emitted('head-clicked')[1][2]).toBeInstanceOf(MouseEvent) /* event */
     expect(wrapper.emitted('head-clicked')[1][3]).toBe(true) /* is footer */
+
+    wrapper.destroy()
   })
 
   it('should not emit head-clicked event when prop busy is set', async () => {
@@ -50,6 +52,8 @@ describe('table tfoot events', () => {
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
     $ths.at(0).trigger('click')
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should not emit head-clicked event when vm.localBusy is true', async () => {
@@ -69,6 +73,8 @@ describe('table tfoot events', () => {
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
     $ths.at(0).trigger('click')
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should not emit head-clicked event when clicking on a button or other interactive element', async () => {
@@ -105,5 +111,7 @@ describe('table tfoot events', () => {
     expect($link.exists()).toBe(true)
     $link.trigger('click')
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-thead-events.spec.js
+++ b/src/components/table/table-thead-events.spec.js
@@ -32,6 +32,8 @@ describe('table thead events', () => {
     expect(wrapper.emitted('head-clicked')[1][1]).toEqual(testFields[2]) /* field def */
     expect(wrapper.emitted('head-clicked')[1][2]).toBeInstanceOf(MouseEvent) /* event */
     expect(wrapper.emitted('head-clicked')[1][3]).toBe(false) /* is footer */
+
+    wrapper.destroy()
   })
 
   it('should not emit head-clicked event when prop busy is set', async () => {
@@ -48,6 +50,8 @@ describe('table thead events', () => {
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
     $ths.at(0).trigger('click')
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should not emit head-clicked event when vm.localBusy is true', async () => {
@@ -66,6 +70,8 @@ describe('table thead events', () => {
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
     $ths.at(0).trigger('click')
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('should not emit head-clicked event when clicking on a button or other interactive element', async () => {
@@ -100,5 +106,7 @@ describe('table thead events', () => {
     expect($link.exists()).toBe(true)
     $link.trigger('click')
     expect(wrapper.emitted('head-clicked')).not.toBeDefined()
+
+    wrapper.destroy()
   })
 })

--- a/src/components/table/table-thead-top.spec.js
+++ b/src/components/table/table-thead-top.spec.js
@@ -18,6 +18,8 @@ describe('table thead-top slot', () => {
     expect(wrapper.find('thead').exists()).toBe(true)
     expect(wrapper.findAll('thead > tr').exists()).toBe(true)
     expect(wrapper.findAll('thead > tr').length).toBe(1)
+
+    wrapper.destroy()
   })
 
   it('should render named slot `thead-top`', async () => {
@@ -47,6 +49,8 @@ describe('table thead-top slot', () => {
         .at(0)
         .classes()
     ).toContain('test')
+
+    wrapper.destroy()
   })
 
   it('should render scoped slot `thead-top`', async () => {
@@ -86,5 +90,7 @@ describe('table thead-top slot', () => {
         .at(0)
         .classes()
     ).toContain('test')
+
+    wrapper.destroy()
   })
 })

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -22,6 +22,8 @@ describe('tab', () => {
     expect(wrapper.attributes('labelledby')).not.toBeDefined()
     expect(wrapper.attributes('tabindex')).not.toBeDefined()
     expect(wrapper.attributes('id')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has expected data state', async () => {
@@ -30,6 +32,8 @@ describe('tab', () => {
     expect(wrapper.vm._isTab).toBe(true)
     expect(wrapper.vm.localActive).toBe(false)
     expect(wrapper.vm.show).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('has class disabled when disabled=true', async () => {
@@ -43,6 +47,8 @@ describe('tab', () => {
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.classes()).not.toContain('fade')
     expect(wrapper.classes()).not.toContain('card-body')
+
+    wrapper.destroy()
   })
 
   it('has class active when active=true', async () => {
@@ -55,6 +61,8 @@ describe('tab', () => {
     expect(wrapper.classes()).not.toContain('disabled')
     expect(wrapper.classes()).not.toContain('fade')
     expect(wrapper.classes()).not.toContain('card-body')
+
+    wrapper.destroy()
   })
 
   it('does not have class active when active=true and disabled=true', async () => {
@@ -71,6 +79,8 @@ describe('tab', () => {
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.classes()).not.toContain('fade')
     expect(wrapper.classes()).not.toContain('card-body')
+
+    wrapper.destroy()
   })
 
   it('has class active and show when localActive becomes true', async () => {
@@ -108,6 +118,8 @@ describe('tab', () => {
     expect(wrapper.classes()).not.toContain('disabled')
     expect(wrapper.classes()).not.toContain('fade')
     expect(wrapper.classes()).not.toContain('card-body')
+
+    wrapper.destroy()
   })
 
   it('emits event "update:active" when localActive becomes true', async () => {
@@ -127,6 +139,8 @@ describe('tab', () => {
 
     expect(called).toBe(true)
     expect(value).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('has class fade when parent has fade=true', async () => {
@@ -149,6 +163,8 @@ describe('tab', () => {
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.classes()).not.toContain('card-body')
+
+    wrapper.destroy()
   })
 
   it('has class card-body when parent has card=true', async () => {
@@ -172,6 +188,8 @@ describe('tab', () => {
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.classes()).not.toContain('fade')
+
+    wrapper.destroy()
   })
 
   it('does not have class card-body when parent has card=true and prop no-body is set', async () => {
@@ -198,6 +216,8 @@ describe('tab', () => {
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.classes()).not.toContain('fade')
+
+    wrapper.destroy()
   })
 
   it('has attribute tabindex="0" when parent has keynav enabled and active', async () => {
@@ -217,6 +237,8 @@ describe('tab', () => {
 
     expect(wrapper.attributes('tabindex')).toBeDefined()
     expect(wrapper.attributes('tabindex')).toBe('0')
+
+    wrapper.destroy()
   })
 
   it("calls parent's updateButton() when title slot provided", async () => {
@@ -247,6 +269,8 @@ describe('tab', () => {
 
     expect(called).toBe(true)
     expect(vm).toEqual(wrapper.vm)
+
+    wrapper.destroy()
   })
 
   it('calls parent de/activateTab() when prop active changes', async () => {
@@ -303,6 +327,8 @@ describe('tab', () => {
     expect(activateVm).toBe(null)
     expect(deactivateCalled).toBe(true)
     expect(deactivateVm).toBe(wrapper.vm)
+
+    wrapper.destroy()
   })
 
   it('does not call parent activateTab() when prop active changes and disabled=true', async () => {
@@ -336,6 +362,8 @@ describe('tab', () => {
 
     expect(activateCalled).toBe(false)
     expect(activateVm).toBe(null)
+
+    wrapper.destroy()
   })
 
   it('does not call parent deactivateTab() when deactivate() called and not active', async () => {
@@ -369,5 +397,7 @@ describe('tab', () => {
     expect(deactivateCalled).toBe(false)
     expect(deactivateVm).toBe(null)
     expect(result).toBe(false)
+
+    wrapper.destroy()
   })
 })

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -17,6 +17,8 @@ describe('tabs', () => {
     expect(wrapper.classes()).not.toContain('row')
     expect(wrapper.classes()).not.toContain('no-gutters')
     expect(wrapper.attributes('id')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('default has expected data state', async () => {
@@ -24,6 +26,8 @@ describe('tabs', () => {
 
     expect(wrapper.vm.currentTab).toBe(-1)
     expect(wrapper.vm.tabs.length).toBe(0)
+
+    wrapper.destroy()
   })
 
   it('sets correct tab active for initial value', async () => {
@@ -38,6 +42,8 @@ describe('tabs', () => {
     expect(wrapper.vm.currentTab).toBe(tabIndex)
     expect(wrapper.vm.tabs.length).toBe(3)
     expect(wrapper.vm.tabs[tabIndex].localActive).toBe(true)
+
+    wrapper.destroy()
   })
 
   it('sets correct tab active when first tab is disabled', async () => {
@@ -66,6 +72,8 @@ describe('tabs', () => {
     expect(tabs.emitted('input').length).toBe(1)
     // Should emit index of 1 (2nd tab)
     expect(tabs.emitted('input')[0][0]).toBe(1)
+
+    wrapper.destroy()
   })
 
   it('sets current index based on active prop of b-tab', async () => {
@@ -94,6 +102,8 @@ describe('tabs', () => {
     expect(tabs.emitted('input').length).toBe(1)
     // Should emit index of 1 (2nd tab)
     expect(tabs.emitted('input')[0][0]).toBe(1)
+
+    wrapper.destroy()
   })
 
   it('selects first non-ditabled tab when active tab disabled', async () => {
@@ -139,6 +149,8 @@ describe('tabs', () => {
     expect(tabs.findAll(Tab).at(2).vm.localActive).toBe(true)
     expect(tabs.emitted('input').length).toBe(2)
     expect(tabs.emitted('input')[1][0]).toBe(2)
+
+    wrapper.destroy()
   })
 
   it('v-model works', async () => {
@@ -180,6 +192,8 @@ describe('tabs', () => {
     expect(tabs.emitted('input').length).toBe(2)
     // Should emit index of 2 (3rd tab)
     expect(tabs.emitted('input')[1][0]).toBe(2)
+
+    wrapper.destroy()
   })
 
   it('v-model works when trying to activate a disabled tab', async () => {
@@ -225,6 +239,8 @@ describe('tabs', () => {
     expect(tabs.emitted('input').length).toBe(2)
     // Should emit index of 0 (1st tab)
     expect(tabs.emitted('input')[1][0]).toBe(0)
+
+    wrapper.destroy()
   })
 
   it('clicking on tab activates the tab, and tab emits click event', async () => {
@@ -296,6 +312,8 @@ describe('tabs', () => {
     expect(tab2.vm.localActive).toBe(false)
     expect(tab3.vm.localActive).toBe(false)
     expect(tab1.emitted('click')).toBeDefined()
+
+    wrapper.destroy()
   })
 
   it('key nav works', async () => {
@@ -372,6 +390,8 @@ describe('tabs', () => {
     expect(tab1.vm.localActive).toBe(true)
     expect(tab2.vm.localActive).toBe(false)
     expect(tab3.vm.localActive).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('disabling active tab selects first non-disabled tab', async () => {
@@ -422,6 +442,8 @@ describe('tabs', () => {
     expect(tab1.vm.localActive).toBe(false)
     expect(tab2.vm.localActive).toBe(true)
     expect(tab3.vm.localActive).toBe(false)
+
+    wrapper.destroy()
   })
 
   it('tab title slots are reactive', async () => {
@@ -454,5 +476,7 @@ describe('tabs', () => {
 
     // Expect tab button content to be `foobar`
     expect(wrapper.find('.nav-link').text()).toBe('foobar')
+
+    wrapper.destroy()
   })
 })

--- a/src/utils/dom.spec.js
+++ b/src/utils/dom.spec.js
@@ -29,18 +29,6 @@ const template1 = `
 `
 
 const App = Vue.extend({
-  destroyed() {
-    // Hack to remove DOM from document as vue-test-utils leaves
-    // the rendered DOM in document after each test, when
-    // mounting option `attachToDocument` is true.
-    // Requires each test to call wrapper.vm.$destroy() when done
-    //
-    // See: https://github.com/vuejs/vue-test-utils/issues/1185
-    //
-    if (this.$el && this.$el.parentNode && this.$el.parentNode.removeChild) {
-      this.$el.parentNode.removeChild(this.$el)
-    }
-  },
   template: template1
 })
 
@@ -55,7 +43,7 @@ describe('utils/dom', () => {
     expect(isElement(null)).toBe(false)
     expect(isElement(App)).toBe(false)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('isDisabled works', async () => {
@@ -71,7 +59,7 @@ describe('utils/dom', () => {
     expect(isDisabled($btns.at(1).element)).toBe(false)
     expect(isDisabled($btns.at(2).element)).toBe(true)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('hasClass works', async () => {
@@ -88,7 +76,7 @@ describe('utils/dom', () => {
     expect(hasClass($span.element, 'fizzlerocks')).toBe(false)
     expect(hasClass(null, 'foobar')).toBe(false)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('contains works', async () => {
@@ -109,7 +97,7 @@ describe('utils/dom', () => {
     expect(contains($span.element, $btn1.element)).toBe(false)
     expect(contains(null, $btn1.element)).toBe(false)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('closest works', async () => {
@@ -133,7 +121,7 @@ describe('utils/dom', () => {
     expect(closest('div.baz', $btns.at(0).element)).toBe($baz.element)
     expect(closest('div.nothere', $btns.at(0).element)).toBe(null)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('matches works', async () => {
@@ -158,7 +146,7 @@ describe('utils/dom', () => {
     expect(matches($btns.at(0).element, 'button#button1')).toBe(true)
     expect(matches(null, 'div.foo')).toBe(false)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('hasAttr works', async () => {
@@ -178,7 +166,7 @@ describe('utils/dom', () => {
     expect(hasAttr($btns.at(2).element, 'role')).toBe(false)
     expect(hasAttr(null, 'role')).toBe(null)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('getAttr works', async () => {
@@ -201,7 +189,7 @@ describe('utils/dom', () => {
     expect(getAttr($btns.at(0).element, '')).toBe(null)
     expect(getAttr($btns.at(0).element, undefined)).toBe(null)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('select works', async () => {
@@ -227,7 +215,7 @@ describe('utils/dom', () => {
     expect(select('button#button3')).toBe($btns.at(2).element)
     expect(select('span.nothere')).toBe(null)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('selectAll works', async () => {
@@ -274,7 +262,7 @@ describe('utils/dom', () => {
     expect(selectAll('div.baz button')[1]).toBe($btns.at(1).element)
     expect(selectAll('div.baz button')[2]).toBe($btns.at(2).element)
 
-    wrapper.vm.$destroy()
+    wrapper.destroy()
   })
 
   it('event options parsing works', async () => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

Vue-test-utils does not automatically destroy mounted wrappers at the end of each test.  This can potentially cause test issues (when using native DOM querySelector methods), and since the DOM is not removed from the JSDOM document it can impact memory usage over time for large test suites.

Note however, that, currently, wrapper.destroy() does not work with functional components.

See https://github.com/vuejs/vue-test-utils/issues/1185

This PR adds `wrapper.destroy()` at the end of each `it(...)` test where appropriate (mainly for mounts that set `attachToDocument: true`), for non-functional component mounts.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other, please describe: test suites

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
