### PR TITLE
fix(form control): handle autofocus inside modal or when inside a transition

### DIFF
--- a/src/components/form-checkbox/form-checkbox.spec.js
+++ b/src/components/form-checkbox/form-checkbox.spec.js
@@ -1,5 +1,6 @@
 import BFormCheckbox from './form-checkbox'
 import { mount } from '@vue/test-utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 
 describe('form-checkbox', () => {
   // --- Custom checkbox structure, class and attributes tests ---
@@ -1270,7 +1271,8 @@ describe('form-checkbox', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('input')
       expect(input.exists()).toBe(true)
@@ -1292,7 +1294,8 @@ describe('form-checkbox', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('input')
       expect(input.exists()).toBe(true)

--- a/src/components/form-file/form-file.spec.js
+++ b/src/components/form-file/form-file.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { waitNT } from '../../../tests/utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 import BFormFile from './form-file'
 
 describe('form-file', () => {
@@ -517,7 +517,8 @@ describe('form-file', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('input')
       expect(input.exists()).toBe(true)

--- a/src/components/form-input/form-input.spec.js
+++ b/src/components/form-input/form-input.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { mount } from '@vue/test-utils'
-import { waitNT } from '../../../tests/utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 import BFormInput from './form-input'
 
 describe('form-input', () => {
@@ -800,7 +800,8 @@ describe('form-input', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('input')
       expect(input.exists()).toBe(true)
@@ -818,7 +819,8 @@ describe('form-input', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('input')
       expect(input.exists()).toBe(true)

--- a/src/components/form-radio/form-radio.spec.js
+++ b/src/components/form-radio/form-radio.spec.js
@@ -1,5 +1,6 @@
 import BFormRadio from './form-radio'
 import { mount } from '@vue/test-utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 
 describe('form-radio', () => {
   /* Custom radio structure, class and attributes tests */
@@ -972,7 +973,8 @@ describe('form-radio', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('input')
       expect(input.exists()).toBe(true)
@@ -993,7 +995,8 @@ describe('form-radio', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('input')
       expect(input.exists()).toBe(true)

--- a/src/components/form-select/form-select.spec.js
+++ b/src/components/form-select/form-select.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { waitNT } from '../../../tests/utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 import BFormSelect from './form-select'
 
 describe('form-select', () => {
@@ -586,7 +586,8 @@ describe('form-select', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('select')
       expect(input.exists()).toBe(true)
@@ -605,7 +606,8 @@ describe('form-select', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('select')
       expect(input.exists()).toBe(true)

--- a/src/components/form-textarea/form-textarea.spec.js
+++ b/src/components/form-textarea/form-textarea.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 import BFormTextarea from './form-textarea'
 
 describe('form-textarea', () => {
@@ -1026,7 +1027,8 @@ describe('form-textarea', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('textarea')
       expect(input.exists()).toBe(true)
@@ -1044,7 +1046,8 @@ describe('form-textarea', () => {
         }
       })
       expect(wrapper.vm).toBeDefined()
-      await wrapper.vm.$nextTick()
+      await waitNT(wrapper.vm)
+      await waitRAF()
 
       const input = wrapper.find('textarea')
       expect(input.exists()).toBe(true)

--- a/src/mixins/form.js
+++ b/src/mixins/form.js
@@ -1,4 +1,4 @@
-import { matches, select, isVisible } from '../utils/dom'
+import { matches, select, isVisible, requestAF } from '../utils/dom'
 
 const SELECTOR = 'input, textarea, select'
 
@@ -38,13 +38,15 @@ export default {
   methods: {
     handleAutofocus() {
       this.$nextTick(() => {
-        let el = this.$el
-        if (this.autofocus && isVisible(el)) {
-          if (!matches(el, SELECTOR)) {
-            el = select(SELECTOR, el)
+        requestAF(() => {
+          let el = this.$el
+          if (this.autofocus && isVisible(el)) {
+            if (!matches(el, SELECTOR)) {
+              el = select(SELECTOR, el)
+            }
+            el && el.focus && el.focus()
           }
-          el && el.focus && el.focus()
-        }
+        })
       })
     }
   }


### PR DESCRIPTION
### Describe the PR

Wrap autofocus routine in a requestAnimationFrame to allow for autofocusing in modal to work.

The `autofocus` prop was introduced in v2.0.0-rc.21

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
