### PR TITLE
fix(pagination): use unicode escape sequence for default bookend buttons (closes #3179)

### DIFF
--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -103,7 +103,7 @@ const props = {
   },
   firstText: {
     type: String,
-    default: '«'
+    default: '\u00AB' // '«'
   },
   labelPrevPage: {
     type: String,
@@ -111,7 +111,7 @@ const props = {
   },
   prevText: {
     type: String,
-    default: '‹'
+    default: '\u2039' // '‹'
   },
   labelNextPage: {
     type: String,
@@ -119,7 +119,7 @@ const props = {
   },
   nextText: {
     type: String,
-    default: '›'
+    default: '\u203A' // '›'
   },
   labelLastPage: {
     type: String,
@@ -127,7 +127,7 @@ const props = {
   },
   lastText: {
     type: String,
-    default: '»'
+    default: '\u00BB' // '»'
   },
   labelPage: {
     type: [String, Function],
@@ -139,7 +139,7 @@ const props = {
   },
   ellipsisText: {
     type: String,
-    default: '…'
+    default: '\u2026' // '…'
   }
 }
 


### PR DESCRIPTION
### Describe the PR

Rather than use string literals like `'…'`, use ES5 Unicode escape sequence string `'\u2026'`.

May address #3179

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
