### PR TITLE
fix(b-tabs): handle cases where `b-tab` has manually specified ID

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -352,10 +352,11 @@ export default Vue.extend({
       this.registeredTabs = this.registeredTabs.slice().filter(t => t !== tab)
     },
     getTabs() {
-      const tabs = this.registeredTabs.slice()
-      // Filter out any BTab components that are extended BTab with a root child BTab
+      // We use registeredTabs as the shouce of truth for child tab components. And we
+      // filter out any BTab components that are extended BTab with a root child BTab.
       // https://github.com/bootstrap-vue/bootstrap-vue/issues/3260
-      tabs = tabs.filter(tab => (tab.$children.filter(t => t._isTab).length === 0))
+      const tabs = this.registeredTabs
+        .filter(tab => tab.$children.filter(t => t._isTab).length === 0)
       // DOM Order of Tabs
       let order = []
       if (this.isMounted && tabs.length > 0) {
@@ -368,7 +369,7 @@ export default Vue.extend({
           .filter(Boolean)
       }
       // Stable sort keeps the original order if not found in the
-      // `order` array, which could happen before mount.
+      // `order` array, which will be an empty array before mount.
       return stableSort(tabs, (a, b) => {
         return order.indexOf(a.safeId()) - order.indexOf(b.safeId())
       })

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -364,7 +364,7 @@ export default Vue.extend({
           .filter(Boolean)
           // The VM attached to the element is `transition` so we need the $parent to get tab
           // but sometimes the vm attached to the element is teh b-tab (depended on render cycle)
-          .map(vm => vm._isTab ? vm : vm.$parent)
+          .map(vm => (vm._isTab ? vm : vm.$parent))
       }
       return tabs.filter(tab => tab && tab._isTab)
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -353,18 +353,22 @@ export default Vue.extend({
     },
     getTabs() {
       const tabs = this.registeredTabs.slice()
+      // Filter out any BTab components that are extended BTab with a root child BTab
+      // https://github.com/bootstrap-vue/bootstrap-vue/issues/3260
+      tabs = tabs.filter(tab => (tab.$children.filter(t => t._isTab).length === 0))
+      // DOM Order of Tabs
       let order = []
       if (this.isMounted && tabs.length > 0) {
-        // We rely on the DOM when mounted to get the 'true' order of the b-tab instances,
-        // as this.$slots.default appears to lie about current tab vm instances, after being
-        // destroyed and then re-intantiated (cached vNodes which don't reflect correct vm).
-        // querySelectorAll(...) always returns elements in document order
+        // We rely on the DOM when mounted to get the 'true' order of the b-tab children.
+        // querySelectorAll(...) always returns elements in document order, regardless of
+        // order specified in the selector.
         const selector = tabs.map(tab => `#${tab.safeId()}`).join(', ')
         order = selectAll(selector, this.$el)
           .map(el => el.id)
           .filter(Boolean)
       }
-      // Stable sort keeps the original order if not found in the `order` array
+      // Stable sort keeps the original order if not found in the
+      // `order` array, which could happen before mount.
       return stableSort(tabs, (a, b) => {
         return order.indexOf(a.safeId()) - order.indexOf(b.safeId())
       })

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -352,17 +352,19 @@ export default Vue.extend({
       this.registeredTabs = this.registeredTabs.slice().filter(t => t !== tab)
     },
     getTabs() {
+      const tabs = this.registeredTabs
       let order = []
       if (this.isMounted) {
         // We rely on the DOM when mounted to get the 'true' order of the b-tab instances,
         // as this.$slots.default appears to lie about current tab vm instances, after being
-        // destroyed and then re-intantiated (cached vNodes which don't reflect correct vm)
-        order = selectAll(`#${this.safeId('_BV_tab_container_')} > .tab-pane`, this.$el)
+        // destroyed and then re-intantiated (cached vNodes which don't reflect correct vm).
+        // querySelectorAll(...) always returns elements in document order
+        order = selectAll(tabs.map(tab => `#${tab.safeId()}`).join(','), this.$el)
           .map(el => el.id)
           .filter(Boolean)
       }
       // Stable sort returns a new array reference, and leaves the original array intact
-      return stableSort(this.registeredTabs, (a, b) => {
+      return stableSort(tabs, (a, b) => {
         return order.indexOf(a.safeId()) - order.indexOf(b.safeId())
       })
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -352,18 +352,19 @@ export default Vue.extend({
       this.registeredTabs = this.registeredTabs.slice().filter(t => t !== tab)
     },
     getTabs() {
-      const tabs = this.registeredTabs
+      const tabs = this.registeredTabs.slice()
       let order = []
       if (this.isMounted && tabs.length > 0) {
         // We rely on the DOM when mounted to get the 'true' order of the b-tab instances,
         // as this.$slots.default appears to lie about current tab vm instances, after being
         // destroyed and then re-intantiated (cached vNodes which don't reflect correct vm).
         // querySelectorAll(...) always returns elements in document order
-        order = selectAll(tabs.map(tab => `#${tab.safeId()}`).join(','), this.$el)
+        const selector = tabs.map(tab => `#${tab.safeId()}`).join(', ')
+        order = selectAll(selector, this.$el)
           .map(el => el.id)
           .filter(Boolean)
       }
-      // Stable sort returns a new array reference, and leaves the original array intact
+      // Stable sort keeps the original order if not found in the `order` array
       return stableSort(tabs, (a, b) => {
         return order.indexOf(a.safeId()) - order.indexOf(b.safeId())
       })

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -362,8 +362,9 @@ export default Vue.extend({
         tabs = selectAll(`#${this.safeId('_BV_tab_container_')} > .tab-pane`, this.$el)
           .map(el => el.__vue__)
           .filter(Boolean)
-          // The VM attached to the element is `transition` so we need the $parent to get tab
-          // but sometimes the vm attached to the element is teh b-tab (depended on render cycle)
+          // The VM attached to the element is usually `transition` so we need the $parent
+          // to get tab vm, but sometimes the tab vm is the one attached to the element
+          // (dependent on render cycle)
           .map(vm => (vm._isTab ? vm : vm.$parent))
       }
       return tabs.filter(tab => tab && tab._isTab)

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -363,7 +363,8 @@ export default Vue.extend({
           .map(el => el.__vue__)
           .filter(Boolean)
           // The VM attached to the element is `transition` so we need the $parent to get tab
-          .map(vm => vm.$parent)
+          // but sometimes the vm attached to the element is teh b-tab (depended on render cycle)
+          .map(vm => vm._isTab ? vm : vm.$parent)
       }
       return tabs.filter(tab => tab && tab._isTab)
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -354,7 +354,7 @@ export default Vue.extend({
     getTabs() {
       const tabs = this.registeredTabs
       let order = []
-      if (this.isMounted) {
+      if (this.isMounted && tabs.length > 0) {
         // We rely on the DOM when mounted to get the 'true' order of the b-tab instances,
         // as this.$slots.default appears to lie about current tab vm instances, after being
         // destroyed and then re-intantiated (cached vNodes which don't reflect correct vm).

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -355,8 +355,9 @@ export default Vue.extend({
       // We use registeredTabs as the shouce of truth for child tab components. And we
       // filter out any BTab components that are extended BTab with a root child BTab.
       // https://github.com/bootstrap-vue/bootstrap-vue/issues/3260
-      const tabs = this.registeredTabs
-        .filter(tab => tab.$children.filter(t => t._isTab).length === 0)
+      const tabs = this.registeredTabs.filter(
+        tab => tab.$children.filter(t => t._isTab).length === 0
+      )
       // DOM Order of Tabs
       let order = []
       if (this.isMounted && tabs.length > 0) {


### PR DESCRIPTION
### Describe the PR

Addresses https://github.com/bootstrap-vue/bootstrap-vue/issues/3260#issuecomment-498640877

In some cases, when querying the DOM for the contained b-tab instances, the vm attached to the element can either be the `transition` component (inside the b-tab) or it can be the `b-tab` itself, dependent on render conditions.

This fix uses the `registeredTabs` array as the source of truth, and then uses the DOM to determine order of the b-tab instances (after mount, by comparing b-tab IDs with the IDs found in the DOM)

Closes #3260 (via work-around https://github.com/bootstrap-vue/bootstrap-vue/issues/3260#issuecomment-498713337)

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
