### PR TITLE
fix(form-input, form-textarea): handle case where input has been removed from document (closes #3498)

### DIFF
--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -126,7 +126,9 @@ export default {
         // When the `localValue` hasn't changed but the actual input value
         // is out of sync, make sure to change it to the given one.
         // Usually casued by browser autocomplete and how it triggers the
-        // change or input event.
+        // change or input event, or depending on the formatter function.
+        // https://github.com/bootstrap-vue/bootstrap-vue/issues/2657
+        // https://github.com/bootstrap-vue/bootstrap-vue/issues/3498
         /* istanbul ignore next: hard to test */
         this.$refs.input.value = value
       }

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -122,7 +122,7 @@ export default {
         }
         // Update the v-model
         this.$emit('update', value)
-      } else if (value !== this.$refs.input.value) {
+      } else if (this.$refs.input && value !== this.$refs.input.value) {
         // When the `localValue` hasn't changed but the actual input value
         // is out of sync, make sure to change it to the given one
         /* istanbul ignore next: hard to test */

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -124,7 +124,9 @@ export default {
         this.$emit('update', value)
       } else if (this.$refs.input && value !== this.$refs.input.value) {
         // When the `localValue` hasn't changed but the actual input value
-        // is out of sync, make sure to change it to the given one
+        // is out of sync, make sure to change it to the given one.
+        // Usually casued by browser autocomplete and how it triggers the
+        // change or input event.
         /* istanbul ignore next: hard to test */
         this.$refs.input.value = value
       }


### PR DESCRIPTION
### Describe the PR

In rare instances, the input may have been removed from document (during destroy phase) and browser autocomplete triggers a change before removed from document, resulting in `this.$refs.input` being undefined.  Adds in a check in `mixins/form-text` to handle this edge case.

Closes #3498

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
