### PR TITLE
fix(utils/get): handle case when nested value is falsy

### DIFF
--- a/src/utils/get.js
+++ b/src/utils/get.js
@@ -37,7 +37,7 @@ const get = (obj, path, defaultValue = null) => {
   }
 
   // Traverse path in object to find result
-  return steps.every(step => isObject(obj) && obj.hasOwnProperty(step) && (obj = obj[step]))
+  return steps.every(step => isObject(obj) && obj.hasOwnProperty(step) && ((obj = obj[step]) != null))
     ? obj
     : defaultValue
 }

--- a/src/utils/get.js
+++ b/src/utils/get.js
@@ -37,7 +37,7 @@ const get = (obj, path, defaultValue = null) => {
   }
 
   // Traverse path in object to find result
-  return steps.every(step => isObject(obj) && obj.hasOwnProperty(step) && ((obj = obj[step]) != null))
+  return steps.every(step => isObject(obj) && obj.hasOwnProperty(step) && (obj = obj[step]) != null)
     ? obj
     : defaultValue
 }

--- a/src/utils/get.spec.js
+++ b/src/utils/get.spec.js
@@ -19,6 +19,7 @@ describe('get', () => {
     expect(get({}, [], 0)).toBe(0)
     expect(get({ a: 'b' }, 'b', {})).toEqual({})
     expect(get({ a: { c: 'd' } }, 'a.d', [])).toEqual([])
+    expect(get({ a: { c: undefined } }, 'a.c')).toBe(null)
   })
 
   it('returns expected value', async () => {
@@ -26,6 +27,7 @@ describe('get', () => {
     const obj2 = { a: { b: { c: { d: 'e' } } } }
     const obj3 = { a: [{ b: 'c' }] }
     const obj4 = { a: [[{ b: 'c' }], [{ d: { e: ['f'] } }]] }
+    const obj5 = { a: { b: 0, c: '', d: false } }
 
     expect(get(obj1, 'a')).toBe('b')
     expect(get(obj1, ['a'])).toBe('b')
@@ -36,6 +38,9 @@ describe('get', () => {
     expect(get(obj4, 'a[1][0].d.e[0]')).toBe('f')
     expect(get(obj4, ['a', 1, 0, 'd', 'e', 0])).toBe('f')
     expect(get(obj4, ['a[1]', 0, 'd', 'e[0]'])).toBe('f')
+    expect(get(obj5, 'a.b')).toBe(0)
+    expect(get(obj5, 'a.c')).toBe('')
+    expect(get(obj5, 'a.d')).toBe(false)
   })
 
   it('handles when field name has dot', async () => {

--- a/src/utils/get.spec.js
+++ b/src/utils/get.spec.js
@@ -20,6 +20,7 @@ describe('get', () => {
     expect(get({ a: 'b' }, 'b', {})).toEqual({})
     expect(get({ a: { c: 'd' } }, 'a.d', [])).toEqual([])
     expect(get({ a: { c: undefined } }, 'a.c')).toBe(null)
+    expect(get({ a: 0, b: false }, 'c')).toBe(null)
   })
 
   it('returns expected value', async () => {
@@ -28,6 +29,7 @@ describe('get', () => {
     const obj3 = { a: [{ b: 'c' }] }
     const obj4 = { a: [[{ b: 'c' }], [{ d: { e: ['f'] } }]] }
     const obj5 = { a: { b: 0, c: '', d: false } }
+    const obj6 = { a: 0, b: false }
 
     expect(get(obj1, 'a')).toBe('b')
     expect(get(obj1, ['a'])).toBe('b')
@@ -41,6 +43,8 @@ describe('get', () => {
     expect(get(obj5, 'a.b')).toBe(0)
     expect(get(obj5, 'a.c')).toBe('')
     expect(get(obj5, 'a.d')).toBe(false)
+    expect(get(obj6, 'a')).toBe(0)
+    expect(get(obj6, 'b')).toBe(false)
   })
 
   it('handles when field name has dot', async () => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

If the nested value in an object was `0`, `get()` was returning `null` instead of the correct value.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
