### PR TITLE
fix(form-textarea): improved computedHeight calculation when in auto resize mode

### DIFF
--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -54,7 +54,7 @@ export default {
       const styles = {
         // Setting `noResize` to true will disable the ability for the user to
         // manually resize the textarea. We also disable when in auto resize mode
-        resize: !this.computedRows || this.noResize ? 'none' : null,
+        resize: !this.computedRows || this.noResize ? 'none' : null
       }
       if (!this.computedRows) {
         // The computed height for auto resize.

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -54,7 +54,10 @@ export default {
       const styles = {
         // Setting `noResize` to true will disable the ability for the user to
         // manually resize the textarea. We also disable when in auto resize mode
-        resize: !this.computedRows || this.noResize ? 'none' : null
+        resize: !this.computedRows || this.noResize ? 'none' : null,
+        // We always add a vertical scrollbar to the textarea when auto-resize is
+        // enabled so that the computed height calcaultion returns a stable value.
+        'overflow-y': this.computedRows ? 'scroll' : null
       }
       if (!this.computedRows) {
         // The computed height for auto resize.

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -92,7 +92,7 @@ export default {
       const el = this.$el
 
       // Element must be visible (not hidden) and in document
-      // *Must* be checked after above checks
+      // Must be checked after above checks
       if (!isVisible(el)) {
         return null
       }
@@ -101,17 +101,14 @@ export default {
       const computedStyle = getCS(el)
       // Height of one line of text in px
       const lineHeight = parseFloat(computedStyle.lineHeight)
-      // calculate height of border and padding
-      const border = (
+      // Calculate height of border and padding
+      const border =
         (parseFloat(computedStyle.borderTopWidth) || 0) +
         (parseFloat(computedStyle.borderBottomWidth) || 0)
-      )
-      const padding = (
-        (parseFloat(computedStyle.paddingTop) || 0) +
-        (parseFloat(computedStyle.paddingBottom) || 0)
-      )
-      // calculate offset
-      const offset = (computedStyle.boxSizing === 'border-box' ? border + padding : 0 )
+      const padding =
+        (parseFloat(computedStyle.paddingTop) || 0) + (parseFloat(computedStyle.paddingBottom) || 0)
+      // Calculate offset
+      const offset = computedStyle.boxSizing === 'border-box' ? border + padding : 0
       // Minimum height for min rows (browser dependant)
       const minHeight = lineHeight * this.computedMinRows + offset
 
@@ -128,10 +125,9 @@ export default {
       // Calculate the required height of the textarea including border and padding (in pixels)
       const height = Math.max(Math.ceil(rows * lineHeight + offset), minHeight)
 
-      // noAutoShrink
+      // Computed height remains the larger of oldHeight and new height
+      // When height is `sticky` (no-auto-shrink is true)
       if (this.noAutoShrink && (parseFloat(oldHeight) || 0) > height) {
-        // Computed height remains the larger of oldHeight and new height
-        // When height is `sticky` (no-auto-shrink is true)
         return oldHeight
       }
 

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -108,7 +108,7 @@ export default {
       const padding =
         (parseFloat(computedStyle.paddingTop) || 0) + (parseFloat(computedStyle.paddingBottom) || 0)
       // Calculate offset
-      const offset = computedStyle.boxSizing === 'border-box' ? border + padding : 0
+      const offset = border + padding
       // Minimum height for min rows (browser dependant)
       const minHeight = lineHeight * this.computedMinRows + offset
 

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -114,7 +114,7 @@ export default {
 
       // Probe scrollHeight by temporarily changing the height to the minimum
       const oldHeight = el.style.height
-      el.style.height = minHeight + 'px'
+      el.style.height = `${minHeight}px`
       const scrollHeight = el.scrollHeight
       el.style.height = oldHeight
 

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -55,14 +55,14 @@ export default {
         // Setting `noResize` to true will disable the ability for the user to
         // manually resize the textarea. We also disable when in auto resize mode
         resize: !this.computedRows || this.noResize ? 'none' : null,
-        // We always add a vertical scrollbar to the textarea when auto-resize is
-        // enabled so that the computed height calcaultion returns a stable value.
-        'overflow-y': this.computedRows ? 'scroll' : null
       }
       if (!this.computedRows) {
         // The computed height for auto resize.
         // We avoid setting the style to null, which can override user manual resize.
         styles.height = this.computedHeight
+        // We always add a vertical scrollbar to the textarea when auto-resize is
+        // enabled so that the computed height calcaultion returns a stable value.
+        styles.overflowY = 'scroll'
       }
       return styles
     },


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

`computedHeight` is used, when `max-rows` is given to an `b-form-textarea` to calculate the auto height.

**1. fix: not subtracting border width from scrollHeight**
`scrollHeight` contains only the padding and not the border.
This resulted in an incorrect calculation of `contentRows` (float instead of int) and lead to an visible vertical scroll bar, even when `max-rows` haven't been reached yet.

~**2. fix: respecting boxSizing in height calculation**~
~Depending on boxSizing, the height of the element contains the padding and border (`box-sizing: border-box`) or not (`box-sizing: content-box`).~ **EDIT (by TM):** _Bootstrap CSS always sets every element to `border-box`, so this extra test would only generate overhead that is not needed_.

~**3. fix: setting height temporary to `minHeight` instead of `'auto'`**~
~Setting it to `auto` might result in a height that is bigger than 2 content rows.
This is bad because when the content height is lower than this height, then `scrollHeight` is affected by this. It effectively results in the `auto`-height being the `minHeight`, therefore the textarea is bigger than it should be.~

---

I only tested chrome, firefox and waterfox on desktop. Because one of the lines I changed was marked as "browser dependant" it should better be tested thoroughly - especially on mobile browsers.

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [ ] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
