### PR TITLE
fix(tabs): fix regression with dynamically added tabs (fixes #3395)

### DIFF
--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -136,6 +136,8 @@ export default Vue.extend({
     }
   },
   mounted() {
+    // Inform b-tabs of our presence
+    this.registerTab()
     // Initially show on mount if active and not disabled
     this.show = this.localActive
     // Deprecate use of `href` prop
@@ -151,7 +153,20 @@ export default Vue.extend({
       this.bvTabs.updateButton(this)
     }
   },
+  destroyed() {
+    // inform b-tabs of our departure
+    this.unregisterTab()
+  },
   methods: {
+    // Private methods
+    registerTab() {
+      // Inform `b-tabs` of our presence
+      this.bvTabs.registerTab && this.bvTabs.registerTab(this)
+    },
+    unregisterTab() {
+      // Inform `b-tabs` of our departure
+      this.bvTabs.unregisterTab && this.bvTabs.unregisterTab(this)
+    },
     // Public methods
     activate() {
       if (this.bvTabs.activateTab && !this.disabled) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -290,7 +290,7 @@ export default Vue.extend({
       })
     },
     isMounted(newVal, oldVal) {
-      if(newVal) {
+      if (newVal) {
         requestAF(() => {
           this.updateTabs()
         })

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -302,15 +302,15 @@ export default Vue.extend({
     })
   },
   mounted() {
+    // Call `updateTabs()` just in case...
+    this.updateTabs()
     // Observe child changes so we can update list of tabs
     // this.setObserver(true)
     this.$nextTick(() => {
-      // Call `updateTabs()` just in case...
-      this.updateTabs()
       // Flag we are now mounted and to switch to DOM for tab probing.
       // As this.$slots.default appears to lie about component instances
       // after b-tabs is destroyed and re-instantiated.
-      this.isMounted = true
+      // this.isMounted = true
     })
   },
   deactivated() /* istanbul ignore next */ {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -4,7 +4,7 @@ import BNav, { props as BNavProps } from '../nav/nav'
 import { requestAF, selectAll } from '../../utils/dom'
 import KeyCodes from '../../utils/key-codes'
 import observeDom from '../../utils/observe-dom'
-import { arrayIncludes } from '../../utils/array'
+import { arrayIncludes, concat } from '../../utils/array'
 import { omit } from '../../utils/object'
 import idMixin from '../../mixins/id'
 import normalizeSlotMixin from '../../mixins/normalize-slot'
@@ -651,7 +651,7 @@ export default Vue.extend({
         class: [{ col: this.vertical }, this.contentClass],
         attrs: { id: this.safeId('_BV_tab_container_') }
       },
-      tabs.length > 0 ? this.normalizeSlot('default') : [empty]
+      concat(this.normalizeSlot('default'), empty)
     )
 
     // Render final output

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -308,9 +308,7 @@ export default Vue.extend({
     // Observe child changes so we can update list of tabs
     this.setObserver(true)
     // Flag we are now mounted and to switch to DOM for tab probing
-    this.$nextTick(() => {
-      this.isMounted = true
-    })
+    this.isMounted = true
   },
   deactivated() /* istanbul ignore next */ {
     this.setObserver(false)
@@ -350,7 +348,8 @@ export default Vue.extend({
     getTabs() {
       let tabs = []
       if (!this.isMounted) {
-        tabs = (this.normalizeSlot('default') || []).map(vnode => vnode.componentInstance)
+        // tabs = (this.normalizeSlot('default') || []).map(vnode => vnode.componentInstance)
+        tabs = this.$children || []
       } else {
         // We rely on the DOM when mounted to get the list of tabs
         // Fix for https://github.com/bootstrap-vue/bootstrap-vue/issues/3361

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -283,8 +283,10 @@ export default Vue.extend({
     },
     isMounted(newVal, oldVal) {
       if (newVal) {
-        requestAF(() => {
-          this.updateTabs()
+        this.$nextTick(() => {
+          requestAF(() => {
+            this.updateTabs()
+          })
         })
       }
     }
@@ -301,18 +303,13 @@ export default Vue.extend({
     })
   },
   mounted() {
+    // Call `updateTabs()` just in case...
+    this.updateTabs()
+    // Observe child changes so we can update list of tabs
+    this.setObserver(true)
+    // Flag we are now mounted and to switch to DOM for tab probing
     this.$nextTick(() => {
-      // Call `updateTabs()` just in case...
-      this.updateTabs()
-      // Observe child changes so we can update list of tabs
-      this.setObserver(true)
-      // Flag we are now mounted and to switch to DOM for tab probing
       this.isMounted = true
-    })
-  },
-  updated() {
-    this.$nextTick(() => {
-      this.updateTabs()
     })
   },
   deactivated() /* istanbul ignore next */ {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -283,7 +283,10 @@ export default Vue.extend({
           }
         }
       }
-    }
+    },
+    registeredTabs(newVal, oldVal) {
+      this.updateTabs()
+    },
   },
   created() {
     let tabIdx = parseInt(this.value, 10)
@@ -300,7 +303,7 @@ export default Vue.extend({
     // Call `updateTabs()` just in case...
     this.updateTabs()
     // Observe child changes so we can update list of tabs
-    this.setObserver(true)
+    // this.setObserver(true)
     // Flag we are now mounted and to switch to DOM for tab probing.
     // As this.$slots.default appears to lie about component instances
     // after b-tabs is destroyed and re-instantiated.
@@ -309,7 +312,7 @@ export default Vue.extend({
     })
   },
   deactivated() /* istanbul ignore next */ {
-    this.setObserver(false)
+    // this.setObserver(false)
     this.isMounted = false
   },
   activated() /* istanbul ignore next */ {
@@ -317,7 +320,7 @@ export default Vue.extend({
     this.currentTab = isNaN(tabIdx) ? -1 : tabIdx
     this.$nextTick(() => {
       this.updateTabs()
-      this.setObserver(true)
+      // this.setObserver(true)
       this.isMounted = true
     })
   },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -304,7 +304,7 @@ export default Vue.extend({
     // Flag we are now mounted and to switch to DOM for tab probing.
     // As this.$slots.default appears to lie about component instances
     // after b-tabs is destroyed and re-instantiated.
-    this.nextTick(() => {
+    this.$nextTick(() => {
       this.isMounted = true
     })
   },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -340,7 +340,7 @@ export default Vue.extend({
   },
   methods: {
     registerTab(tab) {
-      if (!arrayIncludes(this.registeredTabs)) {
+      if (!arrayIncludes(this.registeredTabs, tab)) {
         this.registeredTabs.push(tab)
         tab.$once('hook:destroyed', () => {
           this.unregisterTab(tab)

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -310,7 +310,7 @@ export default Vue.extend({
       // Flag we are now mounted and to switch to DOM for tab probing.
       // As this.$slots.default appears to lie about component instances
       // after b-tabs is destroyed and re-instantiated.
-      // this.isMounted = true
+      this.isMounted = true
     })
   },
   deactivated() /* istanbul ignore next */ {
@@ -636,13 +636,12 @@ export default Vue.extend({
     if (!tabs || tabs.length === 0) {
       empty = h(
         'div',
-        { key: 'empty-tab', class: ['tab-pane', 'active', { 'card-body': this.card }] },
+        { key: 'bv-empty-tab', class: ['tab-pane', 'active', { 'card-body': this.card }] },
         this.normalizeSlot('empty')
       )
     }
 
     // Main content section
-    // TODO: This container should be a helper component
     const content = h(
       'div',
       {
@@ -652,7 +651,7 @@ export default Vue.extend({
         class: [{ col: this.vertical }, this.contentClass],
         attrs: { id: this.safeId('_BV_tab_container_') }
       },
-      [this.normalizeSlot('default'), empty]
+      tabs.length > 0 ? this.normalizeSlot('default') : [empty]
     )
 
     // Render final output

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -306,8 +306,6 @@ export default Vue.extend({
   created() {
     let tabIdx = parseInt(this.value, 10)
     this.currentTab = isNaN(tabIdx) ? -1 : tabIdx
-    // Create private non-reactive prop
-    this._bvObserver = null
     // For SSR and to make sure only a single tab is shown on mount
     // We wrap this in a `$nextTick()` to ensure the child tabs have been created
     this.$nextTick(() => {
@@ -321,6 +319,7 @@ export default Vue.extend({
       // Flag we are now mounted and to switch to DOM for tab probing.
       // As this.$slots.default appears to lie about component instances
       // after b-tabs is destroyed and re-instantiated.
+      // And this.$children does not respect DOM order.
       this.isMounted = true
     })
   },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -332,6 +332,9 @@ export default Vue.extend({
     registerTab(tab) {
       if (!arrayIncludes(this.registeredTabs)) {
         this.registeredTabs.push(tab)
+        tab.$once('hook:destroyed', () => {
+          this.unregisterTab(tab)
+        })
       }
     },
     unregisterTab(tab) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3,7 +3,7 @@ import BLink from '../link/link'
 import BNav, { props as BNavProps } from '../nav/nav'
 import { requestAF, selectAll } from '../../utils/dom'
 import KeyCodes from '../../utils/key-codes'
-import observeDom from '../../utils/observe-dom'
+// import observeDom from '../../utils/observe-dom'
 import { arrayIncludes, concat } from '../../utils/array'
 import { omit } from '../../utils/object'
 import idMixin from '../../mixins/id'
@@ -288,6 +288,13 @@ export default Vue.extend({
       this.$nextTick(() => {
         this.updateTabs()
       })
+    },
+    isMounted(newVal, oldVal) {
+      if(newVal) {
+        requestAF(() => {
+          this.updateTabs()
+        })
+      }
     }
   },
   created() {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -310,6 +310,11 @@ export default Vue.extend({
       this.isMounted = true
     })
   },
+  updated() {
+    this.$nextTick(() => {
+      this.updateTabs()
+    })
+  },
   deactivated() /* istanbul ignore next */ {
     this.setObserver(false)
     this.isMounted = false

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -285,7 +285,9 @@ export default Vue.extend({
       }
     },
     registeredTabs(newVal, oldVal) {
-      this.updateTabs()
+      this.$nextTick(() => {
+        this.updateTabs()
+      })
     }
   },
   created() {
@@ -300,14 +302,14 @@ export default Vue.extend({
     })
   },
   mounted() {
-    // Call `updateTabs()` just in case...
-    this.updateTabs()
     // Observe child changes so we can update list of tabs
     // this.setObserver(true)
-    // Flag we are now mounted and to switch to DOM for tab probing.
-    // As this.$slots.default appears to lie about component instances
-    // after b-tabs is destroyed and re-instantiated.
     this.$nextTick(() => {
+      // Call `updateTabs()` just in case...
+      this.updateTabs()
+      // Flag we are now mounted and to switch to DOM for tab probing.
+      // As this.$slots.default appears to lie about component instances
+      // after b-tabs is destroyed and re-instantiated.
       this.isMounted = true
     })
   },
@@ -325,7 +327,7 @@ export default Vue.extend({
     })
   },
   beforeDestroy() /* istanbul ignore next */ {
-    this.setObserver(false)
+    // this.setObserver(false)
   },
   destroyed() {
     // Ensure no references to child instances exist
@@ -341,8 +343,9 @@ export default Vue.extend({
       }
     },
     unregisterTab(tab) {
-      this.registeredTabs = this.registeredTabs.filter(t => t !== tab)
+      this.registeredTabs = this.registeredTabs.slice().filter(t => t !== tab)
     },
+    /*
     setObserver(on) {
       // Disable any previous observer
       if (this._bvObserver && this._bvObserver.disconnect) {
@@ -367,6 +370,7 @@ export default Vue.extend({
         })
       }
     },
+    */
     getTabs() {
       let tabs = []
       if (!this.isMounted) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -337,7 +337,7 @@ export default Vue.extend({
           })
         }
         // Watch for changes to <b-tab> sub components
-        this._bvObserver = observeDom(this.$refs.tabsContainer, handler, {
+        this._bvObserver = observeDom(this.$refs.tabsContainer, handler.bind(this), {
           childList: true,
           subtree: false,
           attributes: true,

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -331,8 +331,13 @@ export default Vue.extend({
       if (on) {
         // Make sure no existing observer running
         this.setObserver(false)
+        const handler = () => {
+          this.$nextTick(() => {
+            this.updateTabs()
+          })
+        }
         // Watch for changes to <b-tab> sub components
-        this._bvObserver = observeDom(this.$refs.tabsContainer, this.updateTabs.bind(this), {
+        this._bvObserver = observeDom(this.$refs.tabsContainer, handler, {
           childList: true,
           subtree: false,
           attributes: true,
@@ -348,8 +353,7 @@ export default Vue.extend({
     getTabs() {
       let tabs = []
       if (!this.isMounted) {
-        // tabs = (this.normalizeSlot('default') || []).map(vnode => vnode.componentInstance)
-        tabs = this.$children || []
+        tabs = (this.normalizeSlot('default') || []).map(vnode => vnode.componentInstance)
       } else {
         // We rely on the DOM when mounted to get the list of tabs
         // Fix for https://github.com/bootstrap-vue/bootstrap-vue/issues/3361

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -347,7 +347,10 @@ export default Vue.extend({
         // Make sure no existing observer running
         this.setObserver(false)
         const handler = () => {
-          this.updateTabs()
+          // Slight delay to ensure ensure b-tab instances are attached
+          requestAF(() => {
+            this.updateTabs()
+          })
         }
         // Watch for changes to <b-tab> sub components
         this._bvObserver = observeDom(this.$refs.tabsContainer, handler.bind(this), {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -286,7 +286,7 @@ export default Vue.extend({
     },
     registeredTabs(newVal, oldVal) {
       this.updateTabs()
-    },
+    }
   },
   created() {
     let tabIdx = parseInt(this.value, 10)

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -286,7 +286,9 @@ export default Vue.extend({
     },
     registeredTabs(newVal, oldVal) {
       this.$nextTick(() => {
-        this.updateTabs()
+        requestAF(() => {
+          this.updateTabs()
+        })
       })
     },
     isMounted(newVal, oldVal) {


### PR DESCRIPTION
### Describe the PR

Fix when using tabs that are dynamically created

Fixes #3395

Other tweaks:
- removed reliance on MutationObserver for detecting new tabs
- `b-tab` instances now notify `b-tabs` when they have been mounted/unmounted, so that `b-tabs` can then update its list of tabs (in DOM order)
- We still need to use DOM queries after mount (in `b-tabs`) to determine tab order and tab VM instances, as `this.$slots.default` may have cached old vnode instances which don't reflect the current instances (might be a 2.6.x Vue bug, or side-effect of new slot handling), when rendered inside lazy modals
  - While `this.$children` does have accurate lists of the `b-tab` instances, unlike `this.$slots.default`, we can't rely on it as the children in `this.$children` are not guaranteed to be in document order.

Discovered that the issue is related to how Vue 2.6.x allows a child to re-render in a parent slot, without triggering the parent to re-render.. by returning the same vNodes array as before. This is the weird effect we are seeing with tabs rendered inside lazy modals.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [ ] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [ ] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [ ] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
