### PR TITLE
feat(button): add new `squared` prop for making buttons with square corners

### DIFF
--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -50,24 +50,13 @@ Fancy larger or smaller buttons? Specify `lg` or `sm` via the `size` prop.
 <!-- b-button-sizes.vue -->
 ```
 
-### Block level buttons
-
-Create block level buttons — those that span the full width of a parent — by setting the `block`
-prop.
-
-```html
-<div>
-  <b-button block variant="primary">Block Level Button</b-button>
-</div>
-
-<!-- b-button-block.vue -->
-```
-
 ## Contextual variants
 
 Use the `variant` prop to generate the various Bootstrap contextual button variants.
 
 By default `<b-button>` will render with the `secondary` variant.
+
+The `variant` prop adds the Bootstrap V4.3 class `.btn-<variant>` on the rendered button.
 
 ### Solid color variants
 
@@ -124,6 +113,22 @@ padding and size of a button.
 <!-- b-button-link.vue -->
 ```
 
+**Tip:** remove the hover underline from a link variant button by adding the Bootstrap V4.3 utility
+class `no-text-decoration` to `<b-button>`.
+
+## Block level buttons
+
+Create block level buttons — those that span the full width of a parent — by setting the `block`
+prop.
+
+```html
+<div>
+  <b-button block variant="primary">Block Level Button</b-button>
+</div>
+
+<!-- b-button-block.vue -->
+```
+
 ## Pill style
 
 <span class="badge badge-info small">NEW in 2.0.0-rc.20</span>
@@ -143,10 +148,33 @@ Prefer buttons with a more rounded-pill style? Just set the prop `pill` to true.
 <!-- b-button-pill.vue -->
 ```
 
+This prop adds the Bootstrap V4.3 utility class `.rounded-pill` on the rendered button.
+
+## Square style
+
+<span class="badge badge-info small">NEW in 2.0.0-rc.22</span>
+
+Prefer buttons with a more square corner style? Just set the prop `square` to true.
+
+```html
+<div>
+  <b-button square>Button</b-button>
+  <b-button square variant="primary">Button</b-button>
+  <b-button square variant="outline-secondary">Button</b-button>
+  <b-button square variant="success">Button</b-button>
+  <b-button square variant="outline-danger">Button</b-button>
+  <b-button square variant="info">Button</b-button>
+</div>
+
+<!-- b-button-square.vue -->
+```
+
+The `square` prop adds the Bootstrap V4.3 utility class `.rounded-0` on the rendered button.
+
 ## Disabled state
 
 Set the `disabled` prop to disable button default functionality. `disabled` also works with buttons
-rendered as `<a>` elements and `<router-link>`.
+rendered as `<a>` elements and `<router-link>` (i.e. with the `href` or `to` prop set).
 
 ```html
 <div>

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -150,26 +150,27 @@ Prefer buttons with a more rounded-pill style? Just set the prop `pill` to true.
 
 This prop adds the Bootstrap V4.3 utility class `.rounded-pill` on the rendered button.
 
-## Square style
+## Squared style
 
 <span class="badge badge-info small">NEW in 2.0.0-rc.22</span>
 
-Prefer buttons with a more square corner style? Just set the prop `square` to true.
+Prefer buttons with a more square corner style? Just set the prop `squared` to true.
 
 ```html
 <div>
-  <b-button square>Button</b-button>
-  <b-button square variant="primary">Button</b-button>
-  <b-button square variant="outline-secondary">Button</b-button>
-  <b-button square variant="success">Button</b-button>
-  <b-button square variant="outline-danger">Button</b-button>
-  <b-button square variant="info">Button</b-button>
+  <b-button squared>Button</b-button>
+  <b-button squared variant="primary">Button</b-button>
+  <b-button squared variant="outline-secondary">Button</b-button>
+  <b-button squared variant="success">Button</b-button>
+  <b-button squared variant="outline-danger">Button</b-button>
+  <b-button squared variant="info">Button</b-button>
 </div>
 
 <!-- b-button-square.vue -->
 ```
 
-The `square` prop adds the Bootstrap V4.3 utility class `.rounded-0` on the rendered button.
+The `squared` prop adds the Bootstrap V4.3 utility class `.rounded-0` on the rendered button. The
+`pill` prop takes precedence over the `squared` prop.
 
 ## Disabled state
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -114,7 +114,7 @@ padding and size of a button.
 ```
 
 **Tip:** remove the hover underline from a link variant button by adding the Bootstrap V4.3 utility
-class `no-text-decoration` to `<b-button>`.
+class `text-decoration-none` to `<b-button>`.
 
 ## Block level buttons
 

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -41,7 +41,7 @@ const btnProps = {
     type: Boolean,
     default: false
   },
-  square: {
+  squared: {
     type: Boolean,
     default: false
   },
@@ -100,7 +100,7 @@ const computeClass = props => [
     [`btn-${props.size}`]: Boolean(props.size),
     'btn-block': props.block,
     'rounded-pill': props.pill,
-    'rounded-0': props.square && !props.pill,
+    'rounded-0': props.squared && !props.pill,
     disabled: props.disabled,
     active: props.pressed
   }

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -41,6 +41,10 @@ const btnProps = {
     type: Boolean,
     default: false
   },
+  square: {
+    type: Boolean,
+    default: false
+  },
   pressed: {
     // tri-state prop: true, false or null
     // => on, off, not a toggle
@@ -96,6 +100,7 @@ const computeClass = props => [
     [`btn-${props.size}`]: Boolean(props.size),
     'btn-block': props.block,
     'rounded-pill': props.pill,
+    'rounded-0': props.square && !props.pill,
     disabled: props.disabled,
     active: props.pressed
   }

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -106,10 +106,10 @@ describe('button', () => {
     expect(wrapper.classes().length).toBe(3)
   })
 
-  it('applies rounded-0 class when square prop set', async () => {
+  it('applies rounded-0 class when squared prop set', async () => {
     const wrapper = mount(BButton, {
       propsData: {
-        square: true
+        squared: true
       }
     })
 

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -90,7 +90,7 @@ describe('button', () => {
     expect(wrapper.classes().length).toBe(3)
   })
 
-  it('applies pill class', async () => {
+  it('applies rounded-pill class when pill prop set', async () => {
     const wrapper = mount(BButton, {
       propsData: {
         pill: true
@@ -103,6 +103,22 @@ describe('button', () => {
     expect(wrapper.classes()).toContain('btn')
     expect(wrapper.classes()).toContain('btn-secondary')
     expect(wrapper.classes()).toContain('rounded-pill')
+    expect(wrapper.classes().length).toBe(3)
+  })
+
+  it('applies rounded-0 class when square prop set', async () => {
+    const wrapper = mount(BButton, {
+      propsData: {
+        square: true
+      }
+    })
+
+    expect(wrapper.is('button')).toBe(true)
+    expect(wrapper.attributes('type')).toBeDefined()
+    expect(wrapper.attributes('type')).toBe('button')
+    expect(wrapper.classes()).toContain('btn')
+    expect(wrapper.classes()).toContain('btn-secondary')
+    expect(wrapper.classes()).toContain('rounded-0')
     expect(wrapper.classes().length).toBe(3)
   })
 


### PR DESCRIPTION
### Describe the PR

New `squared` prop will add class `rounded-0` to the button to make the corners squared.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
