### PR TITLE
fix(b-button): use capture mode to prevent inner element click bubbling (closes #3290)

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -150,7 +150,7 @@ export default Vue.extend({
       // Modifier `!` places the event handler in capture mode.
       // Needed to prevent bubbling of inner element click evt when disabled
       '!click': evt => {
-        /* istanbul ignore if: blink/button disabled should handle this */
+        /* istanbul ignore if: blink and button disabled should handle this */
         if (props.disabled && evt instanceof Event) {
           evt.stopImmediatePropagation()
           evt.stopPropagation()

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -147,11 +147,13 @@ export default Vue.extend({
     const toggle = isToggle(props)
     const link = isLink(props)
     const on = {
-      click(e) {
+      // Modifier `!` places the event handler in capture mode.
+      // Needed to prevent bubbling of inner element click evt when disabled
+      '!click': evt => {
         /* istanbul ignore if: blink/button disabled should handle this */
-        if (props.disabled && e instanceof Event) {
-          e.stopPropagation()
-          e.preventDefault()
+        if (props.disabled && evt instanceof Event) {
+          evt.stopPropagation()
+          evt.preventDefault()
         } else if (toggle && listeners && listeners['update:pressed']) {
           // Send .sync updates to any "pressed" prop (if .sync listeners)
           // Concat will normalize the value to an array

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -152,6 +152,7 @@ export default Vue.extend({
       '!click': evt => {
         /* istanbul ignore if: blink/button disabled should handle this */
         if (props.disabled && evt instanceof Event) {
+          evt.stopImmediatePropagation()
           evt.stopPropagation()
           evt.preventDefault()
         } else if (toggle && listeners && listeners['update:pressed']) {


### PR DESCRIPTION
### Describe the PR

When disabled, clicking on an inner element (i.e. a span), the event still bubbles upwards.

Placing the click event handler in capture mode should prevent this.

Closes #3290

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
