### PR TITLE
fix(breadcrumb-item): remove `role="presentation"` (closes #2988)

### DIFF
--- a/src/components/breadcrumb/breadcrumb-item.js
+++ b/src/components/breadcrumb/breadcrumb-item.js
@@ -11,8 +11,7 @@ export default {
       'li',
       mergeData(data, {
         staticClass: 'breadcrumb-item',
-        class: { active: props.active },
-        attrs: { role: 'presentation' }
+        class: { active: props.active }
       }),
       [h(BBreadcrumbLink, { props }, children)]
     )

--- a/src/components/breadcrumb/breadcrumb-item.spec.js
+++ b/src/components/breadcrumb/breadcrumb-item.spec.js
@@ -8,8 +8,6 @@ describe('breadcrumb-item', () => {
     expect(wrapper.classes()).toContain('breadcrumb-item')
     expect(wrapper.classes()).not.toContain('active')
     expect(wrapper.classes().length).toBe(1)
-    expect(wrapper.attributes('role')).toBeDefined()
-    expect(wrapper.attributes('role')).toBe('presentation')
   })
 
   it('has class active when prop active is set', async () => {
@@ -22,8 +20,6 @@ describe('breadcrumb-item', () => {
     expect(wrapper.classes()).toContain('active')
     expect(wrapper.classes()).toContain('breadcrumb-item')
     expect(wrapper.classes().length).toBe(2)
-    expect(wrapper.attributes('role')).toBeDefined()
-    expect(wrapper.attributes('role')).toBe('presentation')
   })
 
   it('has link as child', async () => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

This PR removes the `role="presentation"` attribute from `<breadcrumb-item>` which is causing accessibility warnings.

Closes #2988.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement to an existing feature
- [x] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
