### PR TITLE
feat(nuxt): add `usePretranspiled` option

### DIFF
--- a/docs/markdown/intro/README.md
+++ b/docs/markdown/intro/README.md
@@ -56,7 +56,7 @@ _after_ Bootstrap SCSS to ensure variables are set up correctly.
 **Note**: _Requires webpack configuration to load CSS/SCSS files
 ([official guide](https://webpack.js.org/guides/asset-management/#loading-css))_.
 
-## Nuxt.js plugin module
+## Nuxt.js Module
 
 [Nuxt.js](https://nuxtjs.org) version {{ nuxtVersion }} (or greater) is recommended.
 
@@ -152,6 +152,13 @@ module.exports = {
   }
 }
 ```
+
+### Using pretranspiled version of BootstrapVue for Nuxt.js
+
+Nuxt module uses precompiled version of BootstrapVue for faster development builds and source of
+BootstrapVue for higher quality production builds.
+
+You can override this option using `usePretranspiled` option. Setting to `true` uses `es/` instead of `src/`. By default is enabled for development mode only.
 
 ## Vue CLI 2
 

--- a/docs/markdown/intro/README.md
+++ b/docs/markdown/intro/README.md
@@ -158,7 +158,8 @@ module.exports = {
 Nuxt module uses precompiled version of BootstrapVue for faster development builds and source of
 BootstrapVue for higher quality production builds.
 
-You can override this option using `usePretranspiled` option. Setting to `true` uses `es/` instead of `src/`. By default is enabled for development mode only.
+You can override this option using `usePretranspiled` option. Setting to `true` uses `es/` instead
+of `src/`. By default is enabled for development mode only.
 
 ## Vue CLI 2
 

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -47,10 +47,18 @@ module.exports = function nuxtBootstrapVue(moduleOptions = {}) {
       this.options.css.unshift('bootstrap/dist/css/bootstrap.css')
     }
 
-    // Transpile src
+    // Transpile src/
     this.options.build.transpile.push('bootstrap-vue/src')
 
-    const templateOptions = {}
+    // Use es/ or src/
+    const pretranspile = pickFirst(
+      options.pretranspile,
+      this.options.dev
+    )
+
+    const templateOptions = {
+      dist: pretranspile ? 'es' : 'src'
+    }
 
     // TODO: Also add support for individual components & directives
     for (const type of ['componentPlugins', 'directivePlugins']) {

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -51,10 +51,10 @@ module.exports = function nuxtBootstrapVue(moduleOptions = {}) {
     this.options.build.transpile.push('bootstrap-vue/src')
 
     // Use es/ or src/
-    const pretranspile = pickFirst(options.pretranspile, this.options.dev)
+    const usePretranspiled = pickFirst(options.usePretranspiled, this.options.dev)
 
     const templateOptions = {
-      dist: pretranspile ? 'es' : 'src'
+      dist: usePretranspiled ? 'es' : 'src'
     }
 
     // TODO: Also add support for individual components & directives

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -51,10 +51,7 @@ module.exports = function nuxtBootstrapVue(moduleOptions = {}) {
     this.options.build.transpile.push('bootstrap-vue/src')
 
     // Use es/ or src/
-    const pretranspile = pickFirst(
-      options.pretranspile,
-      this.options.dev
-    )
+    const pretranspile = pickFirst(options.pretranspile, this.options.dev)
 
     const templateOptions = {
       dist: pretranspile ? 'es' : 'src'

--- a/nuxt/plugin.template.js
+++ b/nuxt/plugin.template.js
@@ -1,10 +1,10 @@
 import Vue from 'vue'
 <% if (options.componentPlugins.length || options.directivePlugins.length) { %><%=
-options.componentPlugins.reduce((acc, p) => (acc += `import ${p[0]} from 'bootstrap-vue/es/components/${p[1]}'\n` ), '') %><%=
-options.directivePlugins.reduce((acc, p) => (acc += `import ${p[0]} from 'bootstrap-vue/es/directives/${p[1]}'\n` ), '') %>
+options.componentPlugins.reduce((acc, p) => (acc += `import ${p[0]} from 'bootstrap-vue/${options.dist}/components/${p[1]}'\n` ), '') %><%=
+options.directivePlugins.reduce((acc, p) => (acc += `import ${p[0]} from 'bootstrap-vue/${options.dist}/directives/${p[1]}'\n` ), '') %>
 
 <% if (options.config) { %>
-import BVConfigPlugin from 'bootstrap-vue/es/bv-config'
+import BVConfigPlugin from 'bootstrap-vue/<%= options.dist %>/bv-config'
 
 Vue.use(BVConfigPlugin, <%= JSON.stringify(options.config, undefined, 2) %>)
 <% } %>
@@ -13,7 +13,7 @@ Vue.use(BVConfigPlugin, <%= JSON.stringify(options.config, undefined, 2) %>)
 options.componentPlugins.reduce((acc, p) => (acc += `Vue.use(${p[0]})\n` ), '') %><%=
 options.directivePlugins.reduce((acc, p) => (acc += `Vue.use(${p[0]})\n` ), '') %>
 <% } else { %>
-import BootstrapVue from 'bootstrap-vue/es'
+import BootstrapVue from 'bootstrap-vue/<%= options.dist %>'
 
 Vue.use(BootstrapVue, <%= JSON.stringify(options.config || {}, undefined, 2) %>)
 <% } %>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Description of Pull Request:

Introduce a new `pretranspile` option for for users using nuxt module.

BootstrapVue ships with pre-transpiled `es/` dist. This has many advantages and does not needs transpiling again. But as it has a wider babel config (for browser support) than Nuxt, transpiling on final project produces bundles with less size and better runtime perf in flavor of more compile time.

This option by default is only enabled for production mode so we have both speed and final build quality.

Results on a starter nuxt project with BV:

`usePretranspiled: true`: (`es/`)

- 906 KB 
- 221 KB Gzip
- Build time: 20.51s

`usePretranspiled: false`: (`src/`)

- 829 KB
- 210KB Gzip
- Build time: 27.7s

Using `src/` takes more **7.2 sec** and reduces bundle size for **77 KB** ( **11 KB Gzip**)

## PR checklist:

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Enhancement to an existing feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e.
      `fixes #xxxx[,#xxxx]`, where "xxxx" is the issue number)
- [x] The PR should address only one issue or feature. If adding multiple features or fixing a bug
      and adding a new feature, break them into separate PRs if at all possible.
- [x] PR titles should following the
      [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e.
      "fix(alert): not alerting during SSR render", "docs(badge): Updated pill examples, fix typos",
      "chore: fix typo in docs", etc). **This is very important, as the `CHANGELOG` is generated
      from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and
      event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (does it affect screen reader users or
      keyboard only users? clickable items should be in the tab index, etc)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a
      suggestion issue first and wait for approval before working on it)
