### PR TITLE
fix(form-input): properly handle out-of-sync values (closes #2657)

### DIFF
--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -103,7 +103,7 @@ export default {
     getFormatted(value, evt, force = false) {
       value = this.stringifyValue(value)
       if ((!this.lazyFormatter || force) && isFunction(this.formatter)) {
-        return this.formatter(value, evt)
+        value = this.formatter(value, evt)
       }
       return value
     },

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -140,6 +140,7 @@ export default {
       // Exit when the `formatter` function strictly returned `false`
       // or prevented the input event
       if (formatted === false || evt.defaultPrevented) {
+        /* istanbul ignore next */
         evt.preventDefault()
         return
       }
@@ -157,6 +158,7 @@ export default {
       // Exit when the `formatter` function strictly returned `false`
       // or prevented the input event
       if (formatted === false || evt.defaultPrevented) {
+        /* istanbul ignore next */
         evt.preventDefault()
         return
       }

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -125,6 +125,7 @@ export default {
       } else if (value !== this.$refs.input.value) {
         // When the `localValue` hasn't changed but the actual input value
         // is out of sync, make sure to change it to the given one
+        /* istanbul ignore next: hard to test */
         this.$refs.input.value = value
       }
     },

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -83,8 +83,8 @@ export default {
     }
   },
   watch: {
-    value(newVal, oldVal) {
-      if (newVal !== oldVal && newVal !== this.localValue) {
+    value(newVal) {
+      if (newVal !== this.localValue) {
         this.localValue = this.stringifyValue(newVal)
       }
     }
@@ -100,38 +100,44 @@ export default {
     stringifyValue(value) {
       return isUndefined(value) || isNull(value) ? '' : String(value)
     },
-    getFormatted(value, event, force = false) {
+    getFormatted(value, evt, force = false) {
       value = this.stringifyValue(value)
       if ((!this.lazyFormatter || force) && isFunction(this.formatter)) {
-        value = this.formatter(value, event)
+        return this.formatter(value, evt)
       }
       return value
     },
     updateValue(value) {
       value = this.stringifyValue(value)
-      if (this.localValue !== value) {
-        // keep the input set to the value before modifiers
+      if (value !== this.localValue) {
+        // Keep the input set to the value before modifiers
         this.localValue = value
         if (this.number) {
-          // Emulate .number modifier behaviour
+          // Emulate `.number` modifier behaviour
           const num = parseFloat(value)
           value = isNaN(num) ? value : num
         } else if (this.trim) {
-          // Emulate .trim modifier behaviour
+          // Emulate `.trim` modifier behaviour
           value = value.trim()
         }
         // Update the v-model
         this.$emit('update', value)
+      } else if (value !== this.$refs.input.value) {
+        // When the `localValue` hasn't changed but the actual input value
+        // is out of sync, make sure to change it to the given one
+        this.$refs.input.value = value
       }
     },
     onInput(evt) {
-      // evt.target.composing is set by Vue
+      // `evt.target.composing` is set by Vue
       // https://github.com/vuejs/vue/blob/dev/src/platforms/web/runtime/directives/model.js
       /* istanbul ignore if: hard to test composition events */
       if (evt.target.composing) {
         return
       }
       const formatted = this.getFormatted(evt.target.value, evt)
+      // Exit when the `formatter` function strictly returned `false`
+      // or prevented the input event
       if (formatted === false || evt.defaultPrevented) {
         evt.preventDefault()
         return
@@ -140,23 +146,27 @@ export default {
       this.$emit('input', formatted)
     },
     onChange(evt) {
-      // evt.target.composing is set by Vue
+      // `evt.target.composing` is set by Vue
       // https://github.com/vuejs/vue/blob/dev/src/platforms/web/runtime/directives/model.js
       /* istanbul ignore if: hard to test composition events */
       if (evt.target.composing) {
         return
       }
       const formatted = this.getFormatted(evt.target.value, evt)
-      if (formatted === false) {
+      // Exit when the `formatter` function strictly returned `false`
+      // or prevented the input event
+      if (formatted === false || evt.defaultPrevented) {
+        evt.preventDefault()
         return
       }
       this.updateValue(formatted)
       this.$emit('change', formatted)
     },
     onBlur(evt) {
-      // lazy formatter
+      // Lazy formatter
       if (this.lazyFormatter) {
         const formatted = this.getFormatted(evt.target.value, evt, true)
+        // Exit when the `formatter` function strictly returned `false`
         if (formatted === false) {
           return
         }


### PR DESCRIPTION
### Describe the PR

This PR adds an additional check to to the `updateValue()` method to check if the given value is different from the actual input value, even when the `localValue` hasn't changed.
This can be caused by the `formatter` function.

Closes #2657.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
