### PR TITLE
fix(v-b-toggle/b-collapse): ensure toggle remains in sync with collapse (Closes #3020)

### DIFF
--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -7,6 +7,7 @@ const EVENT_STATE = 'bv::collapse::state'
 const EVENT_ACCORDION = 'bv::collapse::accordion'
 // Private event we emit on $root to ensure the toggle state is always synced
 // Gets emited even if the state has not changed!
+// This event is NOT to be documented as people should not be using it.
 const EVENT_STATE_SYNC = 'bv::collapse::sync::state'
 // Events we listen to on $root
 const EVENT_TOGGLE = 'bv::toggle::collapse'

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -73,12 +73,14 @@ export default {
     }
   },
   created() {
+    this.show = this.visible
     // Listen for toggle events to open/close us
     this.listenOnRoot(EVENT_TOGGLE, this.handleToggleEvt)
     // Listen to other collapses for accordion events
     this.listenOnRoot(EVENT_ACCORDION, this.handleAccordionEvt)
   },
   mounted() {
+    this.show = this.visible
     if (this.isNav && inBrowser) {
       // Set up handlers
       this.setWindowEvents(true)
@@ -90,7 +92,8 @@ export default {
   },
   updated() {
     // Emit a private event every time this component updates
-    // to ensure the toggle button is in sync with the collapse's state
+    // to ensure the toggle button is in sync with the collapse's state.
+    // It is emitted regardless if the visible state changes.
     this.$root.$emit(EVENT_STATE_SYNC, this.id, this.show)
   },
   deactivated() /* istanbul ignore next */ {

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -5,6 +5,9 @@ import { closest, matches, reflow, getCS, getBCR, eventOn, eventOff } from '../.
 // Events we emit on $root
 const EVENT_STATE = 'bv::collapse::state'
 const EVENT_ACCORDION = 'bv::collapse::accordion'
+// Private event we emit on $root to ensure the toggle state is always synced
+// Gets emited even if the state has not changed!
+const EVENT_STATE_SYNC = 'bv::collapse::sync::state'
 // Events we listen to on $root
 const EVENT_TOGGLE = 'bv::toggle::collapse'
 
@@ -80,7 +83,14 @@ export default {
       this.setWindowEvents(true)
       this.handleResize()
     }
-    this.emitState()
+    this.$nextTick(() => {
+      this.emitState()
+    })
+  },
+  updated() {
+    // Emit a private event every time this component updates
+    // to ensure the toggle button is in sync with the collapse's state
+    this.$root.$emit(EVENT_STATE_SYNC, this.id, this.show)
   },
   deactivated() /* istanbul ignore next */ {
     if (this.isNav && inBrowser) {
@@ -91,6 +101,7 @@ export default {
     if (this.isNav && inBrowser) {
       this.setWindowEvents(true)
     }
+    this.$root.$emit(EVENT_STATE_SYNC, this.id, this.show)
   },
   beforeDestroy() {
     // Trigger state emit if needed

--- a/src/components/navbar/navbar-toggle.js
+++ b/src/components/navbar/navbar-toggle.js
@@ -21,11 +21,11 @@ export default {
   },
   created() {
     this.listenOnRoot('bv::collapse::state', this.handleStateEvt)
+    this.listenOnRoot('bv::collapse::sync::state', this.handleStateEvt)
   },
   methods: {
     onClick(evt) {
       this.$emit('click', evt)
-      /* istanbul ignore next */
       if (!evt.defaultPrevented) {
         this.$root.$emit('bv::toggle::collapse', this.target)
       }

--- a/src/components/navbar/navbar-toggle.js
+++ b/src/components/navbar/navbar-toggle.js
@@ -1,13 +1,24 @@
 import listenOnRootMixin from '../../mixins/listen-on-root'
+import { getComponentConfig } from '../../utils/config'
+
+const NAME = 'BNavbarToggle'
+
+// Events we emit on $root
+const EVENT_TOGGLE 'bv::toggle::collapse'
+
+// Events we listen to on $root
+const EVENT_STATE = 'bv::collapse::state'
+// This private event is NOT to be documented as people should not be using it.
+const EVENT_STATE_SYNC = 'bv::collapse::sync::state'
 
 // @vue/component
 export default {
-  name: 'BNavbarToggle',
+  name: NAME,
   mixins: [listenOnRootMixin],
   props: {
     label: {
       type: String,
-      default: 'Toggle navigation'
+      default: () => String(getComponentConfig(NAME, 'label') || '')
     },
     target: {
       type: String,
@@ -20,14 +31,14 @@ export default {
     }
   },
   created() {
-    this.listenOnRoot('bv::collapse::state', this.handleStateEvt)
-    this.listenOnRoot('bv::collapse::sync::state', this.handleStateEvt)
+    this.listenOnRoot(EVENT_STATE, this.handleStateEvt)
+    this.listenOnRoot(EVENT_STATE_SYNC, this.handleStateEvt)
   },
   methods: {
     onClick(evt) {
       this.$emit('click', evt)
       if (!evt.defaultPrevented) {
-        this.$root.$emit('bv::toggle::collapse', this.target)
+        this.$root.$emit(EVENT_TOGGLE, this.target)
       }
     },
     handleStateEvt(id, state) {

--- a/src/components/navbar/navbar-toggle.js
+++ b/src/components/navbar/navbar-toggle.js
@@ -4,7 +4,7 @@ import { getComponentConfig } from '../../utils/config'
 const NAME = 'BNavbarToggle'
 
 // Events we emit on $root
-const EVENT_TOGGLE 'bv::toggle::collapse'
+const EVENT_TOGGLE = 'bv::toggle::collapse'
 
 // Events we listen to on $root
 const EVENT_STATE = 'bv::collapse::state'

--- a/src/components/navbar/navbar-toggle.spec.js
+++ b/src/components/navbar/navbar-toggle.spec.js
@@ -74,17 +74,27 @@ describe('navbar-toggle', () => {
     wrapper.vm.$root.$off('bv::toggle::collapse', onRootClick)
   })
 
-  it('sets areia-expanded when receives root emit for target', async () => {
+  it('sets area-expanded when receives root emit for target', async () => {
     const wrapper = mount(NavbarToggle, {
       propsData: {
         target: 'target'
       }
     })
+
+    // Private state event
     wrapper.vm.$root.$emit('bv::collapse::state', 'target', true)
     expect(wrapper.attributes('aria-expanded')).toBe('true')
     wrapper.vm.$root.$emit('bv::collapse::state', 'target', false)
     expect(wrapper.attributes('aria-expanded')).toBe('false')
     wrapper.vm.$root.$emit('bv::collapse::state', 'foo', true)
+    expect(wrapper.attributes('aria-expanded')).toBe('false')
+
+    // Private sync event
+    wrapper.vm.$root.$emit('bv::collapse::sync::state', 'target', true)
+    expect(wrapper.attributes('aria-expanded')).toBe('true')
+    wrapper.vm.$root.$emit('bv::collapse::sync::state', 'target', false)
+    expect(wrapper.attributes('aria-expanded')).toBe('false')
+    wrapper.vm.$root.$emit('bv::collapse::sync::state', 'foo', true)
     expect(wrapper.attributes('aria-expanded')).toBe('false')
   })
 })

--- a/src/components/navbar/navbar-toggle.spec.js
+++ b/src/components/navbar/navbar-toggle.spec.js
@@ -74,7 +74,7 @@ describe('navbar-toggle', () => {
     wrapper.vm.$root.$off('bv::toggle::collapse', onRootClick)
   })
 
-  it('sets area-expanded when receives root emit for target', async () => {
+  it('sets aria-expanded when receives root emit for target', async () => {
     const wrapper = mount(NavbarToggle, {
       propsData: {
         target: 'target'

--- a/src/directives/toggle/toggle.js
+++ b/src/directives/toggle/toggle.js
@@ -9,12 +9,17 @@ const listenTypes = { click: true }
 const BV_TOGGLE = '__BV_toggle__'
 const BV_TOGGLE_STATE = '__BV_toggle_STATE__'
 const BV_TOGGLE_CONTROLS = '__BV_toggle_CONTROLS__'
+const BV_TOGGLE_TARGETS = '__BV_toggle_CONTROLS__'
 
 // Emitted control event for collapse (emitted to collapse)
 const EVENT_TOGGLE = 'bv::toggle::collapse'
 
 // Listen to event for toggle state update (emitted by collapse)
 const EVENT_STATE = 'bv::collapse::state'
+
+// Private event emitted on $root to ensure the toggle state is always synced.
+// Gets emitted even if the state of b-collapse has not changed
+const EVENT_STATE_SYNC = 'bv::collapse::sync::state'
 
 // Reset and remove a property from the provided element
 const resetProp = (el, prop) => {
@@ -53,6 +58,8 @@ export default {
     })
 
     if (inBrowser && vnode.context && targets.length > 0) {
+      // Add targets array to element
+      el[BV_TOGGLE_TARGETS] = targets
       // Add aria attributes to element
       el[BV_TOGGLE_CONTROLS] = targets.join(' ')
       // State is initially collapsed until we receive a state event
@@ -66,6 +73,7 @@ export default {
 
       // Toggle state handler, stored on element
       el[BV_TOGGLE] = function toggleDirectiveHandler(id, state) {
+        const targets = el[BV_TOGGLE_TARGETS] || []
         if (targets.indexOf(id) !== -1) {
           // Set aria-expanded state
           setAttr(el, 'aria-expanded', state ? 'true' : 'false')
@@ -79,8 +87,10 @@ export default {
         }
       }
 
-      // Listen for toggle state changes
+      // Listen for toggle state changes (public)
       vnode.context.$root.$on(EVENT_STATE, el[BV_TOGGLE])
+      // Listen for toggle state sync (private)
+      vnode.context.$root.$on(EVENT_STATE_SYNC, el[BV_TOGGLE])
     }
   },
   componentUpdated: handleUpdate,
@@ -90,11 +100,13 @@ export default {
     // Remove our $root listener
     if (el[BV_TOGGLE]) {
       vnode.context.$root.$off(EVENT_STATE, el[BV_TOGGLE])
+      vnode.context.$root.$off(EVENT_STATE_SYNC, el[BV_TOGGLE])
     }
     // Reset custom  props
     resetProp(el, BV_TOGGLE)
     resetProp(el, BV_TOGGLE_STATE)
     resetProp(el, BV_TOGGLE_CONTROLS)
+    resetProp(el, BV_TOGGLE_TARGETS)
     // Reset classes/attrs
     removeClass(el, 'collapsed')
     removeAttr(el, 'aria-expanded')

--- a/src/directives/toggle/toggle.js
+++ b/src/directives/toggle/toggle.js
@@ -18,7 +18,8 @@ const EVENT_TOGGLE = 'bv::toggle::collapse'
 const EVENT_STATE = 'bv::collapse::state'
 
 // Private event emitted on $root to ensure the toggle state is always synced.
-// Gets emitted even if the state of b-collapse has not changed
+// Gets emitted even if the state of b-collapse has not changed.
+// This event is NOT to be documented as people should not be using it.
 const EVENT_STATE_SYNC = 'bv::collapse::sync::state'
 
 // Reset and remove a property from the provided element

--- a/src/directives/toggle/toggle.js
+++ b/src/directives/toggle/toggle.js
@@ -9,7 +9,7 @@ const listenTypes = { click: true }
 const BV_TOGGLE = '__BV_toggle__'
 const BV_TOGGLE_STATE = '__BV_toggle_STATE__'
 const BV_TOGGLE_CONTROLS = '__BV_toggle_CONTROLS__'
-const BV_TOGGLE_TARGETS = '__BV_toggle_CONTROLS__'
+const BV_TOGGLE_TARGETS = '__BV_toggle_TARGETS__'
 
 // Emitted control event for collapse (emitted to collapse)
 const EVENT_TOGGLE = 'bv::toggle::collapse'

--- a/src/directives/toggle/toggle.spec.js
+++ b/src/directives/toggle/toggle.spec.js
@@ -7,6 +7,9 @@ const EVENT_TOGGLE = 'bv::toggle::collapse'
 // Listen to event for toggle state update (emitted by collapse)
 const EVENT_STATE = 'bv::collapse::state'
 
+// Listen to event for toggle sync state update (emitted by collapse)
+const EVENT_STATE_SYNC = 'bv::collapse::sync::state'
+
 describe('v-b-toggle directive', () => {
   it('works on buttons', async () => {
     const localVue = new CreateLocalVue()
@@ -49,7 +52,6 @@ describe('v-b-toggle directive', () => {
 
     wrapper.destroy()
   })
-
   it('works on passing ID as directive value', async () => {
     const localVue = new CreateLocalVue()
     const spy = jest.fn()
@@ -182,6 +184,48 @@ describe('v-b-toggle directive', () => {
     expect(wrapper.find('button').classes()).not.toContain('collapsed')
 
     $root.$emit(EVENT_STATE, 'test', false)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('button').attributes('aria-controls')).toBe('test')
+    expect(wrapper.find('button').attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find('button').classes()).toContain('collapsed')
+
+    wrapper.destroy()
+  })
+
+  it('responds to private sync state update events', async () => {
+    const localVue = new CreateLocalVue()
+
+    const App = localVue.extend({
+      directives: {
+        bToggle: toggleDirective
+      },
+      data() {
+        return {}
+      },
+      template: '<button v-b-toggle.test>button</button>'
+    })
+
+    const wrapper = mount(App, {
+      localVue: localVue
+    })
+
+    expect(wrapper.isVueInstance()).toBe(true)
+    expect(wrapper.is('button')).toBe(true)
+    expect(wrapper.find('button').attributes('aria-controls')).toBe('test')
+    expect(wrapper.find('button').attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find('button').classes()).not.toContain('collapsed')
+
+    const $root = wrapper.vm.$root
+
+    $root.$emit(EVENT_STATE_SYNC, 'test', true)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('button').attributes('aria-controls')).toBe('test')
+    expect(wrapper.find('button').attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('button').classes()).not.toContain('collapsed')
+
+    $root.$emit(EVENT_STATE_SYNC, 'test', false)
     await wrapper.vm.$nextTick()
 
     expect(wrapper.find('button').attributes('aria-controls')).toBe('test')

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -81,6 +81,9 @@ const DEFAULTS = {
     okTitle: 'OK',
     okVariant: 'primary',
     headerCloseLabel: 'Close'
+  },
+  BNavbarToggle: {
+    label: 'Toggle navigation'
   }
 }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

Adds a new private $root event for ensuring the toggle state is in line with the collapse state.

The new event is emitted anytime the `<b-collapse>` component updates, regardless of the visible state of the collapse.

Closes #3020

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
