### PR TITLE
feat(b-dropdown): new `split-button-type` prop to specify split button type (closes #3694)

### DIFF
--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -201,8 +201,8 @@ router link `to` value via the `split-to` prop, while maintaining the look of a 
 
 <span class="badge badge-info small">NEW in 2.0.0-rc.27</span>
 
-The split button defaults to a button `type` of `'button'`. You can specify an alternate type via the
-`split-button-type` prop. Supported values are: `'button'`, `'submit'` and `'reset'`.
+The split button defaults to a button `type` of `'button'`. You can specify an alternate type via
+the `split-button-type` prop. Supported values are: `'button'`, `'submit'` and `'reset'`.
 
 If props `split-to` or `split-href` are set, the `split-button-type` prop will be ignored.
 

--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -197,6 +197,15 @@ router link `to` value via the `split-to` prop, while maintaining the look of a 
 <!-- b-dropdown-split-link.vue -->
 ```
 
+### Split button type
+
+<span class="badge badge-info small">NEW in 2.0.0-rc.27</span>
+
+The split button defaults to a button `type` of `'button'`. You can specify an alternate type via the
+`split-button-type` prop. Supported values are: `'button'`, `'submit'` and `'reset'`.
+
+If props `split-to` or `split-href` are set, the `split-button-type` prop will be ignored.
+
 ## Styling options
 
 Dropdowns support various props for styling the dropdown trigger button.

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1,4 +1,5 @@
 import Vue from '../../utils/vue'
+import { arrayIncludes } from '../../utils/array'
 import { stripTags } from '../../utils/html'
 import { getComponentConfig } from '../../utils/config'
 import { HTMLElement } from '../../utils/safe-types'
@@ -55,6 +56,11 @@ export const props = {
     type: String,
     default: () => getComponentConfig(NAME, 'splitVariant')
   },
+  splitButtonType: {
+    type: String,
+    default: 'button',
+    validator: value => arrayIncludes(['button', 'submit', 'reset'], value)
+  }.
   role: {
     type: String,
     default: 'menu'
@@ -120,9 +126,10 @@ export const BDropdown = /*#__PURE__*/ Vue.extend({
       // We add these as needed due to router-link issues with defined property with undefined/null values
       if (this.splitTo) {
         btnProps.to = this.splitTo
-      }
-      if (this.splitHref) {
+      } else if (this.splitHref) {
         btnProps.href = this.splitHref
+      } else if (this.splitButtonType) {
+        btnProps.type = this.splitButtonType
       }
       split = h(
         BButton,

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -60,7 +60,7 @@ export const props = {
     type: String,
     default: 'button',
     validator: value => arrayIncludes(['button', 'submit', 'reset'], value)
-  }.
+  },
   role: {
     type: String,
     default: 'menu'

--- a/src/components/dropdown/dropdown.spec.js
+++ b/src/components/dropdown/dropdown.spec.js
@@ -115,6 +115,8 @@ describe('dropdown', () => {
     expect($split.classes()).toContain('btn-secondary')
     expect($split.attributes('id')).toBeDefined()
     expect($split.attributes('id')).toEqual(`${wrapperId}__BV_button_`)
+    expect($split.attributes('type')).toBeDefined()
+    expect($split.attributes('type')).toEqual('button')
     expect($split.text()).toEqual('')
 
     expect($toggle.classes()).toContain('btn')
@@ -128,6 +130,8 @@ describe('dropdown', () => {
     expect($toggle.attributes('aria-expanded')).toEqual('false')
     expect($toggle.attributes('id')).toBeDefined()
     expect($toggle.attributes('id')).toEqual(`${wrapperId}__BV_toggle_`)
+    expect($toggle.attributes('type')).toBeDefined()
+    expect($toggle.attributes('type')).toEqual('button')
     expect($toggle.findAll('span.sr-only').length).toBe(1)
     expect($toggle.find('span.sr-only').text()).toEqual('Toggle Dropdown')
     expect($toggle.text()).toEqual('Toggle Dropdown')
@@ -143,6 +147,37 @@ describe('dropdown', () => {
     expect($menu.attributes('aria-labelledby')).toBeDefined()
     expect($menu.attributes('aria-labelledby')).toEqual(`${wrapperId}__BV_button_`)
     expect($menu.text()).toEqual('')
+
+    wrapper.destroy()
+  })
+
+
+  it('split mode accepts split-button-type value', async () => {
+    const wrapper = mount(BDropdown, {
+      attachToDocument: true,
+      propsData: {
+        split: true,
+        splitButtonType: 'submit'
+      }
+    })
+
+    expect(wrapper.is('div')).toBe(true)
+    expect(wrapper.isVueInstance()).toBe(true)
+
+    await waitNT(wrapper.vm)
+
+    expect(wrapper.classes()).toContain('dropdown')
+
+    expect(wrapper.findAll('button').length).toBe(2)
+    const $buttons = wrapper.findAll('button')
+    const $split = $buttons.at(0)
+    const $toggle = $buttons.at(1)
+
+    expect($split.attributes('type')).toBeDefined()
+    expect($split.attributes('type')).toEqual('submit')
+
+    expect($toggle.attributes('type')).toBeDefined()
+    expect($toggle.attributes('type')).toEqual('button')
 
     wrapper.destroy()
   })

--- a/src/components/dropdown/dropdown.spec.js
+++ b/src/components/dropdown/dropdown.spec.js
@@ -151,7 +151,6 @@ describe('dropdown', () => {
     wrapper.destroy()
   })
 
-
   it('split mode accepts split-button-type value', async () => {
     const wrapper = mount(BDropdown, {
       attachToDocument: true,


### PR DESCRIPTION
### Describe the PR

Add a new prop `split-button-type` for specifying the split button's type (`button`, `submit`, `reset`, defaults to `button`).

The prop has no effect if `split-to` or `split-href` is set.

Closes #3694

To Do:

- [x] Docs update
- [x] new unit test(s)

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
