### PR TITLE
fix(b-dropdown): close when clicking on nested elements inside item with `to` prop (fixes #3474)

### DIFF
--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -121,11 +121,11 @@ const clickHandlerFactory = ({ disabled, tag, href, suppliedHandler, parent }) =
       // Needed to prevent vue-router for doing its thing
       evt.stopImmediatePropagation()
     } else {
-      if (isRouterLink(tag) && evt.target.__vue__) {
+      if (isRouterLink(tag) && evt.currentTarget.__vue__) {
         // Router links do not emit instance 'click' events, so we
         // add in an $emit('click', evt) on it's vue instance
         /* istanbul ignore next: difficult to test, but we know it works */
-        evt.target.__vue__.$emit('click', evt)
+        evt.currentTarget.__vue__.$emit('click', evt)
       }
       // Call the suppliedHandler(s), if any provided
       concat(suppliedHandler)


### PR DESCRIPTION
### Describe the PR

Checks `evt.currentTarget` instead of `evt.target` when searching for router-link's vue instance in `b-link`.

Fixes #3474

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
