### PR TITLE
feat(tooltip, popover): add support for contextual variants and custom class (closes #1983, #2075)

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -22,7 +22,11 @@ $b-toast-bg-level: $alert-bg-level !default;
 $b-toast-border-level: $alert-border-level !default;
 $b-toast-color-level: $alert-color-level !default;
 
+// --- Tooltip variants ---
+$bv-enable-tooltip-variants: true !default;
+
 // --- Popover variant levels wrt theme color value ---
+$bv-enable-popover-variants: true !default;
 $bv-popover-bg-level: $alert-bg-level !default;
 $bv-popover-border-level: $alert-border-level !default;
 $bv-popover-color-level: $alert-color-level !default;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -20,3 +20,8 @@ $b-toaster-offset-right: $b-toaster-offset-top !default;
 $b-toast-bg-level: $alert-bg-level !default;
 $b-toast-border-level: $alert-border-level !default;
 $b-toast-color-level: $alert-color-level !default;
+
+// --- Popover variant levels ---
+$bv-popover-bg-level: $alert-bg-level !default;
+$bv-popover-border-level: $alert-border-level !default;
+$bv-popover-color-level: $alert-color-level !default;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -17,11 +17,12 @@ $b-toaster-offset-bottom: $b-toaster-offset-top !default;
 $b-toaster-offset-left: $b-toaster-offset-top !default;
 $b-toaster-offset-right: $b-toaster-offset-top !default;
 
+// --- Toast variant levels wrt theme color value ---
 $b-toast-bg-level: $alert-bg-level !default;
 $b-toast-border-level: $alert-border-level !default;
 $b-toast-color-level: $alert-color-level !default;
 
-// --- Popover variant levels ---
+// --- Popover variant levels wrt theme color value ---
 $bv-popover-bg-level: $alert-bg-level !default;
 $bv-popover-border-level: $alert-border-level !default;
 $bv-popover-color-level: $alert-color-level !default;

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -9,6 +9,7 @@
 @import "navbar/index";
 @import "pagination/index";
 @import "pagination-nav/index";
+@import "popover/index";
 @import "table/index";
 @import "toast/index";
 @import "tooltip/index";

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -11,3 +11,4 @@
 @import "pagination-nav/index";
 @import "table/index";
 @import "toast/index";
+@import "tooltip/index";

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -276,7 +276,7 @@ BootstrapVue's popovers support contextual color variants via our custom CSS, vi
 ```html
 <div class="text-center">
   <b-button id="popover-button-variant">Button</b-button>
-  <b-popover target="popover-button-variant" variant="danger">
+  <b-popover target="popover-button-variant" variant="danger" triggers="focus">
     <template slot="title">Danger!</template>
     Danger variant popover
   </b-popover>
@@ -284,6 +284,10 @@ BootstrapVue's popovers support contextual color variants via our custom CSS, vi
 
 <!-- b-popover-variant.vue -->
 ```
+
+Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`, `info`,
+`light`, and `dark`. You can change or add additional variants via Bootstrap
+[SCSS variables](/docs/reference/theming)
 
 A custom class can be applied to the popover outer wrapper `<div>` by using the `custom-class` prop:
 

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -266,6 +266,44 @@ The special `blur` trigger **must** be used in combination with the `click` trig
 | `container`          | `null`           | Element string ID to append rendered popover into. If `null` or element not found, popover is appended to `<body>` (default)                                                                               | Any valid in-document unique element ID.                                                                                                         |
 | `boundary`           | `'scrollParent'` | The container that the popover will be constrained visually. The default should suffice in most cases, but you may need to change this if your target element is in a small container with overflow scroll | `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.                                                         |
 | `boundary-padding`   | `5`              | Amount of pixel used to define a minimum distance between the boundaries and the popover. This makes sure the popover always has a little padding between the edges of its container.                      | Any positive number                                                                                                                              |
+| `variant`            | `null`           | Contextual color variant for the popover                                                                                                                                                                   | Any contextual theme color variant name                                                                                                      |
+| `customClass`        | `null`           | A custom classname to apply to the popover outer wrapper element                                                                                                                                     | A string                                                                                                                  |
+
+### Variants and custom class
+
+<span class="badge badge-info small">NEW in 2.0.0-rc.26</span>
+
+BootstrapVue's popovers support contextual color variants via our custom CSS, via the `variant` prop:
+
+```html
+<div class="text-center">
+  <b-button id="popover-button-variant">Button</b-button>
+  <b-popover target="popover-button-variant" variant="danger">
+    <template slot="title">Danger!</template>
+    Danger variant popover
+  </b-popover>
+</div>
+
+<!-- b-popover-variant.vue -->
+```
+
+A custom class can be applied to the popover outer wrapper `<div>` by using the `custom-class` prop:
+
+```html
+<div class="text-center">
+  <b-button id="my-button">Button</b-button>
+  <b-popover target="my-button" custom-class="my-popover-class">
+    <template slot="title">Popover Title</template>
+    Popover content
+  </b-popover>
+</div>
+```
+
+**Note:** Custom classes will not work with scoped styles, as the popovers are appended to the document
+`<body>` element by default.
+
+Refer to the [popover directive](/docs/directives/popover) docs on applying variants and custom class
+to the directive version.
 
 ### Programmatically show and hide popover
 

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -264,14 +264,15 @@ The special `blur` trigger **must** be used in combination with the `click` trig
 | `container`          | `null`           | Element string ID to append rendered popover into. If `null` or element not found, popover is appended to `<body>` (default)                                                                               | Any valid in-document unique element ID.                                                                                                         |
 | `boundary`           | `'scrollParent'` | The container that the popover will be constrained visually. The default should suffice in most cases, but you may need to change this if your target element is in a small container with overflow scroll | `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.                                                         |
 | `boundary-padding`   | `5`              | Amount of pixel used to define a minimum distance between the boundaries and the popover. This makes sure the popover always has a little padding between the edges of its container.                      | Any positive number                                                                                                                              |
-| `variant`            | `null`           | Contextual color variant for the popover                                                                                                                                                                   | Any contextual theme color variant name                                                                                                      |
-| `customClass`        | `null`           | A custom classname to apply to the popover outer wrapper element                                                                                                                                     | A string                                                                                                                  |
+| `variant`            | `null`           | Contextual color variant for the popover                                                                                                                                                                   | Any contextual theme color variant name                                                                                                          |
+| `customClass`        | `null`           | A custom classname to apply to the popover outer wrapper element                                                                                                                                           | A string                                                                                                                                         |
 
 ### Variants and custom class
 
 <span class="badge badge-info small">NEW in 2.0.0-rc.26</span>
 
-BootstrapVue's popovers support contextual color variants via our custom CSS, via the `variant` prop:
+BootstrapVue's popovers support contextual color variants via our custom CSS, via the `variant`
+prop:
 
 ```html
 <div class="text-center">
@@ -285,8 +286,8 @@ BootstrapVue's popovers support contextual color variants via our custom CSS, vi
 <!-- b-popover-variant.vue -->
 ```
 
-Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`, `info`,
-`light`, and `dark`. You can change or add additional variants via Bootstrap
+Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`,
+`info`, `light`, and `dark`. You can change or add additional variants via Bootstrap
 [SCSS variables](/docs/reference/theming)
 
 A custom class can be applied to the popover outer wrapper `<div>` by using the `custom-class` prop:
@@ -301,11 +302,11 @@ A custom class can be applied to the popover outer wrapper `<div>` by using the 
 </div>
 ```
 
-**Note:** Custom classes will not work with scoped styles, as the popovers are appended to the document
-`<body>` element by default.
+**Note:** Custom classes will not work with scoped styles, as the popovers are appended to the
+document `<body>` element by default.
 
-Refer to the [popover directive](/docs/directives/popover) docs on applying variants and custom class
-to the directive version.
+Refer to the [popover directive](/docs/directives/popover) docs on applying variants and custom
+class to the directive version.
 
 ### Programmatically show and hide popover
 

--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -16,17 +16,15 @@
 
 Things to know when using popover component:
 
-- Popovers rely on the 3rd party library Popper.js for positioning. The library is bundled with
-  BootstrapVue dist files!
+- Popovers rely on the 3rd party library [Popper.js](https://popper.js.org/) for positioning.
 - Popovers with zero-length title _and_ content are never displayed.
 - Specify `container` as `null` (default, appends to `<body>`) to avoid rendering problems in more
   complex components (like input groups, button groups, etc). You can use `container` to optionally
-  specify a different element to append the popover to.
+  specify a different element to append the rendered popover to.
 - Triggering popovers on hidden elements will not work.
 - Popovers for `disabled` elements must be triggered on a wrapper element.
 - When triggered from hyperlinks that span multiple lines, popovers will be centered. Use
   `white-space: nowrap;` on your `<a>`s, `<b-link>`s and `<router-link>`s to avoid this behavior.
-- Popovers must be hidden before their corresponding markup elements have been removed from the DOM.
 
 The `<b-popover>` component inserts a hidden (`display: none;`) `<div>` intermediate container
 element at the point in the DOM where the `<b-popover>` component is placed. This may affect layout

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -6,7 +6,7 @@
     $po-header-bg: darken($po-bg-color, 3%);
     $po-header-color: color-yiq($po-header-bg);
     $po-arrow-color: $po-bg-color;
-    $po-arrow-color-top: $po-header-bg;
+    $po-arrow-color-bottom: $po-header-bg;
     $po-arrow-outer-color: fade-in($po-border-color, .05);
 
     &.popover {
@@ -21,8 +21,7 @@
         }
 
         &::after {
-          // Use the header bg color
-          border-top-color: $po-arrow-color-top;
+          border-top-color: $po-arrow-color;
         }
       }
     }
@@ -46,7 +45,8 @@
         }
 
         &::after {
-          border-bottom-color: $po-arrow-color;
+          // Use the header bg color
+          border-bottom-color: $po-arrow-color-bottom;
         }
       }
       

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -6,7 +6,7 @@
     $po-header-bg: darken($po-bg-color, 3%);
     $po-header-color: color-yiq($po-header-bg);
     $po-arrow-color: $po-bg-color;
-    $po-arrow-outer-color: fade-in($po-border-color, .05)
+    $po-arrow-outer-color: fade-in($po-border-color, .05);
 
     &.popover {
       background-color: $po-bg-color;

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -6,6 +6,7 @@
     $po-header-bg: darken($po-bg-color, 3%);
     $po-header-color: color-yiq($po-header-bg);
     $po-arrow-color: $po-bg-color;
+    $po-arrow-color-top: $po-header-bg;
     $po-arrow-outer-color: fade-in($po-border-color, .05);
 
     &.popover {
@@ -20,7 +21,8 @@
         }
 
         &::after {
-          border-top-color: $po-arrow-color;
+          // Use the header bg color
+          border-top-color: $po-arrow-color-top;
         }
       }
     }

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -1,0 +1,93 @@
+@each $color, $value in $theme-colors {
+  .b-popover-#{$color} {
+    $po-bg-color: theme-color-level($color, $bv-popover-bg-level);
+    $po-border-color: theme-color-level($color, $bv-popover-border-level);
+    $po-color: theme-color-level($color, $bv-popover-color-level);
+    $po-header-bg: darken($po-bg-color, 3%);
+    $po-header-color: color-yiq($po-header-bg);
+    $po-arrow-color: $po-bg-color;
+    $po-arrow-outer-color: fade-in($po-border-color, .05)
+
+    &.popover {
+      background-color: $po-bg-color;
+      border-color: $po-border-color;
+    }
+
+    &.bs-popover-top {
+      > .arrow {
+        &::before {
+          border-top-color: $po-arrow-outer-color;
+        }
+
+        &::after {
+          border-top-color: $po-arrow-color;
+        }
+      }
+    }
+
+    &.bs-popover-right {
+      > .arrow {
+        &::before {
+          border-right-color: $po-arrow-outer-color;
+        }
+
+        &::after {
+          border-right-color: $po-arrow-color;
+        }
+      }
+    }
+
+    &.bs-popover-bottom {
+      > .arrow {
+        &::before {
+          border-bottom-color: $po-arrow-outer-color;
+        }
+
+        &::after {
+          border-bottom-color: $po-arrow-color;
+        }
+      }
+      
+      .popover-header::before {
+        border-bottom-color: $po-header-bg;
+      }
+    }
+
+    &.bs-popover-left {
+      > .arrow {
+        &::before {
+          border-left-color: $po-arrow-outer-color;
+        }
+
+        &::after {
+          border-left-color: $po-arrow-color;
+        }
+      }
+    }
+
+    &.bs-popover-auto {
+      &[x-placement^="top"] {
+        @extend .bs-popover-top;
+      }
+      &[x-placement^="right"] {
+        @extend .bs-popover-right;
+      }
+      &[x-placement^="bottom"] {
+        @extend .bs-popover-bottom;
+      }
+      &[x-placement^="left"] {
+        @extend .bs-popover-left;
+      }
+    }
+
+    .popover-header {
+      color: $po-header-color;
+      background-color: $po-header-bg;
+      border-bottom-color: darken($po-header-bg, 5%);
+    }
+
+    .popover-body {
+      color: $po-color;
+    }
+  }
+}

--- a/src/components/popover/index.scss
+++ b/src/components/popover/index.scss
@@ -1,0 +1,1 @@
+@import "popover";

--- a/src/components/popover/package.json
+++ b/src/components/popover/package.json
@@ -4,6 +4,7 @@
   "meta": {
     "title": "Popover",
     "description": "The Popover feature provides a tooltip-like behavior, can be easily applied to any interactive element via the <b-popover> component or v-b-popover directive",
+    "enhanced": true,
     "directives": [
       "VBPopover"
     ],

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -33,6 +33,14 @@ export const props = {
       return isArray(value) || arrayIncludes(['flip', 'clockwise', 'counterclockwise'], value)
     }
   },
+  variant: {
+    type: String,
+    default: () => getComponentConfig(NAME, 'variant')
+  },
+  customClass: {
+    type: String,
+    default: () => getComponentConfig(NAME, 'customClass')
+  },
   delay: {
     type: [Number, Object, String],
     default: () => getComponentConfig(NAME, 'delay')

--- a/src/components/popover/popover.spec.js
+++ b/src/components/popover/popover.spec.js
@@ -6,7 +6,17 @@ const localVue = new CreateLocalVue()
 
 // Our test application definition
 const appDef = {
-  props: ['triggers', 'show', 'disabled', 'noFade', 'title', 'titleAttr', 'btnDisabled'],
+  props: [
+    'triggers',
+    'show',
+    'disabled',
+    'noFade',
+    'title',
+    'titleAttr',
+    'btnDisabled',
+    'variant',
+    'customClass'
+  ],
   render(h) {
     return h('article', { attrs: { id: 'wrapper' } }, [
       h(
@@ -30,7 +40,9 @@ const appDef = {
             triggers: this.triggers,
             show: this.show,
             disabled: this.disabled,
-            noFade: this.noFade || false
+            noFade: this.noFade || false,
+            variant: this.variant,
+            customClass: this.customClass
           }
         },
         [h('template', { slot: 'title' }, this.$slots.title), this.$slots.default || '']
@@ -45,7 +57,7 @@ const appDef = {
 
 // Note: `wrapper.destroy()` MUST be called at the end of each test in order for
 // the next test to function properly!
-describe('tooltip', () => {
+describe('b-popover', () => {
   const originalCreateRange = document.createRange
   const origGetBCR = Element.prototype.getBoundingClientRect
 

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -158,7 +158,10 @@ then clicks the trigger element, they must click it again **and** move focus to 
 | `boundary-padding`   | `5`              | Amount of pixel used to define a minimum distance between the boundaries and the tooltip. This makes sure the tooltip always has a little padding between the edges of its container.                      | Any positive number                                                                                                                              |
 | `variant`            | `null`           | Contextual color variant for the tooltip                                                                                                                                                                   | Any contextual theme color variant name                                                                                                      |
 | `customClass`        | `null`           | A custom classname to apply to the tooltip outer wrapper element                                                                                                                                     | A string                                                                                                                  |
+
 ### Variants and custom class
+
+<span class="badge badge-info small">NEW in 2.0.0-rc.26</span>
 
 BootstrapVue's tooltips support contextual color variants via our custom CSS, via the `variant` prop:
 
@@ -176,7 +179,7 @@ A custom class can be applied to the tooltip outer wrapper `<div>` by using the 
 ```html
 <div class="text-center">
   <b-button id="my-button">Button</b-button>
-  <b-tooltip target="my-button" custom class="my-tooltip-class">Tooltip Title</b-tooltip>
+  <b-tooltip target="my-button" custom-class="my-tooltip-class">Tooltip Title</b-tooltip>
 </div>
 ```
 

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -154,14 +154,15 @@ then clicks the trigger element, they must click it again **and** move focus to 
 | `container`          | `null`           | Element string ID to append rendered tooltip into. If `null` or element not found, tooltip is appended to `<body>` (default)                                                                               | Any valid in-document unique element ID.                                                                                                         |
 | `boundary`           | `'scrollParent'` | The container that the tooltip will be constrained visually. The default should suffice in most cases, but you may need to change this if your target element is in a small container with overflow scroll | `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.                                                         |
 | `boundary-padding`   | `5`              | Amount of pixel used to define a minimum distance between the boundaries and the tooltip. This makes sure the tooltip always has a little padding between the edges of its container.                      | Any positive number                                                                                                                              |
-| `variant`            | `null`           | Contextual color variant for the tooltip                                                                                                                                                                   | Any contextual theme color variant name                                                                                                      |
-| `customClass`        | `null`           | A custom classname to apply to the tooltip outer wrapper element                                                                                                                                     | A string                                                                                                                  |
+| `variant`            | `null`           | Contextual color variant for the tooltip                                                                                                                                                                   | Any contextual theme color variant name                                                                                                          |
+| `customClass`        | `null`           | A custom classname to apply to the tooltip outer wrapper element                                                                                                                                           | A string                                                                                                                                         |
 
 ### Variants and custom class
 
 <span class="badge badge-info small">NEW in 2.0.0-rc.26</span>
 
-BootstrapVue's tooltips support contextual color variants via our custom CSS, via the `variant` prop:
+BootstrapVue's tooltips support contextual color variants via our custom CSS, via the `variant`
+prop:
 
 ```html
 <div class="text-center">
@@ -172,8 +173,8 @@ BootstrapVue's tooltips support contextual color variants via our custom CSS, vi
 <!-- b-tooltip-variant.vue -->
 ```
 
-Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`, `info`,
-`light`, and `dark`. You can change or add additional variants via Bootstrap
+Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`,
+`info`, `light`, and `dark`. You can change or add additional variants via Bootstrap
 [SCSS variables](/docs/reference/theming)
 
 A custom class can be applied to the tooltip outer wrapper `<div>` by using the `custom-class` prop:
@@ -185,11 +186,11 @@ A custom class can be applied to the tooltip outer wrapper `<div>` by using the 
 </div>
 ```
 
-**Note:** Custom classes will not work with scoped styles, as the tooltips are appended to the document
-`<body>` element by default.
+**Note:** Custom classes will not work with scoped styles, as the tooltips are appended to the
+document `<body>` element by default.
 
-Refer to the [tooltip directive](/docs/directives/tooltip) docs on applying variants and custom class
-to the directive version.
+Refer to the [tooltip directive](/docs/directives/tooltip) docs on applying variants and custom
+class to the directive version.
 
 ### Programmatically show and hide tooltip
 

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -172,6 +172,10 @@ BootstrapVue's tooltips support contextual color variants via our custom CSS, vi
 <!-- b-tooltip-variant.vue -->
 ```
 
+Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`, `info`,
+`light`, and `dark`. You can change or add additional variants via Bootstrap
+[SCSS variables](/docs/reference/theming)
+
 A custom class can be applied to the tooltip outer wrapper `<div>` by using the `custom-class` prop:
 
 ```html

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -156,6 +156,35 @@ then clicks the trigger element, they must click it again **and** move focus to 
 | `container`          | `null`           | Element string ID to append rendered tooltip into. If `null` or element not found, tooltip is appended to `<body>` (default)                                                                               | Any valid in-document unique element ID.                                                                                                         |
 | `boundary`           | `'scrollParent'` | The container that the tooltip will be constrained visually. The default should suffice in most cases, but you may need to change this if your target element is in a small container with overflow scroll | `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.                                                         |
 | `boundary-padding`   | `5`              | Amount of pixel used to define a minimum distance between the boundaries and the tooltip. This makes sure the tooltip always has a little padding between the edges of its container.                      | Any positive number                                                                                                                              |
+| `variant`            | `null`           | Contextual color variant for the tooltip                                                                                                                                                                   | Any contextual theme color variant name                                                                                                      |
+| `customClass`        | `null`           | A custom classname to apply to the tooltip outer wrapper element                                                                                                                                     | A string                                                                                                                  |
+### Variants and custom class
+
+BootstrapVue's tooltips support contextual color variants via our custom CSS, via the `variant` prop:
+
+```html
+<div class="text-center">
+  <b-button id="tooltip-button-variant">Button</b-button>
+  <b-tooltip target="tooltip-button-variant" variant="danger">Danger variant tooltip</b-tooltip>
+</div>
+
+<!-- b-tooltip-variant.vue -->
+```
+
+A custom class can be applied to the tooltip outer wrapper `<div>` by using the `custom-class` prop:
+
+```html
+<div class="text-center">
+  <b-button id="my-button">Button</b-button>
+  <b-tooltip target="my-button" custom class="my-tooltip-class">Tooltip Title</b-tooltip>
+</div>
+```
+
+**Note:** Custom classes will not work with scoped styles, as the tooltips are appended to the document
+`<body>` element by default.
+
+Refer to the [tooltip directive](/docs/directives/tooltip) docs on applying variants and custom class
+to the directive version.
 
 ### Programmatically show and hide tooltip
 

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -15,8 +15,7 @@
 
 Things to know when using tooltip component:
 
-- Tooltips rely on the 3rd party library Popper.js for positioning. The library is bundled with
-  BootstrapVue in the dist files!
+- Tooltips rely on the 3rd party library [Popper.js](https://popper.js.org/) for positioning.
 - Tooltips with zero-length titles are never displayed.
 - Triggering tooltips on hidden elements will not work.
 - Specify `container` as `null` (default, appends to `<body>`) to avoid rendering problems in more
@@ -25,7 +24,6 @@ Things to know when using tooltip component:
 - Tooltips for `disabled` elements must be triggered on a wrapper element.
 - When triggered from hyperlinks that span multiple lines, tooltips will be centered. Use
   white-space: nowrap; on your `<a>`s, `<b-link>`s and `<router-link>`s to avoid this behavior.
-- Tooltips must be hidden before their corresponding elements have been removed from the DOM.
 
 The `<b-tooltip>` component inserts a hidden (`display:none`) `<div>` intermediate container element
 at the point in the DOM where the `<b-tooltip>` component is placed. This may affect layout and/or

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -1,6 +1,6 @@
 // Create custom variants for tooltips
 @each $color, $value in $theme-colors {
-  .tooltip.tooltip-#{$color} {
+  .tooltip.b-tooltip-#{$color} {
     $tip-text-color: color-yiq($value);
 
     &.bs-tooltip-top {

--- a/src/components/tooltip/index.scss
+++ b/src/components/tooltip/index.scss
@@ -1,0 +1,1 @@
+@import "tooltip";

--- a/src/components/tooltip/package.json
+++ b/src/components/tooltip/package.json
@@ -4,6 +4,7 @@
   "meta": {
     "title": "Tooltip",
     "description": "Easily add tooltips to elements or components via the <b-tooltip> component or v-b-tooltip directive.",
+    "enhanced": true,
     "directives": [
       "VBTooltip"
     ],

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -33,6 +33,14 @@ export const BTooltip = /*#__PURE__*/ Vue.extend({
         return isArray(value) || arrayIncludes(['flip', 'clockwise', 'counterclockwise'], value)
       }
     },
+    variant: {
+      type: String,
+      default: () => getComponentConfig(NAME, 'variant')
+    },
+    customClass: {
+      type: String,
+      default: () => getComponentConfig(NAME, 'customClass')
+    },
     delay: {
       type: [Number, Object, String],
       default: () => getComponentConfig(NAME, 'delay')

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -42,8 +42,8 @@ const appDef = {
             disabled: this.disabled,
             noFade: this.noFade || false,
             title: this.title || null,
-            variant: this.variant || null,
-            customClass: this.customClass || null
+            variant: this.variant,
+            customClass: this.customClass
           }
         },
         this.$slots.default || ''

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -54,7 +54,7 @@ const appDef = {
 
 // Note: `wrapper.destroy()` MUST be called at the end of each test in order for
 // the next test to function properly!
-describe('tooltip', () => {
+describe('b-tooltip', () => {
   const originalCreateRange = document.createRange
   const origGetBCR = Element.prototype.getBoundingClientRect
 

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -6,7 +6,7 @@ const localVue = new CreateLocalVue()
 
 // Our test application definition
 const appDef = {
-  props: ['triggers', 'show', 'disabled', 'noFade', 'title', 'titleAttr', 'btnDisabled'],
+  props: ['triggers', 'show', 'disabled', 'noFade', 'title', 'titleAttr', 'btnDisabled', 'variant', 'customClass'],
   render(h) {
     return h('article', { attrs: { id: 'wrapper' } }, [
       h(
@@ -31,7 +31,9 @@ const appDef = {
             show: this.show,
             disabled: this.disabled,
             noFade: this.noFade || false,
-            title: this.title || null
+            title: this.title || null,
+            variant: this.variant || null,
+            customClass: this.customClass || null
           }
         },
         this.$slots.default || ''
@@ -851,6 +853,92 @@ describe('tooltip', () => {
 
     // Tooltip element should not be in the document
     expect(document.querySelector(`#${adb}`)).toBe(null)
+
+    wrapper.destroy()
+  })
+
+  it('Applies variant class', async () => {
+    jest.useFakeTimers()
+    const App = localVue.extend(appDef)
+    const wrapper = mount(App, {
+      attachToDocument: true,
+      localVue: localVue,
+      propsData: {
+        show: true,
+        variant: 'danger'
+      },
+      slots: {
+        default: 'title'
+      }
+    })
+
+    expect(wrapper.isVueInstance()).toBe(true)
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    jest.runOnlyPendingTimers()
+
+    expect(wrapper.is('article')).toBe(true)
+    expect(wrapper.attributes('id')).toBeDefined()
+    expect(wrapper.attributes('id')).toEqual('wrapper')
+
+    // The trigger button
+    const $button = wrapper.find('button')
+    expect($button.exists()).toBe(true)
+    // ID of the tooltip that will be in the body
+    const adb = $button.attributes('aria-describedby')
+
+    // Find the tooltip element in the document
+    const tip = document.querySelector(`#${adb}`)
+    expect(tip).not.toBe(null)
+    expect(tip).toBeInstanceOf(HTMLElement)
+    expect(tip.tagName).toEqual('DIV')
+    expect(tip.classList.contains('tooltip')).toBe(true)
+    expect(tip.classList.contains('b-tooltip-danger')).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('Applies custom class', async () => {
+    jest.useFakeTimers()
+    const App = localVue.extend(appDef)
+    const wrapper = mount(App, {
+      attachToDocument: true,
+      localVue: localVue,
+      propsData: {
+        show: true,
+        customClass: 'foobar-class'
+      },
+      slots: {
+        default: 'title'
+      }
+    })
+
+    expect(wrapper.isVueInstance()).toBe(true)
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    jest.runOnlyPendingTimers()
+
+    expect(wrapper.is('article')).toBe(true)
+    expect(wrapper.attributes('id')).toBeDefined()
+    expect(wrapper.attributes('id')).toEqual('wrapper')
+
+    // The trigger button
+    const $button = wrapper.find('button')
+    expect($button.exists()).toBe(true)
+    // ID of the tooltip that will be in the body
+    const adb = $button.attributes('aria-describedby')
+
+    // Find the tooltip element in the document
+    const tip = document.querySelector(`#${adb}`)
+    expect(tip).not.toBe(null)
+    expect(tip).toBeInstanceOf(HTMLElement)
+    expect(tip.tagName).toEqual('DIV')
+    expect(tip.classList.contains('tooltip')).toBe(true)
+    expect(tip.classList.contains('foobar-class')).toBe(true)
 
     wrapper.destroy()
   })

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -6,7 +6,17 @@ const localVue = new CreateLocalVue()
 
 // Our test application definition
 const appDef = {
-  props: ['triggers', 'show', 'disabled', 'noFade', 'title', 'titleAttr', 'btnDisabled', 'variant', 'customClass'],
+  props: [
+    'triggers',
+    'show',
+    'disabled',
+    'noFade',
+    'title',
+    'titleAttr',
+    'btnDisabled',
+    'variant',
+    'customClass'
+  ],
   render(h) {
     return h('article', { attrs: { id: 'wrapper' } }, [
       h(

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -430,7 +430,7 @@ Where `[mod]` can be (all optional):
 - A boundary setting of `window` or `viewport`. The element to constrain the visual placement of the
   popover. If not specified, the boundary defaults to the trigger element's scroll parent (in most
   cases this will suffice).
-- A contextual variant in the form of `v-XXXX` (where `XXXX` is the color variant name).
+- A contextual variant in the form of `v-XXX` (where `XXX` is the color variant name).
 
 Where `[container]` can be (optional):
 

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -388,7 +388,7 @@ A custom class can be applied to the popover outer wrapper <div> by using the cu
 
 ```html
 <b-button
-  v-b-popover.hover="{ customClass: 'my-tooltip-class', content: 'Popover content' }"
+  v-b-popover.hover="{ customClass: 'my-popover-class', content: 'Popover content' }"
   title="Popover"
 >
   Button

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -350,6 +350,47 @@ Content can also be a function reference, which is called each time the popover 
 <!-- b-popover-content.vue -->
 ```
 
+## Variants and custom class
+
+BootstrapVue's popovers support contextual color variants via our custom CSS, either by using directive
+modifiers or config options:
+
+```html
+<template>
+  <b-container fluid>
+    <b-row class="text-center">
+      <b-col>
+        <b-button
+          v-b-popover.hover.v-danger="{ content: 'Popover content' }"
+          title="Danger variant"
+        >
+          Danger Modifier
+        </b-button>
+      </b-col>
+      <b-col>
+        <b-button
+          v-b-popover.hover="{ variant: 'info',  content: 'Popover content' }"
+          title="Info variant"
+        >
+          Info Config
+        </b-button>
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+
+<!-- b-popover-variants.vue -->
+```
+
+A custom class can be applied to the popover outer wrapper <div> by using the customClass option property:
+
+```html
+<b-button v-b-tooltip.hover="{ customClass: 'my-tooltip-class' }" title="Tooltip">Button</b-button>
+```
+
+**Note:** Custom classes will not work with scoped styles, as the popovers are appended to the document
+`<body>` element by default.
+
 ## Directive syntax and usage
 
 ```
@@ -380,11 +421,12 @@ Where `[mod]` can be (all optional):
 - A boundary setting of `window` or `viewport`. The element to constrain the visual placement of the
   popover. If not specified, the boundary defaults to the trigger element's scroll parent (in most
   cases this will suffice).
+- A contextual variant in the form of `v-XXXX` (where `XXXX` is the color variant name).
 
 Where `[container]` can be (optional):
 
-- An element ID (minus the #) to place the popover markup in when visible
-- If not provided, popovers are appended to the body when visible
+- An element ID (minus the #) to place the popover markup in, when visible
+- If not provided, popovers are appended to the `<body>` when visible
 
 ### Usage
 

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -381,6 +381,10 @@ modifiers or config options:
 <!-- b-popover-variants.vue -->
 ```
 
+Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`, `info`,
+`light`, and `dark`. You can change or add additional variants via Bootstrap
+[SCSS variables](/docs/reference/theming)
+
 A custom class can be applied to the popover outer wrapper <div> by using the customClass option property:
 
 ```html

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -352,6 +352,8 @@ Content can also be a function reference, which is called each time the popover 
 
 ## Variants and custom class
 
+<span class="badge badge-info small">NEW in 2.0.0-rc.26</span>
+
 BootstrapVue's popovers support contextual color variants via our custom CSS, either by using directive
 modifiers or config options:
 

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -387,7 +387,12 @@ modifiers or config options:
 A custom class can be applied to the popover outer wrapper <div> by using the customClass option property:
 
 ```html
-<b-button v-b-tooltip.hover="{ customClass: 'my-tooltip-class' }" title="Tooltip">Button</b-button>
+<b-button
+  v-b-popover.hover="{ customClass: 'my-tooltip-class', content: 'Popover content' }"
+  title="Popover"
+>
+  Button
+</b-button>
 ```
 
 **Note:** Custom classes will not work with scoped styles, as the popovers are appended to the document

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -20,7 +20,7 @@ to appear.
 
 Things to know when using popovers:
 
-- Popovers rely on the 3rd party library Popper.js for positioning. It is bundled with BootstrapVue!
+- Popovers rely on the 3rd party library [Popper.js](https://popper.js.org/) for positioning.
 - Zero-length title and content values will never show a popover.
 - Specify container: 'body' (default) to avoid rendering problems in more complex components (like
   input groups, button groups, etc).
@@ -28,9 +28,6 @@ Things to know when using popovers:
 - Popovers for `disabled` elements must be triggered on a wrapper element.
 - When triggered from hyperlinks that span multiple lines, popovers will be centered. Use
   white-space: nowrap; on your `<a>`s, `<b-link>`s or `<router-link>`s b to avoid this behavior.
-- Popovers must be hidden before their corresponding elements have been removed from the DOM.
-- When using a client side router, popovers will listen to changes in `$route` and automatically
-  hide.
 - Elements that trigger popovers should be in the document tab sequence. Add `tabindex="0"` if
   required.
 

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -351,8 +351,8 @@ Content can also be a function reference, which is called each time the popover 
 
 <span class="badge badge-info small">NEW in 2.0.0-rc.26</span>
 
-BootstrapVue's popovers support contextual color variants via our custom CSS, either by using directive
-modifiers or config options:
+BootstrapVue's popovers support contextual color variants via our custom CSS, either by using
+directive modifiers or config options:
 
 ```html
 <template>
@@ -381,11 +381,12 @@ modifiers or config options:
 <!-- b-popover-variants.vue -->
 ```
 
-Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`, `info`,
-`light`, and `dark`. You can change or add additional variants via Bootstrap
+Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`,
+`info`, `light`, and `dark`. You can change or add additional variants via Bootstrap
 [SCSS variables](/docs/reference/theming)
 
-A custom class can be applied to the popover outer wrapper <div> by using the customClass option property:
+A custom class can be applied to the popover outer wrapper <div> by using the customClass option
+property:
 
 ```html
 <b-button
@@ -396,8 +397,8 @@ A custom class can be applied to the popover outer wrapper <div> by using the cu
 </b-button>
 ```
 
-**Note:** Custom classes will not work with scoped styles, as the popovers are appended to the document
-`<body>` element by default.
+**Note:** Custom classes will not work with scoped styles, as the popovers are appended to the
+document `<body>` element by default.
 
 ## Directive syntax and usage
 

--- a/src/directives/popover/package.json
+++ b/src/directives/popover/package.json
@@ -4,6 +4,7 @@
   "meta": {
     "title": "Popover",
     "description": "Add BootstrapVue popovers to any element on your site, using Bootstrap v4 CSS for styling and animations. Popovers are tooltips on steroids.",
+    "enhanced": true,
     "directive": "VBPopover"
   }
 }

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -24,7 +24,7 @@ const placementRE = /^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom
 const boundaryRE = /^(window|viewport|scrollParent)$/
 const delayRE = /^d\d+$/
 const offsetRE = /^o-?\d+$/
-const variantRE = /^v-\s+$/
+const variantRE = /^v-.+$/
 
 // Build a PopOver config based on bindings (if any)
 // Arguments and modifiers take precedence over passed value config object

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -62,7 +62,7 @@ const parseBindings = bindings => /* istanbul ignore next: not easy to test */ {
     if (htmlRE.test(mod)) {
       // Title allows HTML
       config.html = true
-    } else if (notFadeRE.test(mod)) {
+    } else if (noFadeRE.test(mod)) {
       // no animation
       config.animation = false
     } else if (placementRE.test(mod)) {

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -17,6 +17,15 @@ const validTriggers = {
   blur: true
 }
 
+// Directive modifier test regular expressions. Pre-compile for performance
+const htmlRE = /^html$/
+const noFadeRE = /^nofade$/i
+const placementRE = /^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom)?|right(top|bottom)?)$/
+const boundaryRE = /^(window|viewport|scrollParent)$/
+const delayRE = /^d\d+$/
+const offsetRE = /^o-?\d+$/
+const variantRE = /^v-\s+$/
+
 // Build a PopOver config based on bindings (if any)
 // Arguments and modifiers take precedence over passed value config object
 /* istanbul ignore next: not easy to test */
@@ -50,35 +59,33 @@ const parseBindings = bindings => /* istanbul ignore next: not easy to test */ {
 
   // Process modifiers
   keys(bindings.modifiers).forEach(mod => {
-    if (/^html$/.test(mod)) {
+    if (htmlRE.test(mod)) {
       // Title allows HTML
       config.html = true
-    } else if (/^nofade$/.test(mod)) {
+    } else if (notFadeRE.test(mod)) {
       // no animation
       config.animation = false
-    } else if (
-      /^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom)?|right(top|bottom)?)$/.test(mod)
-    ) {
+    } else if (placementRE.test(mod)) {
       // placement of popover
       config.placement = mod
-    } else if (/^(window|viewport|scrollParent)$/.test(mod)) {
+    } else if (boundaryRE.test(mod)) {
       // Boundary of popover
       config.boundary = mod
-    } else if (/^d\d+$/.test(mod)) {
+    } else if (delayRE.test(mod)) {
       // Delay value
       const delay = parseInt(mod.slice(1), 10) || 0
       if (delay) {
         config.delay = delay
       }
-    } else if (/^o-?\d+$/.test(mod)) {
+    } else if (offsetRE.test(mod)) {
       // Offset value (negative allowed)
       const offset = parseInt(mod.slice(1), 10) || 0
       if (offset) {
         config.offset = offset
       }
-    } else if (/^v-\s+$/.test(mod)) {
+    } else if (variantRE.test(mod)) {
       // Variant
-      config.variant = mod.slice(1) || null
+      config.variant = mod.slice(2) || null
     }
   })
 

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -76,6 +76,9 @@ const parseBindings = bindings => /* istanbul ignore next: not easy to test */ {
       if (offset) {
         config.offset = offset
       }
+    } else if (/^v-\s+$/.test(mod)) {
+      // Variant
+      config.variant = mod.slice(1) || null
     }
   })
 

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -35,7 +35,9 @@ const parseBindings = bindings => /* istanbul ignore next: not easy to test */ {
   let config = {
     delay: getComponentConfig(NAME, 'delay'),
     boundary: String(getComponentConfig(NAME, 'boundary')),
-    boundaryPadding: parseInt(getComponentConfig(NAME, 'boundaryPadding'), 10) || 0
+    boundaryPadding: parseInt(getComponentConfig(NAME, 'boundaryPadding'), 10) || 0,
+    variant: getComponentConfig(NAME, 'variant'),
+    customClass: getComponentConfig(NAME, 'customClass')
   }
 
   // Process bindings.value

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -219,6 +219,37 @@ Title can also be a function reference, which is called each time the tooltip is
 <!-- b-tooltip-content.vue -->
 ```
 
+## Variants and custom class
+
+BootstrapVue's tooltips support contetual color variants via our custom CSS, either by using 
+directive modifiers or config options:
+
+```html
+<template>
+  <b-container fluid>
+    <b-row class="text-center">
+      <b-col>
+        <b-button v-b-tooltip.hover.v-danger title="Danger variant">Danger Modifier</b-button>
+      </b-col>
+      <b-col>
+        <b-button v-b-tooltip.hover="{ variant: 'info' }" title="Info variant">Info Config</b-button>
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+<!-- b-tooltip-variants.vue -->
+```
+
+A custom class can be applied to the tooltip outer wrapper `<div>` by using the `customClass` option
+property:
+
+```html
+<b-button v-b-tooltip.hover="{ customClass: 'my-tooltip-class' } title="Tooltip">Button</b-button>
+```
+
+**Note:** Custom classes will not work with scoped styles, as the tooltips are appended to the
+document `<body>` element by default.
+
 ## Directive syntax and usage
 
 ```
@@ -240,12 +271,13 @@ Where [modX] can be (all optional):
   `hover`. `blur` is a close handler only, and if specified by itself, will be converted to `focus`)
 - `nofade` to turn off animation
 - `html` to enable rendering raw HTML. By default HTML is escaped and converted to text
-- A delay value in the format of `d###` (where `###` is in ms, defaults to 0);
+- A delay value in the format of `d###` (where `###` is in ms, defaults to 0)
 - An offset value in pixels in the format of `o###` (where `###` is the number of pixels, defaults
   to 0. Negative values allowed)
 - A boundary setting of `window` or `viewport`. The element to constrain the visual placement of the
   tooltip. If not specified, the boundary defaults to the trigger element's scroll parent (in most
-  cases this will suffice).
+  cases this will suffice)
+- A contextual variant in the form of `v-XXXX` (where `XXXX` is the color variant name)
 
 Where `<value>` can be (optional):
 
@@ -270,6 +302,8 @@ Where `<value>` can be (optional):
 | `fallbackPlacement` | String or Array                 | `'flip'`         | Allow to specify which position Popper will use on fallback. Can be `flip`, `clockwise`, `counterclockwise` or an array of placements. For more information refer to Popper.js's behavior docs.                                                                                                                                                                                                                                                                            |
 | `boundary`          | String or HTMLElement reference | `'scrollParent'` | The container that the tooltip will be constrained visually. The default should suffice in most cases, but you may need to change this if your target element is in a small container with overflow scroll. Supported values: `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.                                                                                                                                                     |
 | `boundaryPadding`   | Number                          | `5`              | Amount of pixel used to define a minimum distance between the boundaries and the tooltip. This makes sure the tooltip always has a little padding between the edges of its container.                                                                                                                                                                                                                                                                                      |
+| `variant`           | String                          | `null`           | Contextual color vaiant name                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `customClass`       | String                          | `null`           | Custom class to applye to the outer wrapper `div`.                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
 ### Usage
 
@@ -292,6 +326,13 @@ v-b-tooltip.bottom
 v-b-tooltip.right
 ```
 
+**Variant examples:**
+
+```
+v-b-tooltip.v-primary => `primary` variant
+v-b-tooltip.v-danger => `danger` variant
+```
+
 **Trigger examples:**
 
 ```
@@ -305,12 +346,13 @@ v-b-tooltip.hover.focus => Both hover and focus
 ```
 v-b-tooltip.hover.bottom => Show on hover and place at bottom
 v-b-tooltip.bottom.hover => Same as above
+v-b-tooltip.bottom.hover.v-danger => Same as above, but with variant
 ```
 
 **Object:**
 
 ```
-v-b-tooltip="{title: 'Title', placement: 'bottom'}"
+v-b-tooltip="{ title: 'Title', placement: 'bottom', variant: 'danger' }"
 ```
 
 ## Hiding and showing tooltips via \$root events

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -222,7 +222,7 @@ Title can also be a function reference, which is called each time the tooltip is
 
 <span class="badge badge-info small">NEW in 2.0.0-rc.26</span>
 
-BootstrapVue's tooltips support contextual color variants via our custom CSS, either by using 
+BootstrapVue's tooltips support contextual color variants via our custom CSS, either by using
 directive modifiers or config options:
 
 ```html
@@ -241,8 +241,8 @@ directive modifiers or config options:
 <!-- b-tooltip-variants.vue -->
 ```
 
-Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`, `info`,
-`light`, and `dark`. You can change or add additional variants via Bootstrap
+Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`,
+`info`, `light`, and `dark`. You can change or add additional variants via Bootstrap
 [SCSS variables](/docs/reference/theming)
 
 A custom class can be applied to the tooltip outer wrapper `<div>` by using the `customClass` option
@@ -307,8 +307,8 @@ Where `<value>` can be (optional):
 | `fallbackPlacement` | String or Array                 | `'flip'`         | Allow to specify which position Popper will use on fallback. Can be `flip`, `clockwise`, `counterclockwise` or an array of placements. For more information refer to Popper.js's behavior docs.                                                                                                                                                                                                                                                                            |
 | `boundary`          | String or HTMLElement reference | `'scrollParent'` | The container that the tooltip will be constrained visually. The default should suffice in most cases, but you may need to change this if your target element is in a small container with overflow scroll. Supported values: `'scrollParent'` (default), `'viewport'`, `'window'`, or a reference to an HTML element.                                                                                                                                                     |
 | `boundaryPadding`   | Number                          | `5`              | Amount of pixel used to define a minimum distance between the boundaries and the tooltip. This makes sure the tooltip always has a little padding between the edges of its container.                                                                                                                                                                                                                                                                                      |
-| `variant`           | String                          | `null`           | Contextual color vaiant name                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `customClass`       | String                          | `null`           | Custom class to applye to the outer wrapper `div`.                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `variant`           | String                          | `null`           | Contextual color variant for the tooltip.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `customClass`       | String                          | `null`           | A custom classname to apply to the tooltip outer wrapper element.                                                                                                                                                                                                                                                                                                                                                                                                          |
 
 ### Usage
 

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -18,8 +18,7 @@ appear.
 
 Things to know when using tooltips:
 
-- Tooltips rely on the 3rd party library Popper.js for positioning. The library is bundled with
-  BootstrapVue!
+- Tooltips rely on the 3rd party library [Popper.js](https://popper.js.org/) for positioning.
 - Tooltips with zero-length titles are never displayed.
 - Specify container: 'body' (default) to avoid rendering problems in more complex components (like
   input groups, button groups, etc).

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -282,7 +282,7 @@ Where [modX] can be (all optional):
 - A boundary setting of `window` or `viewport`. The element to constrain the visual placement of the
   tooltip. If not specified, the boundary defaults to the trigger element's scroll parent (in most
   cases this will suffice)
-- A contextual variant in the form of `v-XXXX` (where `XXXX` is the color variant name)
+- A contextual variant in the form of `v-XXX` (where `XXX` is the color variant name)
 
 Where `<value>` can be (optional):
 

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -241,6 +241,10 @@ directive modifiers or config options:
 <!-- b-tooltip-variants.vue -->
 ```
 
+Bootstrap default theme variants are: `danger`, `warning`, `success`, `primary`, `secondary`, `info`,
+`light`, and `dark`. You can change or add additional variants via Bootstrap
+[SCSS variables](/docs/reference/theming)
+
 A custom class can be applied to the tooltip outer wrapper `<div>` by using the `customClass` option
 property:
 

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -221,6 +221,8 @@ Title can also be a function reference, which is called each time the tooltip is
 
 ## Variants and custom class
 
+<span class="badge badge-info small">NEW in 2.0.0-rc.26</span>
+
 BootstrapVue's tooltips support contextual color variants via our custom CSS, either by using 
 directive modifiers or config options:
 

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -221,7 +221,7 @@ Title can also be a function reference, which is called each time the tooltip is
 
 ## Variants and custom class
 
-BootstrapVue's tooltips support contetual color variants via our custom CSS, either by using 
+BootstrapVue's tooltips support contextual color variants via our custom CSS, either by using 
 directive modifiers or config options:
 
 ```html
@@ -244,7 +244,7 @@ A custom class can be applied to the tooltip outer wrapper `<div>` by using the 
 property:
 
 ```html
-<b-button v-b-tooltip.hover="{ customClass: 'my-tooltip-class' } title="Tooltip">Button</b-button>
+<b-button v-b-tooltip.hover="{ customClass: 'my-tooltip-class' }" title="Tooltip">Button</b-button>
 ```
 
 **Note:** Custom classes will not work with scoped styles, as the tooltips are appended to the

--- a/src/directives/tooltip/package.json
+++ b/src/directives/tooltip/package.json
@@ -4,6 +4,7 @@
   "meta": {
     "title": "Tooltip",
     "description": "Add custom BootstrapVue tooltips to any element. Tooltips can be triggered by hovering, focusing, or clicking an element.",
+    "enhanced": true,
     "directive": "VBTooltip"
   }
 }

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -24,7 +24,7 @@ const placementRE = /^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom
 const boundaryRE = /^(window|viewport|scrollParent)$/
 const delayRE = /^d\d+$/
 const offsetRE = /^o-?\d+$/
-const variantRE = /^v-\s+$/
+const variantRE = /^v-.+$/
 
 // Build a ToolTip config based on bindings (if any)
 // Arguments and modifiers take precedence over passed value config object

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -17,6 +17,15 @@ const validTriggers = {
   blur: true
 }
 
+// Directive modifier test regular expressions. Pre-compile for performance
+const htmlRE = /^html$/
+const noFadeRE = /^nofade$/
+const placementRE = /^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom)?|right(top|bottom)?)$/
+const boundaryRE = /^(window|viewport|scrollParent)$/
+const delayRE = /^d\d+$/
+const offsetRE = /^o-?\d+$/
+const variantRE = /^v-\s+$/
+
 // Build a ToolTip config based on bindings (if any)
 // Arguments and modifiers take precedence over passed value config object
 /* istanbul ignore next: not easy to test */
@@ -50,35 +59,33 @@ const parseBindings = bindings => /* istanbul ignore next: not easy to test */ {
 
   // Process modifiers
   keys(bindings.modifiers).forEach(mod => {
-    if (/^html$/.test(mod)) {
+    if (htmlRE.test(mod)) {
       // Title allows HTML
       config.html = true
-    } else if (/^nofade$/.test(mod)) {
+    } else if (noFadeRE.test(mod)) {
       // No animation
       config.animation = false
-    } else if (
-      /^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom)?|right(top|bottom)?)$/.test(mod)
-    ) {
+    } else if (placementRE.test(mod)) {
       // Placement of tooltip
       config.placement = mod
-    } else if (/^(window|viewport|scrollParent)$/.test(mod)) {
+    } else if (boundaryRE.test(mod)) {
       // Boundary of tooltip
       config.boundary = mod
-    } else if (/^d\d+$/.test(mod)) {
+    } else if (delayRE.test(mod)) {
       // Delay value
       const delay = parseInt(mod.slice(1), 10) || 0
       if (delay) {
         config.delay = delay
       }
-    } else if (/^o-?\d+$/.test(mod)) {
+    } else if (offsetRE.test(mod)) {
       // Offset value, negative allowed
       const offset = parseInt(mod.slice(1), 10) || 0
       if (offset) {
         config.offset = offset
       }
-    } else if (/^v-\s+$/.test(mod)) {
+    } else if (variantRE.test(mod)) {
       // Variant
-      config.variant = mod.slice(1) || null
+      config.variant = mod.slice(2) || null
     }
   })
 

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -19,7 +19,7 @@ const validTriggers = {
 
 // Directive modifier test regular expressions. Pre-compile for performance
 const htmlRE = /^html$/
-const noFadeRE = /^nofade$/
+const noFadeRE = /^nofade$/i
 const placementRE = /^(auto|top(left|right)?|bottom(left|right)?|left(top|bottom)?|right(top|bottom)?)$/
 const boundaryRE = /^(window|viewport|scrollParent)$/
 const delayRE = /^d\d+$/

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -76,6 +76,9 @@ const parseBindings = bindings => /* istanbul ignore next: not easy to test */ {
       if (offset) {
         config.offset = offset
       }
+    } else if (/^v-\s+$/.test(mod)) {
+      // Variant
+      config.variant = mod.slice(1) || null
     }
   })
 

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -35,7 +35,9 @@ const parseBindings = bindings => /* istanbul ignore next: not easy to test */ {
   let config = {
     delay: getComponentConfig(NAME, 'delay'),
     boundary: String(getComponentConfig(NAME, 'boundary')),
-    boundaryPadding: parseInt(getComponentConfig(NAME, 'boundaryPadding'), 10) || 0
+    boundaryPadding: parseInt(getComponentConfig(NAME, 'boundaryPadding'), 10) || 0,
+    variant: getComponentConfig(NAME, 'variant'),
+    customClass: getComponentConfig(NAME, 'customClass')
   }
 
   // Process bindings.value

--- a/src/directives/tooltip/tooltip.spec.js
+++ b/src/directives/tooltip/tooltip.spec.js
@@ -123,4 +123,52 @@ describe('v-b-tooltip directive', () => {
 
     wrapper.destroy()
   })
+
+  it('variant and customClass should work', async () => {
+    jest.useFakeTimers()
+    const localVue = new CreateLocalVue()
+
+    const App = localVue.extend({
+      directives: {
+        bTooltip: tooltipDirective
+      },
+      data() {
+        return {}
+      },
+      template: `<button v-b-tooltip.click.html.v-info="{ customClass: 'foobar'}" title="<b>foobar</b>">button</button>`
+    })
+
+    const wrapper = mount(App, {
+      localVue: localVue,
+      attachToDocument: true
+    })
+
+    expect(wrapper.isVueInstance()).toBe(true)
+    expect(wrapper.is('button')).toBe(true)
+    const $button = wrapper.find('button')
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    jest.runOnlyPendingTimers()
+
+    // Trigger click
+    $button.trigger('click')
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    jest.runOnlyPendingTimers()
+
+    expect($button.attributes('aria-describedby')).toBeDefined()
+    const adb = $button.attributes('aria-describedby')
+
+    const tip = document.querySelector(`#${adb}`)
+    expect(tip).not.toBe(null)
+    expect(tip.classList.contains('tooltip')).toBe(true)
+    expect(tip.classList.contains('b-tooltip-info')).toBe(true)
+    expect(tip.classList.contains('foobar')).toBe(true)
+
+    wrapper.destroy()
+  })
 })

--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -66,6 +66,10 @@ export default {
     variant: {
       type: String,
       default: null
+    },
+    customClass: {
+      type: String,
+      default: null
     }
   },
   data() {
@@ -101,6 +105,8 @@ export default {
         animation: !this.noFade,
         // Variant
         variant: this.variant,
+        // Custom class
+        customClass: this.customClass,
         // Open/Close Trigger(s)
         trigger: isArray(this.triggers) ? this.triggers.join(' ') : this.triggers,
         // Callbacks so we can trigger events on component

--- a/src/mixins/toolpop.js
+++ b/src/mixins/toolpop.js
@@ -62,14 +62,6 @@ export default {
     disabled: {
       type: Boolean,
       default: false
-    },
-    variant: {
-      type: String,
-      default: null
-    },
-    customClass: {
-      type: String,
-      default: null
     }
   },
   data() {

--- a/src/utils/config-defaults.js
+++ b/src/utils/config-defaults.js
@@ -110,6 +110,13 @@ export default deepFreeze({
   BNavbarToggle: {
     label: 'Toggle navigation'
   },
+  BPopover: {
+    boundary: 'scrollParent',
+    boundaryPadding: 5,
+    customClass: null,
+    delay: 0,
+    variant: null
+  },
   BProgress: {
     variant: null
   },
@@ -139,13 +146,10 @@ export default deepFreeze({
     role: null
   },
   BTooltip: {
-    delay: 0,
     boundary: 'scrollParent',
-    boundaryPadding: 5
-  },
-  BPopover: {
+    boundaryPadding: 5,
+    customClass: null,
     delay: 0,
-    boundary: 'scrollParent',
-    boundaryPadding: 5
+    variant: null
   }
 })

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -609,11 +609,9 @@ class ToolTip {
     // set as relatedTarget in focusin/out events
     this.$tip.tabIndex = -1
     // Add variant if specified
-    /* istanbul ignore next: until variant test is written */
     if (this.$config.variant) {
       addClass(this.$tip, `b-${this.constructor.NAME}-${this.$config.variant}`)
     }
-    /* istanbul ignore next: until custom-class test is written */
     if (this.$config.customClass) {
       addClass(this.$tip, String(this.$config.customClass))
     }

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -609,7 +609,7 @@ class ToolTip {
     this.$tip.tabIndex = -1
     // Add variant if specified
     if (this.$config.variant) {
-      addClass(this.$tip, `${this.constructor.NAME}-${this.$config.variant}`)
+      addClass(this.$tip, `b-${this.constructor.NAME}-${this.$config.variant}`)
     }
     return this.$tip
   }

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -608,6 +608,7 @@ class ToolTip {
     // set as relatedTarget in focusin/out events
     this.$tip.tabIndex = -1
     // Add variant if specified
+    /* istanbul ignore next: until viant test is written */
     if (this.$config.variant) {
       addClass(this.$tip, `b-${this.constructor.NAME}-${this.$config.variant}`)
     }

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -608,7 +608,7 @@ class ToolTip {
     // set as relatedTarget in focusin/out events
     this.$tip.tabIndex = -1
     // Add variant if specified
-    /* istanbul ignore next: until viant test is written */
+    /* istanbul ignore next: until variant test is written */
     if (this.$config.variant) {
       addClass(this.$tip, `b-${this.constructor.NAME}-${this.$config.variant}`)
     }

--- a/src/utils/tooltip.class.js
+++ b/src/utils/tooltip.class.js
@@ -97,7 +97,8 @@ const Defaults = {
   callbacks: {},
   boundary: 'scrollParent',
   boundaryPadding: 5,
-  variant: null
+  variant: null,
+  customClass: null
 }
 
 // Transition event names
@@ -611,6 +612,10 @@ class ToolTip {
     /* istanbul ignore next: until variant test is written */
     if (this.$config.variant) {
       addClass(this.$tip, `b-${this.constructor.NAME}-${this.$config.variant}`)
+    }
+    /* istanbul ignore next: until custom-class test is written */
+    if (this.$config.customClass) {
+      addClass(this.$tip, String(this.$config.customClass))
     }
     return this.$tip
   }


### PR DESCRIPTION
### Describe the PR

- Add support for tooltip and popover variants
- Add support for custom class for tooltips and popovers
- Improve directive version performance by pre-compiling modifier test regular expressions

New props on components:
- `variant` - supports Bootstrap theme colors (i.e. 'danger', 'primary', 'info', etc)
- `custom-class` - a string classname added to the outer wrapper of the tooltip or popover.

Directive versions have new modifier `v-<variant>`, and support passing optional config options `variant` and `className` (passing config object as the expression) 

Default values (current value is `null`) can be specified via the BootstrapVue global config.

SCSS Notes:

- Tooltip variants use the base Bootstrap theme colors for background, and yiq-color for text.
- Popovers also use the bootstrap theme colors and borrows from alert styling for the background, border and text color.
- If users define new theme colors and compile Bootstrap + BootstrapVue SCSS, the new themes will kick in.
- Users can optionally disable generation of tooltip and/or popover variants by setting variables in SCSS

Closes: #1983, #2075

To Do:

- [x] new unit tests
- [x] tooltip SCSS
- [x] popover SCSS
- [x] update b-tooltip/b-popover for variant / custom-class
- [x] update v-b-tooltip/v-b-popover for variant / custom-class
- [x] documentation update

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
