### PR TITLE
fix(modal): return focus edge case bug in IE11 (fixes #3206)

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -386,14 +386,14 @@ export default Vue.extend({
         return
       }
       this.is_opening = true
+      // Note: On IE11, `document.activeElement` may be null. So we test it for
+      // truthyness first.
+      // https://github.com/bootstrap-vue/bootstrap-vue/issues/3206
       if (isBrowser && document.activeElement && document.activeElement.focus) {
         // Preset the fallback return focus value if it is not set
         // `document.activeElement` should be the trigger element that was clicked or
         // in the case of using the v-model, which ever element has current focus
         // Will be overridden by some commands such as toggle, etc.
-        // Note, on IE11, document.activeElement may be null. So we test it for
-        // truthyness first.
-        // https://github.com/bootstrap-vue/bootstrap-vue/issues/3206
         this.return_focus = this.return_focus || document.activeElement
       }
       const showEvt = new BvModalEvent('show', {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -386,11 +386,14 @@ export default Vue.extend({
         return
       }
       this.is_opening = true
-      if (isBrowser && document.activeElement.focus) {
+      if (isBrowser && document.activeElement && document.activeElement.focus) {
         // Preset the fallback return focus value if it is not set
         // `document.activeElement` should be the trigger element that was clicked or
         // in the case of using the v-model, which ever element has current focus
         // Will be overridden by some commands such as toggle, etc.
+        // Note, on IE11, document.activeElement may be null. So we test it for
+        // truthyness first.
+        // https://github.com/bootstrap-vue/bootstrap-vue/issues/3206
         this.return_focus = this.return_focus || document.activeElement
       }
       const showEvt = new BvModalEvent('show', {


### PR DESCRIPTION
### Describe the PR

In some cases, IE 11 is not setting document.activeElement, which is used to determine which element to return focus to when the modal closes.

This PR adds in an extra check for that.

fixes #3206 

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
