### PR TITLE
feat(toast): add additional options to global config (closes #3169)

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -32,7 +32,7 @@ export const props = {
   },
   toaster: {
     type: String,
-    default: () => String(getComponentConfig(NAME, 'toaster'))
+    default: () => getComponentConfig(NAME, 'toaster')
   },
   variant: {
     type: String,
@@ -159,6 +159,9 @@ export default Vue.extend({
       // Minimum supported duration is 1 second
       return Math.max(parseInt(this.autoHideDelay, 10) || 0, MIN_DURATION)
     },
+    computedToaster() {
+      return String(this.toaster)
+    },
     transitionHandlers() {
       return {
         beforeEnter: this.onBeforeEnter,
@@ -212,7 +215,7 @@ export default Vue.extend({
     })
     // Make sure we hide when toaster is destroyed
     this.listenOnRoot('bv::toaster::destroyed', toaster => {
-      if (toaster === this.toaster) {
+      if (toaster === this.computedToaster) {
         this.hide()
       }
     })
@@ -252,8 +255,7 @@ export default Vue.extend({
         relatedTarget: null,
         ...opts,
         vueTarget: this,
-        componentId: this.id || null,
-        toastId: this.id || null
+        componentId: this.id || null
       })
     },
     emitEvent(bvEvt) {
@@ -265,13 +267,13 @@ export default Vue.extend({
       if (this.static) {
         return
       }
-      if (!Wormhole.hasTarget(this.toaster)) {
+      if (!Wormhole.hasTarget(this.computedToaster)) {
         const div = document.createElement('div')
         document.body.appendChild(div)
         const toaster = new BToaster({
           parent: this.$root,
           propsData: {
-            name: this.toaster
+            name: this.computedToaster
           }
         })
         toaster.$mount(div)
@@ -424,7 +426,7 @@ export default Vue.extend({
       {
         props: {
           name: name,
-          to: this.toaster,
+          to: this.computedToaster,
           order: this.order,
           slim: true,
           disabled: this.static

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -32,7 +32,7 @@ export const props = {
   },
   variant: {
     type: String,
-    default: null
+    default: () => getComponentConfig(NAME, 'variant') || null
   },
   toaster: {
     type: String,
@@ -53,7 +53,7 @@ export const props = {
   },
   autoHideDelay: {
     type: [Number, String],
-    default: 5000
+    default: () => getComponentConfig(NAME, 'autoHideDelay') || 5000
   },
   noCloseButton: {
     type: Boolean,
@@ -73,15 +73,15 @@ export const props = {
   },
   toastClass: {
     type: [String, Object, Array],
-    default: ''
+    default: () => getComponentConfig(NAME, 'toastClass') || ''
   },
   headerClass: {
     type: [String, Object, Array],
-    default: ''
+    default: () => getComponentConfig(NAME, 'headerClass') || ''
   },
   bodyClass: {
     type: [String, Object, Array],
-    default: ''
+    default: () => getComponentConfig(NAME, 'bodyClass') || ''
   },
   href: {
     type: String,

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -30,13 +30,13 @@ export const props = {
     type: String,
     default: null
   },
-  variant: {
-    type: String,
-    default: () => getComponentConfig(NAME, 'variant') || null
-  },
   toaster: {
     type: String,
     default: () => getComponentConfig(NAME, 'toaster') || 'b-toaster-top-right'
+  },
+  variant: {
+    type: String,
+    default: () => getComponentConfig(NAME, 'variant')
   },
   isStatus: {
     // Switches role to 'status' and aria-live to 'polite'
@@ -53,7 +53,7 @@ export const props = {
   },
   autoHideDelay: {
     type: [Number, String],
-    default: () => getComponentConfig(NAME, 'autoHideDelay') || 5000
+    default: () => getComponentConfig(NAME, 'autoHideDelay')
   },
   noCloseButton: {
     type: Boolean,
@@ -73,15 +73,15 @@ export const props = {
   },
   toastClass: {
     type: [String, Object, Array],
-    default: () => getComponentConfig(NAME, 'toastClass') || ''
+    default: () => getComponentConfig(NAME, 'toastClass')
   },
   headerClass: {
     type: [String, Object, Array],
-    default: () => getComponentConfig(NAME, 'headerClass') || ''
+    default: () => getComponentConfig(NAME, 'headerClass')
   },
   bodyClass: {
     type: [String, Object, Array],
-    default: () => getComponentConfig(NAME, 'bodyClass') || ''
+    default: () => getComponentConfig(NAME, 'bodyClass')
   },
   href: {
     type: String,

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -32,7 +32,7 @@ export const props = {
   },
   toaster: {
     type: String,
-    default: () => getComponentConfig(NAME, 'toaster') || 'b-toaster-top-right'
+    default: () => String(getComponentConfig(NAME, 'toaster'))
   },
   variant: {
     type: String,

--- a/src/components/toast/toaster.js
+++ b/src/components/toast/toaster.js
@@ -1,6 +1,7 @@
 import Vue from '../../utils/vue'
 import { PortalTarget, Wormhole } from 'portal-vue'
 import warn from '../../utils/warn'
+import { getComponentConfig } from '../../utils/config'
 import { removeClass, requestAF } from '../../utils/dom'
 
 /* istanbul ignore file: for now until ready for testing */
@@ -16,16 +17,16 @@ export const props = {
   },
   ariaLive: {
     type: String,
-    default: 'polite'
+    default: () => String(getComponentConfig(NAME, 'ariaLive'))
   },
   ariaAtomic: {
     type: String,
-    default: 'true' // Allowed: 'true' or 'false'
+    default: () => String(getComponentConfig(NAME, 'ariaAtomic')) // Allowed: 'true' or 'false'
   },
   role: {
     // Aria role
     type: String,
-    default: null
+    default: () => String(getComponentConfig(NAME, 'role'))
   }
   /*
   transition: {
@@ -109,7 +110,7 @@ export default Vue.extend({
       const $target = h(PortalTarget, {
         staticClass: 'b-toaster-slot',
         attrs: {
-          role: this.role,
+          role: this.role || null, // fallback to null to make sure attribute doesn't exist
           'aria-live': this.ariaLive,
           'aria-atomic': this.ariaAtomic
         },

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -93,7 +93,13 @@ const DEFAULTS = {
     label: 'Toggle navigation'
   },
   BToast: {
-    toaster: 'b-toaster-top-right'
+    toaster: 'b-toaster-top-right',
+    autoHideDelay: 5000,
+    variant: null,
+    toastClass: null,
+    headerClass: null,
+    bodyClass: null,
+    solid: false
   }
 }
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -100,6 +100,11 @@ const DEFAULTS = {
     headerClass: null,
     bodyClass: null,
     solid: false
+  },
+  BToaster: {
+    ariaLive: 'polite',
+    ariaAtomic: 'true',
+    role: null
   }
 }
 


### PR DESCRIPTION
### Describe the PR

Adds additional values to global config for `b-toast`, `b-toaster` (and `this.$bvToast.toast()` as it uses the previous two).

Closes #3169

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
