### PR TITLE
fix(tab): don't use `aria-expanded` on the panel

### DIFF
--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -204,7 +204,6 @@ export default Vue.extend({
           id: this.safeId(),
           tabindex: this.localActive && !this.bvTabs.noKeyNav ? '0' : null,
           'aria-hidden': this.localActive ? 'false' : 'true',
-          'aria-expanded': this.localActive ? 'true' : 'false',
           'aria-labelledby': this.controlledBy || null
         }
       },

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -19,7 +19,6 @@ describe('tab', () => {
     expect(wrapper.classes()).not.toContain('card-body')
     expect(wrapper.attributes('role')).toBe('tabpanel')
     expect(wrapper.attributes('aria-hidden')).toBe('true')
-    expect(wrapper.attributes('aria-expanded')).toBe('false')
     expect(wrapper.attributes('labelledby')).not.toBeDefined()
     expect(wrapper.attributes('tabindex')).not.toBeDefined()
     expect(wrapper.attributes('id')).toBeDefined()


### PR DESCRIPTION
I'm a screen reader user, and the existence of `aria-expanded="true"` on the panel doesn't make much sense to me and isn't visible in any ARIA examples I've examined. This removes the attribute and updates the spec.