### PR TITLE
fix(table): adjustments to sort icon positioning SCSS (closes #3563)

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -5,6 +5,7 @@ $b-table-busy-opacity: 0.55 !default;
 $b-table-sort-icon-null: "\2195" !default; // Up-Down arrow
 $b-table-sort-icon-ascending: "\2193" !default; // Down arrow
 $b-table-sort-icon-descending: "\2191" !default; // Up arrow
+$b-table-sort-icon-padding-left: 0.5em !default;
 $b-table-stacked-heading-width: 40% !default;
 $b-table-stacked-gap: 1rem !default;
 

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -5,7 +5,8 @@ $b-table-busy-opacity: 0.55 !default;
 $b-table-sort-icon-null: "\2195" !default; // Up-Down arrow
 $b-table-sort-icon-ascending: "\2193" !default; // Down arrow
 $b-table-sort-icon-descending: "\2191" !default; // Up arrow
-$b-table-sort-icon-padding-left: 0.5em !default;
+$b-table-sort-icon-margin-left: 0.5em !default;
+$b-table-sort-icon-width: 0.5em !default;
 $b-table-stacked-heading-width: 40% !default;
 $b-table-stacked-gap: 1rem !default;
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -38,8 +38,7 @@
           // Up/down sort=null indicator
           &::after {
             display: inline-block;
-            padding-left: 0.5em;
-            padding-right: 0.5em;
+            padding-left: $b-table-sort-icon-padding-left;
             font-size: inherit;
             line-height: inherit;
             opacity: 0.4;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -26,18 +26,6 @@
     }
   }
 
-  // Make cells relatively position for thinks like tooltips, etc.
-  > thead,
-  > tfoot {
-    > tr {
-      > th,
-      > td {
-        // So dropdowns, tooltips, sorting, etc., will position properly
-        position: relative;
-      }
-    }
-  }
-
   // --- Header sort styling ---
   > thead,
   > tfoot {
@@ -45,17 +33,13 @@
       > th {
         &[aria-sort] {
           // `&.sorting`
-          position: relative;
-          padding-right: 1.125em;
           cursor: pointer;
 
           // Up/down sort=null indicator
           &::after {
-            position: absolute;
-            display: block;
-            bottom: 0;
-            right: 0.35em;
-            padding-bottom: inherit;
+            display: inline-block;
+            padding-left: 0.5em;
+            padding-right: 0.5em;
             font-size: inherit;
             line-height: inherit;
             opacity: 0.4;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -39,7 +39,8 @@
           &::before {
             display: inline-block;
             float: right;
-            padding-left: $b-table-sort-icon-padding-left;
+            margin-left: $b-table-sort-icon-margin-left;
+            width: $b-table-sort-icon-width;
             font-size: inherit;
             line-height: inherit;
             opacity: 0.4;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -36,8 +36,9 @@
           cursor: pointer;
 
           // Up/down sort=null indicator
-          &::after {
+          &::before {
             display: inline-block;
+            float: right;
             padding-left: $b-table-sort-icon-padding-left;
             font-size: inherit;
             line-height: inherit;
@@ -47,14 +48,14 @@
           }
 
           // Ascending indicator
-          &[aria-sort="ascending"]::after {
+          &[aria-sort="ascending"]::before {
             // `&.sorting_asc::after.sorting_asc`
             opacity: 1;
             content: $b-table-sort-icon-ascending; // Down arrow
           }
 
           // Descending indicator
-          &[aria-sort="descending"]::after {
+          &[aria-sort="descending"]::before {
             // `&.sorting_desc::after`
             opacity: 1;
             content: $b-table-sort-icon-descending; // Up arrow


### PR DESCRIPTION
### Describe the PR

Switch from absolute positioning to `display: inline-block` + `float: right` + `::before` (instead of `::after`) for sort icons.

Removes need for `position: relative;` on table header/footer cells which can interfere with dropdowns and tooltips/popovers in headers of responsive tables (note `boundary` option needs to be set on dropdown, tooltip, popover, to allow to break out of responsive table container)

closes #3563 

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other (please describe) SCSS update

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
