### PR TITLE
feat(tooltip, popover): remove need for route watcher

### DIFF
--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -63,7 +63,7 @@ export const BPopover = /*#__PURE__*/ Vue.extend({
       const target = this.getTarget()
       /* istanbul ignore else */
       if (target) {
-        this._toolpop = new PopOver(target, this.getConfig(), this.$root)
+        this._toolpop = new PopOver(target, this.getConfig(), this)
       } else {
         this._toolpop = null
         warn("b-popover: 'target' element not found!")

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -57,7 +57,7 @@ export const BTooltip = /*#__PURE__*/ Vue.extend({
       const target = this.getTarget()
       /* istanbul ignore else */
       if (target) {
-        this._toolpop = new ToolTip(target, this.getConfig(), this.$root)
+        this._toolpop = new ToolTip(target, this.getConfig(), this)
       } else {
         this._toolpop = null
         warn("b-tooltip: 'target' element not found!")

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -129,7 +129,7 @@ const applyPopover = (el, bindings, vnode) => {
   if (el[BV_POPOVER]) {
     el[BV_POPOVER].updateConfig(config)
   } else {
-    el[BV_POPOVER] = new PopOver(el, config, vnode.context.$root)
+    el[BV_POPOVER] = new PopOver(el, config, vnode.context)
   }
 }
 

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -129,7 +129,7 @@ const applyTooltip = (el, bindings, vnode) => {
   if (el[BV_TOOLTIP]) {
     el[BV_TOOLTIP].updateConfig(config)
   } else {
-    el[BV_TOOLTIP] = new ToolTip(el, config, vnode.context.$root)
+    el[BV_TOOLTIP] = new ToolTip(el, config, vnode.context)
   }
 }
 

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -148,7 +148,7 @@ class ToolTip {
     this.updateConfig(config)
     // Destroy ourselves if the parent is destroyed
     if ($parent) {
-      $parent.$once('hook:beforeDestroy', this.destroy)
+      $parent.$once('hook:beforeDestroy', this.destroy.bind(this))
     }
   }
 

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -121,7 +121,7 @@ const generateId = name => `__BV_${name}_${NEXTID++}__`
  */
 class ToolTip {
   // Main constructor
-  constructor(element, config, $root) {
+  constructor(element, config, $parent) {
     // New tooltip object
     this.$isEnabled = true
     this.$fadeTimeout = null
@@ -133,7 +133,7 @@ class ToolTip {
     this.$element = element
     this.$tip = null
     this.$id = generateId(this.constructor.NAME)
-    this.$root = $root || null
+    this.$parent = $parent || null
     this.$routeWatcher = null
     // We use a bound version of the following handlers for root/modal
     // listeners to maintain the 'this' context
@@ -145,6 +145,10 @@ class ToolTip {
     this._noop = noop.bind(this)
     // Set the configuration
     this.updateConfig(config)
+    // Destroy ourselves if the parent is destroyed
+    if (this.$parent) {
+      this.$parent.$once('hook:beforeDestroy', this.destroy.bind(this))
+    }
   }
 
   // NOTE: Overridden by PopOver class
@@ -216,7 +220,7 @@ class ToolTip {
     // Null out other properties
     this.$id = null
     this.$isEnabled = null
-    this.$root = null
+    this.$parent = null
     this.$element = null
     this.$config = null
     this.$hoverState = null
@@ -380,8 +384,6 @@ class ToolTip {
     // Periodic $element visibility check
     // For handling when tip is in <keepalive>, tabs, carousel, etc
     this.visibleCheck(on)
-    // Route change events
-    this.setRouteWatcher(on)
     // On-touch start listeners
     this.setOnTouchStartListener(on)
     if (on && /(focus|blur)/.test(this.$config.trigger)) {
@@ -472,9 +474,10 @@ class ToolTip {
 
   emitEvent(evt) {
     const evtName = evt.type
-    if (this.$root && this.$root.$emit) {
+    const $root = this.$parent && this.$parent.$root
+    if ($root && $root.$emit) {
       // Emit an event on $root
-      this.$root.$emit(`bv::${this.constructor.NAME}::${evtName}`, evt)
+      $root.$emit(`bv::${this.constructor.NAME}::${evtName}`, evt)
     }
     const callbacks = this.$config.callbacks || {}
     if (isFunction(callbacks[evtName])) {
@@ -765,28 +768,6 @@ class ToolTip {
   }
 
   /* istanbul ignore next */
-  setRouteWatcher(on) {
-    if (on) {
-      this.setRouteWatcher(false)
-      if (this.$root && Boolean(this.$root.$route)) {
-        this.$routeWatcher = this.$root.$watch('$route', (newVal, oldVal) => {
-          if (newVal === oldVal) {
-            return
-          }
-          // If route has changed, we force hide the tooltip/popover
-          this.forceHide()
-        })
-      }
-    } else {
-      if (this.$routeWatcher) {
-        // Cancel the route watcher by calling the stored reference
-        this.$routeWatcher()
-        this.$routeWatcher = null
-      }
-    }
-  }
-
-  /* istanbul ignore next */
   setModalListener(on) {
     const modal = closest(MODAL_CLASS, this.$element)
     if (!modal) {
@@ -794,18 +775,19 @@ class ToolTip {
       return
     }
     // We can listen for modal hidden events on $root
-    if (this.$root) {
-      this.$root[on ? '$on' : '$off'](MODAL_CLOSE_EVENT, this.$forceHide)
+    if (this.$parent && this.$parent.$root) {
+      this.$parent.$root[on ? '$on' : '$off'](MODAL_CLOSE_EVENT, this.$forceHide)
     }
   }
 
   setRootListener(on) {
     // Listen for global 'bv::{hide|show}::{tooltip|popover}' hide request event
-    if (this.$root) {
-      this.$root[on ? '$on' : '$off'](`bv::hide::${this.constructor.NAME}`, this.$doHide)
-      this.$root[on ? '$on' : '$off'](`bv::show::${this.constructor.NAME}`, this.$doShow)
-      this.$root[on ? '$on' : '$off'](`bv::disable::${this.constructor.NAME}`, this.$doDisable)
-      this.$root[on ? '$on' : '$off'](`bv::enable::${this.constructor.NAME}`, this.$doEnable)
+    const $root = this.$parent && this.$parent.$root
+    if ($root) {
+      $root[on ? '$on' : '$off'](`bv::hide::${this.constructor.NAME}`, this.$doHide)
+      $root[on ? '$on' : '$off'](`bv::show::${this.constructor.NAME}`, this.$doShow)
+      $root[on ? '$on' : '$off'](`bv::disable::${this.constructor.NAME}`, this.$doDisable)
+      $root[on ? '$on' : '$off'](`bv::enable::${this.constructor.NAME}`, this.$doEnable)
     }
   }
 

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -684,6 +684,7 @@ class ToolTip {
 
   listen() {
     const el = this.$element
+    /* istanbul ignore next */
     if (!el) {
       return
     }
@@ -712,6 +713,7 @@ class ToolTip {
 
   unListen() {
     const el = this.$element
+    /* istanbul ignore next */
     if (!el) {
       return
     }
@@ -779,6 +781,7 @@ class ToolTip {
   /* istanbul ignore next */
   setModalListener(on) {
     const el = this.$element
+    /* istanbul ignore next */
     if (!el || !this.$root) {
       return
     }


### PR DESCRIPTION
### Describe the PR

This PR passes the parent context rather than root context to tooltips/popovers, so that they can auto-destroy when the parent context is destroyed.

In the earlier days of tooltips/popovers, the tooltip/popover would remain in document when not shown (and in some instanced would remain in document when route changes), where as in later releases tooltips/popovers are only instantiated when shown (and destroyed on hide).

This PR passes the `parent` context to the tooltip/popover class rather than the root context.  So that the tooltip/popover can hook into the parent `destroyed` hooks and destroy itself.

This will be beneficial for those that have tooltips outside of a child `<router-view>` (or `<nuxt-child>`) and the tooltips were being closed when the child route changes.

Now the tooltip or popover will only be destroyed when the parent component is destroyed.

Issue brought up on Discord chat re tips closing on child route changes.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
