### PR TITLE
feat(nuxt module): optimize imports into single import statements

### DIFF
--- a/docs/markdown/intro/README.md
+++ b/docs/markdown/intro/README.md
@@ -365,7 +365,9 @@ components and/or directives.
 
 <div class="alert alert-info">
   <p class="mb-0">
-    <b>Note:</b> Tree shaking only works when webpack 4 is in <code>production</code> mode.
+    <b>Note:</b> Tree shaking only works when webpack 4 is in
+    [<code>production</code>](https://webpack.js.org/guides/tree-shaking) mode and javascript
+    minification is enabled.
   </p>
 </div>
 

--- a/docs/markdown/intro/README.md
+++ b/docs/markdown/intro/README.md
@@ -163,9 +163,15 @@ import 'custom.scss'
 
 <span class="badge badge-info small">ENHANCED in 2.0.0-rc.20</span>
 
-If you wish to reduce your bundle size because you only use a subset of the available BootstrapVue
-plugins, you can configure the list of BootstrapVue `componentPlugins` or `directivePlugins` you
-want to globally install in your Nuxt.js project.
+<div class="alert alert-info">
+  <p class="mb-0">
+    <b>Note:</b> Tree shaking only works when webpack 4 / Nuxt.js is in <code>production</code> mode.
+  </p>
+</div>
+
+If you wish to reduce your production bundle size because you only use a subset of the available
+BootstrapVue plugins, you can configure the list of BootstrapVue `componentPlugins` or
+`directivePlugins` you want to globally install in your Nuxt.js project.
 
 ```js
 module.exports = {
@@ -214,7 +220,7 @@ Refer to the reference section at the bottom of each of the [component](/docs/co
 [directive](/docs/directives) docs for details on the plugin names available (and which components
 and directives are included in each plugin) and component and/or directive import names.
 
-Note that when importing individual components, the component aliases will not be available.
+Note that when importing individual components, any component aliases will **not** be available.
 
 ### Passing custom BootstrapVue config with Nuxt.js
 
@@ -240,6 +246,17 @@ and the source (`src/`) of BootstrapVue for higher quality production builds.
 
 You can override this option using `usePretranspiled` option. Setting to `true` uses `es/` instead
 of `src/`. By default `usePretranspiled` is enabled in development mode only.
+
+<div class="alert alert-info">
+  <p class="mb-0">
+    <b>Note:</b> if you are also importing individual components, directives or plugins
+    <em>within</em> your Nuxt app as well as via the tree-shaking options above, you will want to
+    set the <code>usePretranspiled</code> option to match the directory you are importing from
+    (i.e. use <code>true</code> if importing from <code>bootstrap-vue/es</code> or
+    <code>false</code> if importing from <code>bootstrap-vue/src</code>). Otherwise, you may end
+    up with a larger bundle size due to code duplication.
+  </p>
+</div>
 
 ## Vue CLI 2
 

--- a/docs/markdown/intro/README.md
+++ b/docs/markdown/intro/README.md
@@ -363,6 +363,12 @@ In the future this plugin will provide options for more advanced configurations 
 When using a module bundler you can optionally import only specific components groups (plugins),
 components and/or directives.
 
+<div class="alert alert-info">
+  <p class="mb-0">
+    <b>Note:</b> Tree shaking only works when webpack 4 is in <code>production</code> mode.
+  </p>
+</div>
+
 ### Component groups and directives as Vue plugins
 
 You can import component groups and directives as Vue plugins by importing from the `components`

--- a/nuxt/plugin.template.js
+++ b/nuxt/plugin.template.js
@@ -1,4 +1,4 @@
-import Vue from 'vue'
+import Vue from 'vue';
 <% if (
   options.componentPlugins.length ||
   options.directivePlugins.length ||
@@ -8,32 +8,32 @@ import Vue from 'vue'
 <% if (options.componentPlugins.length || options.components.length) { %>
 import {
   <%= [].concat(options.componentPlugins, options.components).filter(Boolean).join(',\n  ') %>
-} from 'bootstrap-vue/<%= options.dist %>/components'
+} from 'bootstrap-vue/<%= options.dist %>/components';
 <% } %>
 <% if (options.directivePlugins.length || options.directives.length) { %>
 import {
   <%= [].concat(options.directivePlugins, options.directives).filter(Boolean).join(',\n  ') %>
-} from 'bootstrap-vue/<%= options.dist %>/directives'
+} from 'bootstrap-vue/<%= options.dist %>/directives';
 <% } %>
 
 <% if (options.config) { %>
-import BVConfigPlugin from 'bootstrap-vue/<%= options.dist %>/bv-config'
+import BVConfigPlugin from 'bootstrap-vue/<%= options.dist %>/bv-config';
 
-Vue.use(BVConfigPlugin, <%= JSON.stringify(options.config, undefined, 2) %>)
+Vue.use(BVConfigPlugin, <%= JSON.stringify(options.config, undefined, 2) %>)'
 <% } %>
 
 <%=
-options.componentPlugins.reduce((acc, cp) => (acc += `Vue.use(${cp})\n` ), '')
+options.componentPlugins.reduce((acc, cp) => (acc += `Vue.use(${cp});\n` ), '')
 %><%=
-options.directivePlugins.reduce((acc, dp) => (acc += `Vue.use(${dp})\n` ), '')
+options.directivePlugins.reduce((acc, dp) => (acc += `Vue.use(${dp});\n` ), '')
 %><%=
-options.components.reduce((acc, c) => (acc += `Vue.component('${c}', ${c})\n` ), '')
+options.components.reduce((acc, c) => (acc += `Vue.component('${c}', ${c});\n` ), '')
 %><%=
-options.directives.reduce((acc, d) => (acc += `Vue.directive('${d.replace(/^VB/, 'B')}', ${d})\n` ), '')
+options.directives.reduce((acc, d) => (acc += `Vue.directive('${d.replace(/^VB/, 'B')}', ${d});\n` ), '')
 %>
 
 <% } else { %>
-import BootstrapVue from 'bootstrap-vue/<%= options.dist %>'
+import BootstrapVue from 'bootstrap-vue/<%= options.dist %>';
 
-Vue.use(BootstrapVue, <%= JSON.stringify(options.config || {}, undefined, 2) %>)
+Vue.use(BootstrapVue, <%= JSON.stringify(options.config || {}, undefined, 2) %>);
 <% } %>

--- a/nuxt/plugin.template.js
+++ b/nuxt/plugin.template.js
@@ -4,11 +4,17 @@ import Vue from 'vue'
   options.directivePlugins.length ||
   options.components.length ||
   options.directives.length
-) { %><%=
-options.componentPlugins.reduce((acc, p) => (acc += `import { ${p} } from 'bootstrap-vue/${options.dist}/components'\n` ), '') %><%=
-options.directivePlugins.reduce((acc, p) => (acc += `import { ${p} } from 'bootstrap-vue/${options.dist}/directives'\n` ), '') %><%=
-options.components.reduce((acc, c) => (acc += `import { ${c} } from 'bootstrap-vue/${options.dist}/components'\n` ), '') %><%=
-options.directives.reduce((acc, d) => (acc += `import { ${d} } from 'bootstrap-vue/${options.dist}/directives'\n` ), '') %>
+) { %>
+<% if (options.componentPlugins.length || options.components.length) { %>
+import {
+  <%= [].concat(options.componentPlugins, options.components).filter(Boolean).join(',\n  ') %>
+} from 'bootstrap-vue/<%= options.dist %>/components'
+<% } %>
+<% if (options.directivePlugins.length || options.directives.length) { %>
+import {
+  <%= [].concat(options.directivePlugins, options.directives).filter(Boolean).join(',\n  ') %>
+} from 'bootstrap-vue/<%= options.dist %>/directives'
+<% } %>
 
 <% if (options.config) { %>
 import BVConfigPlugin from 'bootstrap-vue/<%= options.dist %>/bv-config'
@@ -17,10 +23,14 @@ Vue.use(BVConfigPlugin, <%= JSON.stringify(options.config, undefined, 2) %>)
 <% } %>
 
 <%=
-options.componentPlugins.reduce((acc, p) => (acc += `Vue.use(${p})\n` ), '') %><%=
-options.directivePlugins.reduce((acc, p) => (acc += `Vue.use(${p})\n` ), '') %><%=
-options.components.reduce((acc, c) => (acc += `Vue.component('${c}', ${c})\n` ), '') %><%=
-options.directives.reduce((acc, d) => (acc += `Vue.directive('${d.replace(/^VB/, 'B')}', ${d})\n` ), '') %>
+options.componentPlugins.reduce((acc, cp) => (acc += `Vue.use(${cp})\n` ), '')
+%><%=
+options.directivePlugins.reduce((acc, dp) => (acc += `Vue.use(${dp})\n` ), '')
+%><%=
+options.components.reduce((acc, c) => (acc += `Vue.component('${c}', ${c})\n` ), '')
+%><%=
+options.directives.reduce((acc, d) => (acc += `Vue.directive('${d.replace(/^VB/, 'B')}', ${d})\n` ), '')
+%>
 
 <% } else { %>
 import BootstrapVue from 'bootstrap-vue/<%= options.dist %>'


### PR DESCRIPTION
### Describe the PR

Merges imports from same module into a single import statement

Adds note in docs that tree-shaking only works when in `production` mode in Nuxt, and note on using tree shaking option combined with manual imports of components/directive/plugins inside the Nuxt app.

Adds a note about tree shaking in intro section when importing individual components/directives/plugins.

Addresses #3323

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
