### PR TITLE
fix(tabs): use DOM query for tab probing after mount (closes: #3361)

### DIFF
--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -188,7 +188,7 @@ export default Vue.extend({
         attrs: {
           role: 'tabpanel',
           id: this.safeId(),
-          tabindex: this.localActive && !this.bvTabs.noKeyNav ? '0' : null,
+          tabindex: this.localActive && !this.bvTabs.noKeyNav ? '-1' : null,
           'aria-hidden': this.localActive ? 'false' : 'true',
           'aria-labelledby': this.controlledBy || null
         }

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -178,7 +178,7 @@ describe('tab', () => {
     wrapper.destroy()
   })
 
-  it('has attribute tabindex="0" when parent has keynav enabled and active', async () => {
+  it('has attribute tabindex="-1" when parent has keynav enabled and active', async () => {
     const wrapper = mount(BTab, {
       provide() {
         return {
@@ -194,7 +194,7 @@ describe('tab', () => {
     })
 
     expect(wrapper.attributes('tabindex')).toBeDefined()
-    expect(wrapper.attributes('tabindex')).toBe('0')
+    expect(wrapper.attributes('tabindex')).toBe('-1')
 
     wrapper.destroy()
   })

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -1,7 +1,7 @@
 import Vue from '../../utils/vue'
 import BLink from '../link/link'
 import BNav, { props as BNavProps } from '../nav/nav'
-import { selectAll } from '../../utils/dom'
+import { requestAF, selectAll } from '../../utils/dom'
 import KeyCodes from '../../utils/key-codes'
 import observeDom from '../../utils/observe-dom'
 import { omit } from '../../utils/object'
@@ -296,10 +296,12 @@ export default Vue.extend({
   mounted() {
     this.isMounted = true
     this.$nextTick(() => {
-      // Call `updateTabs()` just in case...
-      this.updateTabs()
-      // Observe child changes so we can update list of tabs
-      this.setObserver(true)
+      requestAF(() => {
+        // Call `updateTabs()` just in case...
+        this.updateTabs()
+        // Observe child changes so we can update list of tabs
+        this.setObserver(true)
+      })
     })
   },
   deactivated() /* istanbul ignore next */ {
@@ -343,6 +345,7 @@ export default Vue.extend({
         tabs = (this.normalizeSlot('default') || []).map(vnode => vnode.componentInstance)
       } else {
         // We rely on the DOM when mounted to get the list of tabs
+        // Fix for https://github.com/bootstrap-vue/bootstrap-vue/issues/3361
         tabs = selectAll(`#${this.safeId('_BV_tab_container_')} > .tab-pane`, this.$el)
           .map(el => el.__vue__)
           .filter(Boolean)

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -296,11 +296,13 @@ export default Vue.extend({
   mounted() {
     this.isMounted = true
     this.$nextTick(() => {
+      // Call `updateTabs()` just in case...
+      // this.updateTabs()
+      // Observe child changes so we can update list of tabs
+      this.setObserver(true)
       requestAF(() => {
         // Call `updateTabs()` just in case...
         this.updateTabs()
-        // Observe child changes so we can update list of tabs
-        this.setObserver(true)
       })
     })
   },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -280,6 +280,13 @@ export default Vue.extend({
           }
         }
       }
+    },
+    isMounted(newVal, oldVal) {
+      if (newVal) {
+        requestAF(() => {
+          this.updateTabs()
+        })
+      }
     }
   },
   created() {
@@ -294,16 +301,13 @@ export default Vue.extend({
     })
   },
   mounted() {
-    this.isMounted = true
     this.$nextTick(() => {
       // Call `updateTabs()` just in case...
-      // this.updateTabs()
+      this.updateTabs()
       // Observe child changes so we can update list of tabs
       this.setObserver(true)
-      requestAF(() => {
-        // Call `updateTabs()` just in case...
-        this.updateTabs()
-      })
+      // Flag we are now mounted and to switch to DOM for tab probing
+      this.isMounted = true
     })
   },
   deactivated() /* istanbul ignore next */ {
@@ -311,12 +315,12 @@ export default Vue.extend({
     this.isMounted = false
   },
   activated() /* istanbul ignore next */ {
-    this.isMounted = true
     let tabIdx = parseInt(this.value, 10)
     this.currentTab = isNaN(tabIdx) ? -1 : tabIdx
     this.$nextTick(() => {
       this.updateTabs()
       this.setObserver(true)
+      this.isMounted = true
     })
   },
   beforeDestroy() /* istanbul ignore next */ {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -338,19 +338,18 @@ export default Vue.extend({
       }
     },
     getTabs() {
+      let tabs = []
       if (!this.isMounted) {
-        return (this.normalizeSlot('default') || [])
-          .map(vnode => vnode.componentInstance)
-          .filter(tab => tab && tab._isTab)
+        tabs = (this.normalizeSlot('default') || []).map(vnode => vnode.componentInstance)
       } else {
         // We rely on the DOM when mounted to get the list of tabs
-        return selectAll(`#${this.safeId('_BV_tab_container_')} > .tab-panel`, this.$el)
+        tabs = selectAll(`#${this.safeId('_BV_tab_container_')} > .tab-pane`, this.$el)
           .map(el => el.__vue__)
           .filter(Boolean)
           // The VM attached to the element is `transition` so we need the $parent to get tab
           .map(vm => vm.$parent)
-          .filter(tab => tab._isTab)
       }
+      return tabs.filter(tab => tab && tab._isTab)
     },
     // Update list of <b-tab> children
     updateTabs() {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -224,7 +224,8 @@ export default Vue.extend({
       currentTab: tabIdx,
       // Array of direct child <b-tab> instances
       tabs: [],
-      isMounted = false
+      // Flag to know if we are mounted or not
+      isMounted: false
     }
   },
   computed: {

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { mount } from '@vue/test-utils'
-import { waitNT } from '../../../tests/utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 import BLink from '../link/link'
 import BTab from './tab'
 import BTabs from './tabs'
@@ -12,6 +12,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
 
     expect(wrapper.is('div')).toBe(true)
     expect(wrapper.classes()).toContain('tabs')
@@ -40,6 +41,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
 
     expect(wrapper.is('div')).toBe(true)
     expect(wrapper.classes()).toContain('tabs')
@@ -61,6 +63,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
 
     expect(wrapper.is('div')).toBe(true)
     expect(wrapper.classes()).toContain('tabs')
@@ -89,6 +92,7 @@ describe('tabs', () => {
     })
 
     await waitNT(wrapper.vm)
+    await waitRAF()
 
     expect(wrapper.vm.currentTab).toBe(tabIndex)
     expect(wrapper.vm.tabs.length).toBe(3)
@@ -111,6 +115,8 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
+
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -141,6 +147,8 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
+
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -171,6 +179,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -192,6 +201,7 @@ describe('tabs', () => {
       .at(1)
       .setProps({ active: false })
     await waitNT(wrapper.vm)
+    await waitRAF()
 
     // Expect last tab (index 2) to be active
     expect(tabs.vm.currentTab).toBe(2)
@@ -218,6 +228,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -231,6 +242,7 @@ describe('tabs', () => {
     // Set 2nd BTab to be active
     tabs.setProps({ value: 1 })
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(1)
     expect(tabs.emitted('input').length).toBe(1)
     // Should emit index of 1 (2nd tab)
@@ -239,6 +251,7 @@ describe('tabs', () => {
     // Set 3rd BTab to be active
     tabs.setProps({ value: 2 })
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(2)
     expect(tabs.emitted('input').length).toBe(2)
     // Should emit index of 2 (3rd tab)
@@ -261,6 +274,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -273,6 +287,7 @@ describe('tabs', () => {
     // Try to set 2nd (disabled) BTab to be active
     tabs.setProps({ value: 1 })
     await waitNT(wrapper.vm)
+    await waitRAF()
     // Will try activate next non-disabled tab instead (3rd tab, index 2)
     expect(tabs.vm.currentTab).toBe(2)
     expect(tabs.emitted('input').length).toBe(1)
@@ -282,9 +297,11 @@ describe('tabs', () => {
     // Needed for test since value not bound to actual v-model on App
     tabs.setProps({ value: 2 })
     await waitNT(wrapper.vm)
+    await waitRAF()
     // Try and set 2nd BTab to be active
     tabs.setProps({ value: 1 })
     await waitNT(wrapper.vm)
+    await waitRAF()
     // Will find the previous non-disabled tab (1st tab, index 0)
     expect(tabs.vm.currentTab).toBe(0)
     expect(tabs.emitted('input').length).toBe(2)
@@ -308,6 +325,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -332,6 +350,7 @@ describe('tabs', () => {
       .at(1)
       .trigger('click')
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(1)
     expect(tab1.vm.localActive).toBe(false)
     expect(tab2.vm.localActive).toBe(true)
@@ -345,6 +364,7 @@ describe('tabs', () => {
       .at(2)
       .trigger('click')
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(2)
     expect(tab1.vm.localActive).toBe(false)
     expect(tab2.vm.localActive).toBe(false)
@@ -358,6 +378,7 @@ describe('tabs', () => {
       .at(0)
       .trigger('keydown.space')
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(0)
     expect(tab1.vm.localActive).toBe(true)
     expect(tab2.vm.localActive).toBe(false)
@@ -381,6 +402,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -404,6 +426,7 @@ describe('tabs', () => {
       .at(0)
       .trigger('keydown.right')
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(1)
     expect(tab1.vm.localActive).toBe(false)
     expect(tab2.vm.localActive).toBe(true)
@@ -415,6 +438,7 @@ describe('tabs', () => {
       .at(1)
       .trigger('keydown.end')
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(2)
     expect(tab1.vm.localActive).toBe(false)
     expect(tab2.vm.localActive).toBe(false)
@@ -426,6 +450,7 @@ describe('tabs', () => {
       .at(2)
       .trigger('keydown.left')
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(1)
     expect(tab1.vm.localActive).toBe(false)
     expect(tab2.vm.localActive).toBe(true)
@@ -437,6 +462,7 @@ describe('tabs', () => {
       .at(1)
       .trigger('keydown.home')
     await waitNT(wrapper.vm)
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(0)
     expect(tab1.vm.localActive).toBe(true)
     expect(tab2.vm.localActive).toBe(false)
@@ -459,6 +485,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -476,6 +503,7 @@ describe('tabs', () => {
     // Disable 3rd tab
     tab3.setProps({ disabled: true })
     await waitNT(wrapper.vm)
+    await waitRAF()
 
     // Expect 1st tab to be active
     expect(tabs.vm.currentTab).toBe(0)
@@ -487,6 +515,7 @@ describe('tabs', () => {
     tab3.setProps({ disabled: false })
     tab1.setProps({ disabled: true })
     await waitNT(wrapper.vm)
+    await waitRAF()
 
     // Expect 2nd tab to be active
     expect(tabs.vm.currentTab).toBe(1)
@@ -509,6 +538,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await waitNT(wrapper.vm)
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(1)
@@ -524,6 +554,7 @@ describe('tabs', () => {
     tabVm.$slots.title = [tabVm.$createElement('span', {}, 'foobar')]
     tabVm.$forceUpdate()
     await waitNT(wrapper.vm)
+    await waitRAF()
 
     // Expect tab button content to be `foobar`
     expect(wrapper.find('.nav-link').text()).toBe('foobar')
@@ -546,6 +577,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await wrapper.vm.$nextTick()
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -561,6 +593,7 @@ describe('tabs', () => {
     // Set 2nd tab to be active
     tabs.setProps({ value: 1 })
     await wrapper.vm.$nextTick()
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(1)
     // Expect 2nd tabs nav item to have "active-nav-item-class" applied
     expect(getNavItemByTab(tabs.vm.tabs[1]).classes(activeNavItemClass)).toBe(true)
@@ -585,6 +618,7 @@ describe('tabs', () => {
     expect(wrapper).toBeDefined()
 
     await wrapper.vm.$nextTick()
+    await waitRAF()
     const tabs = wrapper.find(BTabs)
     expect(tabs).toBeDefined()
     expect(tabs.findAll(BTab).length).toBe(3)
@@ -598,6 +632,7 @@ describe('tabs', () => {
     // Set 2nd tab to be active
     tabs.setProps({ value: 1 })
     await wrapper.vm.$nextTick()
+    await waitRAF()
     expect(tabs.vm.currentTab).toBe(1)
     // Expect 2nd tab to have "active-tab-class" applied
     expect(tabs.vm.tabs[1].$el.classList.contains(activeTabClass)).toBe(true)


### PR DESCRIPTION
### Describe the PR

Closes: #3361

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
