### PR TITLE
feat(b-table, b-table-lite): new field scoped slot naming convention + new fallback scoped slots, deprecated old field slot convention (closes #3731)

### DIFF
--- a/docs/components/componentdoc.vue
+++ b/docs/components/componentdoc.vue
@@ -50,11 +50,14 @@
         bordered
         striped
       >
-        <template slot="prop" slot-scope="{ value, item }">
+        <template slot="[prop]" slot-scope="{ value, item }">
           <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
           <b-badge v-if="item.required" variant="info">Required</b-badge>
           <b-badge v-else-if="item.deprecated" variant="danger">Deprecated</b-badge>
           <b-badge v-else-if="item.deprecation" variant="warning">Deprecation</b-badge>
+        </template>
+        <template slot="[defaultValue]" slot-scope="{ value }">
+          <code v-if="value" class="notranslate" translate="no">{{ value }}</code>
         </template>
         <template slot="row-details" slot-scope="{ item }">
           <p v-if="typeof item.deprecated === 'string'" class="mb-1 small">
@@ -63,9 +66,6 @@
           <p v-if="typeof item.deprecation === 'string'" class="mb-1 small">
             {{ item.deprecation }}
           </p>
-        </template>
-        <template slot="defaultValue" slot-scope="{ value }">
-          <code v-if="value" class="notranslate" translate="no">{{ value }}</code>
         </template>
       </b-table>
 
@@ -82,10 +82,10 @@
           bordered
           striped
         >
-          <template slot="prop" slot-scope="{ value }">
+          <template slot="[prop]" slot-scope="{ value }">
             <code class="notranslate" translate="no">{{ kebabCase(value) }}</code>
           </template>
-          <template slot="event" slot-scope="{ value }">
+          <template slot="[event]" slot-scope="{ value }">
             <code class="notranslate" translate="no">{{ value }}</code>
           </template>
         </b-table>
@@ -105,7 +105,7 @@
         bordered
         striped
       >
-        <template slot="name" slot-scope="{ value }">
+        <template slot="[name]" slot-scope="{ value }">
           <code class="text-nowrap nostranslate" translate="no">{{ value }}</code>
         </template>
       </b-table>
@@ -124,10 +124,10 @@
         bordered
         striped
       >
-        <template slot="event" slot-scope="{ value }">
+        <template slot="[event]" slot-scope="{ value }">
           <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
         </template>
-        <template slot="args" slot-scope="{ value, item }">
+        <template slot="[args]" slot-scope="{ value, item }">
           <p
             v-for="arg in value"
             class="mb-1"
@@ -159,10 +159,10 @@
         bordered
         striped
       >
-        <template slot="event" slot-scope="{ value }">
+        <template slot="[event]" slot-scope="{ value }">
           <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
         </template>
-        <template slot="args" slot-scope="{ value, item }">
+        <template slot="[args]" slot-scope="{ value, item }">
           <p
             v-for="arg in value"
             class="mb-1"

--- a/docs/components/importdoc.vue
+++ b/docs/components/importdoc.vue
@@ -22,13 +22,13 @@
           bordered
           striped
         >
-          <template slot="component" slot-scope="{ value }">
+          <template slot="[component]" slot-scope="{ value }">
             <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
           </template>
-          <template slot="namedExport" slot-scope="{ value }">
+          <template slot="[namedExport]" slot-scope="{ value }">
             <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
           </template>
-          <template slot="importPath" slot-scope="{ value }">
+          <template slot="[importPath]" slot-scope="{ value }">
             <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
           </template>
         </b-table>
@@ -57,13 +57,13 @@
           bordered
           striped
         >
-          <template slot="directive" slot-scope="{ value }">
+          <template slot="[directive]" slot-scope="{ value }">
             <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
           </template>
-          <template slot="namedExport" slot-scope="{ value }">
+          <template slot="[namedExport]" slot-scope="{ value }">
             <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
           </template>
-          <template slot="importPath" slot-scope="{ value }">
+          <template slot="[importPath]" slot-scope="{ value }">
             <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
           </template>
         </b-table>
@@ -103,12 +103,12 @@
         bordered
         striped
       >
-        <template slot="namedExport" slot-scope="{ value, item }">
+        <template slot="[namedExport]" slot-scope="{ value, item }">
           <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
           <b-badge v-if="item.legacy" variant="warning" class="small">DEPRECATED</b-badge>
           <b-badge v-else variant="success" class="small">PREFERRED</b-badge>
         </template>
-        <template slot="importPath" slot-scope="{ value }">
+        <template slot="[importPath]" slot-scope="{ value }">
           <code class="text-nowrap notranslate" translate="no">{{ value }}</code>
         </template>
       </b-table>

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -1043,7 +1043,7 @@ Users are encouraged to switch to the new bracketed syntax.
         <span class="text-info">{{ data.label }}</b>
       </template>
 
-      <!-- A custom formatted footer cell  for field 'name' -->
+      <!-- A custom formatted footer cell for field 'name' -->
       <template slot="FOOT[name]" slot-scope="data">
         <span class="text-danger">{{ data.label }}</span>
       </template>

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -826,7 +826,7 @@ slot `[]` to format any cells that do not have an explicit scoped slot.
 
       <!-- A custom formatted column -->
       <template slot="[name]" slot-scope="data">
-        {{ data.value.first }} {{ data.value.last }}
+        <b>{{ data.value.last }}</b>, {{ data.value.first }}
       </template>
 
       <!-- A virtual composite column -->

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -359,8 +359,8 @@ const fields = [
 
 ## Primary key
 
-`<b-table>` provides an additional prop `primary-key`, which you can use to identify the field key
-that _uniquely_ identifies the row.
+`<b-table>` provides an additional prop `primary-key`, which you can use to identify the _name_ of
+the field key that _uniquely_ identifies the row.
 
 The value specified by the primary column key **must be** either a `string` or `number`, and **must
 be unique** across all rows in the table.
@@ -804,16 +804,16 @@ function.
 
 Scoped field slots give you greater control over how the record data appears. If you want to add an
 extra field which does not exist in the records, just add it to the `fields` array, And then
-reference the field(s) in the scoped slot(s). Field slots use the following naming syntax:
+reference the field(s) in the scoped slot(s). Scoped field slots use the following naming syntax:
 `'[' + field key + ']'`.
 
-<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions prior to
-`2.0.0-rc.28` did not surround the key with square brackets. Using the old field slot names have
-been deprecated in favour of the new bracketed syntax, and support will be removed in a future
-release.
+<span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use the default _fall-back_
+scoped slot `'[]'` to format any cells that do not have an explicit scoped slot provided.
 
-<span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use a default _fall-back_
-scoped slot `[]` to format any cells that do not have an explicit scoped slot.
+<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions prior to
+`2.0.0-rc.28` did not surround the field key with square brackets. Using the old field slot names
+have been deprecated in favour of the new bracketed syntax, and support will be removed in a future
+release. Users are encouraged to switch to the new bracketed syntax.
 
 **Example: Custom data rendering with scoped slots**
 
@@ -1009,39 +1009,6 @@ formatted value as a string (HTML strings are not supported)
 <!-- b-table-data-formatter.vue -->
 ```
 
-## Custom empty and emptyfiltered rendering via slots
-
-Aside from using `empty-text`, `empty-filtered-text`, `empty-html`, and `empty-filtered-html`, it is
-also possible to provide custom rendering for tables that have no data to display using named slots.
-
-In order for these slots to be shown, the `show-empty` attribute must be set and `items` must be
-either falsy or an array of length 0.
-
-```html
-<div>
-  <b-table :fields="fields" :items="items" show-empty>
-    <template slot="empty" slot-scope="scope">
-      <h4>{{ scope.emptyText }}</h4>
-    </template>
-    <template slot="emptyfiltered" slot-scope="scope">
-      <h4>{{ scope.emptyFilteredText }}</h4>
-    </template>
-  </b-table>
-</div>
-```
-
-The slot can optionally be scoped. The slot's scope (`scope` in the above example) will have the
-following properties:
-
-| Property            | Type   | Description                                        |
-| ------------------- | ------ | -------------------------------------------------- |
-| `emptyHtml`         | String | The `empty-html` prop                              |
-| `emptyText`         | String | The `empty-text` prop                              |
-| `emptyFilteredHtml` | String | The `empty-filtered-html` prop                     |
-| `emptyFilteredText` | String | The `empty-filtered-text` prop                     |
-| `fields`            | Array  | The `fields` prop                                  |
-| `items`             | Array  | The `items` prop. Exposed here to check null vs [] |
-
 ## Header and Footer custom rendering via scoped slots
 
 <span class="badge badge-info small">CHANGED in 2.0.0-rc.28</span>
@@ -1049,18 +1016,18 @@ following properties:
 It is also possible to provide custom rendering for the tables `thead` and `tfoot` elements. Note by
 default the table footer is not rendered unless `foot-clone` is set to `true`.
 
-Scoped slots for the header and footer cells uses a special naming convention of `HEAD[<fieldkey>]`
-and `FOOT[<fieldkey>]` respectively. if a `FOOT[...]` slot for a field is not provided, but a
-`HEAD[...]` slot is provided, then the footer will use the `HEAD[...]` slot content.
-
-<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions prior to
-`2.0.0-rc.28` used slot names `HEAD_<key>` and `FOOT_<key>`. Using the old field slot names have
-been deprecated in favour of the new bracketed syntax, and support will be removed in a future
-release.
+Scoped slots for the header and footer cells uses a special naming convention of `'HEAD[<fieldkey>]'`
+and `'FOOT[<fieldkey>]'` respectively. if a `'FOOT[...]'` slot for a field is not provided, but a
+`'HEAD[...]'` slot is provided, then the footer will use the `'HEAD[...]'` slot content.
 
 <span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use a default _fall-back_
-scoped slot `HEAD[]` or `FOOT[]` to format any header or footer cells that do not have an explicit
-scoped slot.
+scoped slot `'HEAD[]'` or `'FOOT[]'` to format any header or footer cells that do not have an
+explicit scoped slot provided.
+
+<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions prior to
+`2.0.0-rc.28` used slot names `'HEAD_<key>'` and `'FOOT_<key>'`. Using the old slot names has been
+deprecated in favour of the new bracketed syntax, and support will be removed in a future release.
+Users are encouraged to switch to the new bracketed syntax.
 
 ```html
 <template>
@@ -1189,91 +1156,38 @@ Slot `thead-top` can be optionally scoped, receiving an object with the followin
 | `columns` | Number | The number of columns in the rendered table                                   |
 | `fields`  | Array  | Array of field definition objects (normalized to the array of objects format) |
 
-## Row select support
+## Custom empty and emptyfiltered rendering via slots
 
-You can make rows selectable, by using the prop `selectable`.
+Aside from using `empty-text`, `empty-filtered-text`, `empty-html`, and `empty-filtered-html`, it is
+also possible to provide custom rendering for tables that have no data to display using named slots.
 
-Users can easily change the selecting mode by setting the `select-mode` prop.
-
-- `multi`: each click will select/deselect the row (default mode)
-- `single`: only a single row can be selected at one time
-- `range`: any row clicked is selected, any other deselected. the SHIFT key selects a range of rows,
-  and CTRL/CMD click will toggle the selected row.
-
-When a table is `selectable` and the user clicks on a row, `<b-table>` will emit the `row-selected`
-event, passing a single argument which is the complete list of selected items. **Treat this argument
-as read-only.**
+In order for these slots to be shown, the `show-empty` attribute must be set and `items` must be
+either falsy or an array of length 0.
 
 ```html
-<template>
-  <div>
-    <b-form-group label="Selection mode:" label-cols-md="4">
-      <b-form-select v-model="selectMode" :options="modes" class="mb-3"></b-form-select>
-    </b-form-group>
-
-    <b-table
-      selectable
-      :select-mode="selectMode"
-      selectedVariant="success"
-      :items="items"
-      :fields="fields"
-      @row-selected="rowSelected"
-      responsive="sm"
-    >
-      <!-- Example scoped slot for illustrative purposes only -->
-      <template slot="[selected]" slot-scope="{ rowSelected }">
-        <span v-if="rowSelected">✔</span>
-      </template>
-    </b-table>
-
-    {{ selected }}
-  </div>
-</template>
-
-<script>
-  export default {
-    data() {
-      return {
-        modes: ['multi', 'single', 'range'],
-        fields: ['selected', 'isActive', 'age', 'first_name', 'last_name'],
-        items: [
-          { isActive: true, age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
-          { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
-          { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson' },
-          { isActive: true, age: 38, first_name: 'Jami', last_name: 'Carney' }
-        ],
-        selectMode: 'multi',
-        selected: []
-      }
-    },
-    methods: {
-      rowSelected(items) {
-        this.selected = items
-      }
-    }
-  }
-</script>
-
-<!-- b-table-selectable.vue -->
+<div>
+  <b-table :fields="fields" :items="items" show-empty>
+    <template slot="empty" slot-scope="scope">
+      <h4>{{ scope.emptyText }}</h4>
+    </template>
+    <template slot="emptyfiltered" slot-scope="scope">
+      <h4>{{ scope.emptyFilteredText }}</h4>
+    </template>
+  </b-table>
+</div>
 ```
 
-When table is selectable, it will have class `b-table-selectable`, and one of the following three
-classes (depending on which mode is in use), on the `<table>` element:
+The slot can optionally be scoped. The slot's scope (`scope` in the above example) will have the
+following properties:
 
-- `b-table-select-single`
-- `b-table-select-multi`
-- `b-table-select-range`
-
-When at least one row is selected the class `b-table-selecting` will be active on the `<table>`
-element.
-
-**Notes:**
-
-- _Paging, filtering, or sorting will clear the selection. The `row-selected` event will be emitted
-  with an empty array if needed._
-- _Selected rows will have a class of `b-row-selected` added to them._
-- _When the table is in `selectable` mode, all data item `<tr>` elements will be in the document tab
-  sequence (`tabindex="0"`) for accessibility reasons._
+| Property            | Type   | Description                                        |
+| ------------------- | ------ | -------------------------------------------------- |
+| `emptyHtml`         | String | The `empty-html` prop                              |
+| `emptyText`         | String | The `empty-text` prop                              |
+| `emptyFilteredHtml` | String | The `empty-filtered-html` prop                     |
+| `emptyFilteredText` | String | The `empty-filtered-text` prop                     |
+| `fields`            | Array  | The `fields` prop                                  |
+| `items`             | Array  | The `items` prop. Exposed here to check null vs [] |
 
 ## Row details support
 
@@ -1365,6 +1279,92 @@ initially showing.
 
 <!-- b-table-details.vue -->
 ```
+
+## Row select support
+
+You can make rows selectable, by using the prop `selectable`.
+
+Users can easily change the selecting mode by setting the `select-mode` prop.
+
+- `multi`: each click will select/deselect the row (default mode)
+- `single`: only a single row can be selected at one time
+- `range`: any row clicked is selected, any other deselected. the SHIFT key selects a range of rows,
+  and CTRL/CMD click will toggle the selected row.
+
+When a table is `selectable` and the user clicks on a row, `<b-table>` will emit the `row-selected`
+event, passing a single argument which is the complete list of selected items. **Treat this argument
+as read-only.**
+
+```html
+<template>
+  <div>
+    <b-form-group label="Selection mode:" label-cols-md="4">
+      <b-form-select v-model="selectMode" :options="modes" class="mb-3"></b-form-select>
+    </b-form-group>
+
+    <b-table
+      selectable
+      :select-mode="selectMode"
+      selectedVariant="success"
+      :items="items"
+      :fields="fields"
+      @row-selected="rowSelected"
+      responsive="sm"
+    >
+      <!-- Example scoped slot for illustrative purposes only -->
+      <template slot="[selected]" slot-scope="{ rowSelected }">
+        <span v-if="rowSelected">✔</span>
+      </template>
+    </b-table>
+
+    {{ selected }}
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        modes: ['multi', 'single', 'range'],
+        fields: ['selected', 'isActive', 'age', 'first_name', 'last_name'],
+        items: [
+          { isActive: true, age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
+          { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
+          { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson' },
+          { isActive: true, age: 38, first_name: 'Jami', last_name: 'Carney' }
+        ],
+        selectMode: 'multi',
+        selected: []
+      }
+    },
+    methods: {
+      rowSelected(items) {
+        this.selected = items
+      }
+    }
+  }
+</script>
+
+<!-- b-table-selectable.vue -->
+```
+
+When table is selectable, it will have class `b-table-selectable`, and one of the following three
+classes (depending on which mode is in use), on the `<table>` element:
+
+- `b-table-select-single`
+- `b-table-select-multi`
+- `b-table-select-range`
+
+When at least one row is selected the class `b-table-selecting` will be active on the `<table>`
+element.
+
+**Notes:**
+
+- _Paging, filtering, or sorting will clear the selection. The `row-selected` event will be emitted
+  with an empty array if needed._
+- _Selected rows will have a class of `b-row-selected` added to them._
+- _When the table is in `selectable` mode, all data item `<tr>` elements will be in the document tab
+  sequence (`tabindex="0"`) for accessibility reasons._
 
 ## Sorting
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -800,9 +800,18 @@ function.
 
 ### Scoped field slots
 
-Scoped slots give you greater control over how the record data appears. If you want to add an extra
+<span class="badge badge-info small">CHANGED in 2.0.0-rc.28</span>
+
+Scoped field slots give you greater control over how the record data appears. If you want to add an extra
 field which does not exist in the records, just add it to the `fields` array, And then reference the
-field(s) in the scoped slot(s).
+field(s) in the scoped slot(s). Field slots use the following naming syntax: `'[' + field key + ']'`.
+
+<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions pror to `2.0.0-rc.28`
+did not surround the key with square brackets. Using the old field slot names have been deprecated in
+favour of the new bracketed syntax, and support will be removed in a future release.
+
+<span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use a default _fall-back_ scoped
+slot `[]` to format any cells that do not have an explicit scoped slot.
 
 **Example: Custom data rendering with scoped slots**
 
@@ -811,18 +820,23 @@ field(s) in the scoped slot(s).
   <div>
     <b-table small :fields="fields" :items="items">
       <!-- A virtual column -->
-      <template slot="index" slot-scope="data">
+      <template slot="[index]" slot-scope="data">
         {{ data.index + 1 }}
       </template>
 
       <!-- A custom formatted column -->
-      <template slot="name" slot-scope="data">
+      <template slot="[name]" slot-scope="data">
         {{ data.value.first }} {{ data.value.last }}
       </template>
 
       <!-- A virtual composite column -->
-      <template slot="nameage" slot-scope="data">
+      <template slot="[nameage]" slot-scope="data">
         {{ data.item.name.first }} is {{ data.item.age }} years old
+      </template>
+
+      <!-- Optional default data cell scoped slot -->
+      <template slot="[]" slot-scope="data">
+        <i>{{ data.value }}</i>
       </template>
     </b-table>
   </div>
@@ -887,7 +901,7 @@ scoped field slot.
 <template>
   <div>
     <b-table :items="items">
-      <span slot="html" slot-scope="data" v-html="data.value"></span>
+      <span slot="[html]" slot-scope="data" v-html="data.value"></span>
     </b-table>
   </div>
 </template>
@@ -936,7 +950,7 @@ formatted value as a string (HTML strings are not supported)
 <template>
   <div>
     <b-table :fields="fields" :items="items">
-      <template slot="name" slot-scope="data">
+      <template slot="[name]" slot-scope="data">
         <!-- `data.value` is the value after formatted by the Formatter -->
         <a :href="`#${data.value.replace(/[^a-z]+/i,'-').toLowerCase()}`">{{ data.value }}</a>
       </template>
@@ -1028,29 +1042,43 @@ following properties:
 
 ## Header and Footer custom rendering via scoped slots
 
+<span class="badge badge-info small">CHANGED in 2.0.0-rc.28</span>
+
 It is also possible to provide custom rendering for the tables `thead` and `tfoot` elements. Note by
 default the table footer is not rendered unless `foot-clone` is set to `true`.
 
-Scoped slots for the header and footer cells uses a special naming convention of `HEAD_<fieldkey>`
-and `FOOT_<fieldkey>` respectively. if a `FOOT_` slot for a field is not provided, but a `HEAD_`
-slot is provided, then the footer will use the `HEAD_` slot content.
+Scoped slots for the header and footer cells uses a special naming convention of `HEAD[<fieldkey>]`
+and `FOOT[<fieldkey>]` respectively. if a `FOOT[...]` slot for a field is not provided, but a `HEAD[..]`
+slot is provided, then the footer will use the `HEAD[...]` slot content.
+
+<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions pror to `2.0.0-rc.28`
+used slot names `HEAD_<key>` and `FOOT_<key>`. Using the old field slot names have been deprecated in
+favour of the new bracketed syntax, and support will be removed in a future release.
+
+<span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use a default _fall-back_ scoped
+slot `HEAD[]` or `FOOT[]` to format any header or footer cells that do not have an explicit scoped slot.
 
 ```html
 <div>
   <b-table :fields="fields" :items="items" foot-clone>
     <!-- A custom formatted data column cell -->
-    <template slot="name" slot-scope="data">
+    <template slot="[name]" slot-scope="data">
       {{ data.value.first }} {{ data.value.last }}
     </template>
 
     <!-- A custom formatted header cell for field 'name' -->
-    <template slot="HEAD_name" slot-scope="data">
+    <template slot="HEAD[name]" slot-scope="data">
       <em>{{ data.label }}</em>
     </template>
 
     <!-- A custom formatted footer cell  for field 'name' -->
-    <template slot="FOOT_name" slot-scope="data">
+    <template slot="FOOT[name]" slot-scope="data">
       <strong>{{ data.label }}</strong>
+    </template>
+
+    <!-- Default fall-back custom formatted footer cell -->
+    <template slot="FOOT[]" slot-scope="data">
+      <i>{{ data.label }}</i>
     </template>
   </b-table>
 </div>
@@ -1065,7 +1093,7 @@ properties:
 | `field`  | Object | the field's object (from the `fields` prop)                   |
 | `label`  | String | The fields label value (also available as `data.field.label`) |
 
-When placing inputs, buttons, selects or links within a `HEAD_` or `FOOT_` slot, note that
+When placing inputs, buttons, selects or links within a `HEAD[..]` or `FOOT[...]` slot, note that
 `head-clicked` event will not be emitted when the input, select, textarea is clicked (unless they
 are disabled). `head-clicked` will never be emitted when clicking on links or buttons inside the
 scoped slots (even when disabled)
@@ -1162,7 +1190,7 @@ as read-only.**
       responsive="sm"
     >
       <!-- Example scoped slot for illustrative purposes only -->
-      <template slot="selected" slot-scope="{ rowSelected }">
+      <template slot="[selected]" slot-scope="{ rowSelected }">
         <span v-if="rowSelected">✔</span>
       </template>
     </b-table>
@@ -1252,7 +1280,7 @@ initially showing.
 <template>
   <div>
     <b-table :items="items" :fields="fields" striped responsive="sm">
-      <template slot="show_details" slot-scope="row">
+      <template slot="[show_details]" slot-scope="row">
         <b-button size="sm" @click="row.toggleDetails" class="mr-2">
           {{ row.detailsShowing ? 'Hide' : 'Show'}} Details
         </b-button>
@@ -2071,15 +2099,15 @@ differences between operating systems, this too is not a preventable default beh
       :sort-direction="sortDirection"
       @filtered="onFiltered"
     >
-      <template slot="name" slot-scope="row">
+      <template slot="[name]" slot-scope="row">
         {{ row.value.first }} {{ row.value.last }}
       </template>
 
-      <template slot="isActive" slot-scope="row">
+      <template slot="[isActive]" slot-scope="row">
         {{ row.value ? 'Yes :)' : 'No :(' }}
       </template>
 
-      <template slot="actions" slot-scope="row">
+      <template slot="[actions]" slot-scope="row">
         <b-button size="sm" @click="info(row.item, row.index, $event.target)" class="mr-1">
           Info modal
         </b-button>

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -1059,29 +1059,56 @@ favour of the new bracketed syntax, and support will be removed in a future rele
 slot `HEAD[]` or `FOOT[]` to format any header or footer cells that do not have an explicit scoped slot.
 
 ```html
-<div>
-  <b-table :fields="fields" :items="items" foot-clone>
-    <!-- A custom formatted data column cell -->
-    <template slot="[name]" slot-scope="data">
-      {{ data.value.first }} {{ data.value.last }}
-    </template>
+<template>
+  <div>
+    <b-table :fields="fields" :items="items" foot-clone>
+      <!-- A custom formatted data column cell -->
+      <template slot="[name]" slot-scope="data">
+        {{ data.value.first }} {{ data.value.last }}
+      </template>
 
-    <!-- A custom formatted header cell for field 'name' -->
-    <template slot="HEAD[name]" slot-scope="data">
-      <em>{{ data.label }}</em>
-    </template>
+      <!-- A custom formatted header cell for field 'name' -->
+      <template slot="HEAD[name]" slot-scope="data">
+        <span class="text-info">{{ data.label }}</b>
+      </template>
 
-    <!-- A custom formatted footer cell  for field 'name' -->
-    <template slot="FOOT[name]" slot-scope="data">
-      <strong>{{ data.label }}</strong>
-    </template>
+      <!-- A custom formatted footer cell  for field 'name' -->
+      <template slot="FOOT[name]" slot-scope="data">
+        <span class="text-danger">{{ data.label }}</span>
+      </template>
 
-    <!-- Default fall-back custom formatted footer cell -->
-    <template slot="FOOT[]" slot-scope="data">
-      <i>{{ data.label }}</i>
-    </template>
-  </b-table>
-</div>
+      <!-- Default fall-back custom formatted footer cell -->
+      <template slot="FOOT[]" slot-scope="data">
+        <i>{{ data.label }}</i>
+      </template>
+    </b-table>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        fields: [
+          // A column that needs custom formatting
+          { key: 'name', label: 'Full Name' },
+          // A regular column
+          'age',
+          // A regular column
+          'sex'
+        ],
+        items: [
+          { name: { first: 'John', last: 'Doe' }, sex: 'Male', age: 42 },
+          { name: { first: 'Jane', last: 'Doe' }, sex: 'Female', age: 36 },
+          { name: { first: 'Rubin', last: 'Kincade' }, sex: 'Male', age: 73 },
+          { name: { first: 'Shirley', last: 'Partridge' }, sex: 'Female', age: 62 }
+        ]
+      }
+    }
+  }
+</script>
+
+<!-- b-table-head-foot-slots.vue -->
 ```
 
 The slots can be optionally scoped (`data` in the above example), and will have the following

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -802,16 +802,18 @@ function.
 
 <span class="badge badge-info small">CHANGED in 2.0.0-rc.28</span>
 
-Scoped field slots give you greater control over how the record data appears. If you want to add an extra
-field which does not exist in the records, just add it to the `fields` array, And then reference the
-field(s) in the scoped slot(s). Field slots use the following naming syntax: `'[' + field key + ']'`.
+Scoped field slots give you greater control over how the record data appears. If you want to add an
+extra field which does not exist in the records, just add it to the `fields` array, And then
+reference the field(s) in the scoped slot(s). Field slots use the following naming syntax:
+`'[' + field key + ']'`.
 
-<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions pror to `2.0.0-rc.28`
-did not surround the key with square brackets. Using the old field slot names have been deprecated in
-favour of the new bracketed syntax, and support will be removed in a future release.
+<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions prior to
+`2.0.0-rc.28` did not surround the key with square brackets. Using the old field slot names have
+been deprecated in favour of the new bracketed syntax, and support will be removed in a future
+release.
 
-<span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use a default _fall-back_ scoped
-slot `[]` to format any cells that do not have an explicit scoped slot.
+<span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use a default _fall-back_
+scoped slot `[]` to format any cells that do not have an explicit scoped slot.
 
 **Example: Custom data rendering with scoped slots**
 
@@ -1048,15 +1050,17 @@ It is also possible to provide custom rendering for the tables `thead` and `tfoo
 default the table footer is not rendered unless `foot-clone` is set to `true`.
 
 Scoped slots for the header and footer cells uses a special naming convention of `HEAD[<fieldkey>]`
-and `FOOT[<fieldkey>]` respectively. if a `FOOT[...]` slot for a field is not provided, but a `HEAD[..]`
-slot is provided, then the footer will use the `HEAD[...]` slot content.
+and `FOOT[<fieldkey>]` respectively. if a `FOOT[...]` slot for a field is not provided, but a
+`HEAD[...]` slot is provided, then the footer will use the `HEAD[...]` slot content.
 
-<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions pror to `2.0.0-rc.28`
-used slot names `HEAD_<key>` and `FOOT_<key>`. Using the old field slot names have been deprecated in
-favour of the new bracketed syntax, and support will be removed in a future release.
+<span class="badge badge-warning small">DEPRECATION in 2.0.0-rc.28</span> Versions prior to
+`2.0.0-rc.28` used slot names `HEAD_<key>` and `FOOT_<key>`. Using the old field slot names have
+been deprecated in favour of the new bracketed syntax, and support will be removed in a future
+release.
 
-<span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use a default _fall-back_ scoped
-slot `HEAD[]` or `FOOT[]` to format any header or footer cells that do not have an explicit scoped slot.
+<span class="badge badge-info small">NEW in 2.0.0-rc.28</span> You can use a default _fall-back_
+scoped slot `HEAD[]` or `FOOT[]` to format any header or footer cells that do not have an explicit
+scoped slot.
 
 ```html
 <template>
@@ -1120,7 +1124,7 @@ properties:
 | `field`  | Object | the field's object (from the `fields` prop)                   |
 | `label`  | String | The fields label value (also available as `data.field.label`) |
 
-When placing inputs, buttons, selects or links within a `HEAD[..]` or `FOOT[...]` slot, note that
+When placing inputs, buttons, selects or links within a `HEAD[...]` or `FOOT[...]` slot, note that
 `head-clicked` event will not be emitted when the input, select, textarea is clicked (unless they
 are disabled). `head-clicked` will never be emitted when clicking on links or buttons inside the
 scoped slots (even when disabled)

--- a/src/components/table/helpers/mixin-tbody-row.js
+++ b/src/components/table/helpers/mixin-tbody-row.js
@@ -205,8 +205,9 @@ export default {
         slotScope.rowSelected = Boolean(this.selectedRows[rowIndex])
       }
       // TODO: Using field.key as scoped slot name is deprecated, to be removed in future release.
-      //   New format uses the square bracketed naming convention 
-      let $childNodes = this.normalizeSlot([`[${field.key}]`, '[]', field.key], slotScope) || toString(formatted)
+      //   New format uses the square bracketed naming convention
+      let $childNodes =
+        this.normalizeSlot([`[${field.key}]`, '[]', field.key], slotScope) || toString(formatted)
       if (this.isStacked) {
         // We wrap in a DIV to ensure rendered as a single cell when visually stacked!
         $childNodes = [h('div', {}, [$childNodes])]

--- a/src/components/table/helpers/mixin-tbody-row.js
+++ b/src/components/table/helpers/mixin-tbody-row.js
@@ -204,7 +204,8 @@ export default {
         // Add in rowSelected scope property if selectable rows supported
         slotScope.rowSelected = Boolean(this.selectedRows[rowIndex])
       }
-      // TODO: Using field.key as scoped slot name is deprecated, to be removed in future release.
+      // TODO:
+      //   Using `field.key` as scoped slot name is deprecated, to be removed in future release
       //   New format uses the square bracketed naming convention
       let $childNodes =
         this.normalizeSlot([`[${field.key}]`, '[]', field.key], slotScope) || toString(formatted)
@@ -304,8 +305,9 @@ export default {
             },
             on: {
               ...handlers,
-              // TODO: Instantiate the following handlers only if we have registered
-              //       listeners i.e. this.$listeners['row-middle-clicked'], etc.
+              // TODO:
+              //   Instantiate the following handlers only if we have registered
+              //   listeners i.e. `this.$listeners['row-middle-clicked']`, etc.
               auxclick: evt => {
                 if (evt.which === 2) {
                   this.middleMouseRowClicked(evt, item, rowIndex)

--- a/src/components/table/helpers/mixin-thead.js
+++ b/src/components/table/helpers/mixin-thead.js
@@ -102,10 +102,14 @@ export default {
           on: handlers
         }
         const fieldScope = { label: field.label, column: field.key, field: field }
-        const slot =
-          isFoot && this.hasNormalizedSlot(`FOOT_${field.key}`)
-            ? this.normalizeSlot(`FOOT_${field.key}`, fieldScope)
-            : this.normalizeSlot(`HEAD_${field.key}`, fieldScope)
+        let slot
+        if (isFoot && this.hasNormalizedSlot([`FOOT[${field.key}]`, 'FOOT[]', `FOOT_${field.key}`])) {
+          // TODO: FOOT_${field.key} is deprecated, to be removed in future release
+          slot = this.normalizeSlot([`FOOT[${field.key}]`, 'FOOT[]', `FOOT_${field.key}`], fieldScope)
+        } else {
+          // TODO: HEAD_${field.key} is deprecated, to be removed in future release
+          slot = this.normalizeSlot([`HEAD[${field.key}]`, 'HEAD[]', `HEAD_${field.key}`], fieldScope)
+        }
         if (!slot) {
           data.domProps = htmlOrText(field.labelHtml)
         }

--- a/src/components/table/helpers/mixin-thead.js
+++ b/src/components/table/helpers/mixin-thead.js
@@ -103,12 +103,21 @@ export default {
         }
         const fieldScope = { label: field.label, column: field.key, field: field }
         let slot
-        if (isFoot && this.hasNormalizedSlot([`FOOT[${field.key}]`, 'FOOT[]', `FOOT_${field.key}`])) {
+        if (
+          isFoot &&
+          this.hasNormalizedSlot([`FOOT[${field.key}]`, 'FOOT[]', `FOOT_${field.key}`])
+        ) {
           // TODO: FOOT_${field.key} is deprecated, to be removed in future release
-          slot = this.normalizeSlot([`FOOT[${field.key}]`, 'FOOT[]', `FOOT_${field.key}`], fieldScope)
+          slot = this.normalizeSlot(
+            [`FOOT[${field.key}]`, 'FOOT[]', `FOOT_${field.key}`],
+            fieldScope
+          )
         } else {
           // TODO: HEAD_${field.key} is deprecated, to be removed in future release
-          slot = this.normalizeSlot([`HEAD[${field.key}]`, 'HEAD[]', `HEAD_${field.key}`], fieldScope)
+          slot = this.normalizeSlot(
+            [`HEAD[${field.key}]`, 'HEAD[]', `HEAD_${field.key}`],
+            fieldScope
+          )
         }
         if (!slot) {
           data.domProps = htmlOrText(field.labelHtml)

--- a/src/components/table/helpers/mixin-thead.js
+++ b/src/components/table/helpers/mixin-thead.js
@@ -27,7 +27,7 @@ export default {
   },
   methods: {
     fieldClasses(field) {
-      // header field (th) classes
+      // Header field (<th>) classes
       return [
         field.variant ? 'table-' + field.variant : '',
         field.class ? field.class : '',
@@ -39,7 +39,7 @@ export default {
         // If table is busy (via provider) then don't propagate
         return
       } else if (filterEvent(evt)) {
-        // clicked on a non-disabled control so ignore
+        // Clicked on a non-disabled control so ignore
         return
       } else if (textSelectionActive(this.$el)) {
         // User is selecting text, so ignore
@@ -60,7 +60,7 @@ export default {
         return h()
       }
 
-      // Helper function to generate a field TH cell
+      // Helper function to generate a field <th> cell
       const makeCell = (field, colIndex) => {
         let ariaLabel = null
         if (!field.label.trim() && !field.headerTitle) {
@@ -107,13 +107,13 @@ export default {
           isFoot &&
           this.hasNormalizedSlot([`FOOT[${field.key}]`, 'FOOT[]', `FOOT_${field.key}`])
         ) {
-          // TODO: FOOT_${field.key} is deprecated, to be removed in future release
+          // TODO: `FOOT_${field.key}` is deprecated, to be removed in future release
           slot = this.normalizeSlot(
             [`FOOT[${field.key}]`, 'FOOT[]', `FOOT_${field.key}`],
             fieldScope
           )
         } else {
-          // TODO: HEAD_${field.key} is deprecated, to be removed in future release
+          // TODO: `HEAD_${field.key}` is deprecated, to be removed in future release
           slot = this.normalizeSlot(
             [`HEAD[${field.key}]`, 'HEAD[]', `HEAD_${field.key}`],
             fieldScope
@@ -125,7 +125,7 @@ export default {
         return h('th', data, slot || field.label)
       }
 
-      // Generate the array of TH cells
+      // Generate the array of <th> cells
       const $cells = fields.map(makeCell).filter(th => th)
 
       // Genrate the row(s)

--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -268,7 +268,7 @@
           {
             "name": "FOOT_key",
             "description": "DEPRECATED in 2.0.0-rc.28. Use slot 'FOOT[key]' instead"
-          } 
+          }
         ]
       },
       {

--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -198,6 +198,30 @@
         ],
         "slots": [
           {
+            "name": "[field key]",
+            "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
+          },
+          {
+            "name": "[]",
+            "description": "Default scoped slot for custom data rendering of field data. See docs for scoped data"
+          },
+          {
+            "name": "HEAD[field key]",
+            "description": "Scoped slot for custom rendering of field header. See docs for scoped header"
+          },
+          {
+            "name": "HEAD[]",
+            "description": "Default scoped slot for custom rendering of field header. See docs for scoped header"
+          },
+          {
+            "name": "FOOT[field key]",
+            "description": "Scoped slot for custom rendering of field footer. See docs for scoped footer"
+          },
+          {
+            "name": "FOOT[]",
+            "description": "Default scoped slot for custom rendering of field footer. See docs for scoped footer"
+          },
+          {
             "name": "table-caption",
             "description": "Content to display in the table's caption element"
           },
@@ -208,18 +232,6 @@
           {
             "name": "table-busy",
             "description": "Optional slot to place loading message when table is in the busy state"
-          },
-          {
-            "name": "[field]",
-            "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
-          },
-          {
-            "name": "HEAD_[field]",
-            "description": "Scoped slot for custom rendering of field header. See docs for scoped header"
-          },
-          {
-            "name": "FOOT_[field]",
-            "description": "Scoped slot for custom rendering of field footer. See docs for scoped footer"
           },
           {
             "name": "row-details",
@@ -383,24 +395,36 @@
         ],
         "slots": [
           {
+            "name": "[field key]",
+            "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
+          },
+          {
+            "name": "[]",
+            "description": "Default scoped slot for custom data rendering of field data. See docs for scoped data"
+          },
+          {
+            "name": "HEAD[field key]",
+            "description": "Scoped slot for custom rendering of field header. See docs for scoped header"
+          },
+          {
+            "name": "HEAD[]",
+            "description": "Default scoped slot for custom rendering of field header. See docs for scoped header"
+          },
+          {
+            "name": "FOOT[field key]",
+            "description": "Scoped slot for custom rendering of field footer. See docs for scoped footer"
+          },
+          {
+            "name": "FOOT[]",
+            "description": "Default scoped slot for custom rendering of field footer. See docs for scoped footer"
+          },
+          {
             "name": "table-caption",
             "description": "Content to display in the table's caption element"
           },
           {
             "name": "table-colgroup",
             "description": "Slot to place custom colgroup and col elements (optionally scoped: columns - number of columns, fields - array of field definition objects)"
-          },
-          {
-            "name": "[field]",
-            "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
-          },
-          {
-            "name": "HEAD_[field]",
-            "description": "Scoped slot for custom rendering of field header. See docs for scoped header"
-          },
-          {
-            "name": "FOOT_[field]",
-            "description": "Scoped slot for custom rendering of field footer. See docs for scoped footer"
           },
           {
             "name": "row-details",

--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -198,24 +198,24 @@
         ],
         "slots": [
           {
-            "name": "[field key]",
-            "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
+            "name": "[key]",
+            "description": "Scoped slot for custom data rendering of field data. 'key' is hte fields key name. See docs for scoped data"
           },
           {
             "name": "[]",
             "description": "Default scoped slot for custom data rendering of field data. See docs for scoped data"
           },
           {
-            "name": "HEAD[field key]",
-            "description": "Scoped slot for custom rendering of field header. See docs for scoped header"
+            "name": "HEAD[key]",
+            "description": "Scoped slot for custom rendering of field header. 'key' is hte fields key name. See docs for scoped header"
           },
           {
             "name": "HEAD[]",
             "description": "Default scoped slot for custom rendering of field header. See docs for scoped header"
           },
           {
-            "name": "FOOT[field key]",
-            "description": "Scoped slot for custom rendering of field footer. See docs for scoped footer"
+            "name": "FOOT[key]",
+            "description": "Scoped slot for custom rendering of field footer. 'key' is hte fields key name. See docs for scoped footer"
           },
           {
             "name": "FOOT[]",
@@ -256,7 +256,19 @@
           {
             "name": "bottom-row",
             "description": "Fixed bottom row slot for user supplied TD cells (Optionally Scoped: columns - number of TDs to provide, fields - array of field definition objects)"
-          }
+          },
+          {
+            "name": "key",
+            "description": "DEPRECATED in 2.0.0-rc.28. Use slot '[key]' instead"
+          },
+          {
+            "name": "HEAD_key",
+            "description": "DEPRECATED in 2.0.0-rc.28. Use slot 'HEAD[key]' instead"
+          },
+          {
+            "name": "FOOT_key",
+            "description": "DEPRECATED in 2.0.0-rc.28. Use slot 'FOOT[key]' instead"
+          } 
         ]
       },
       {

--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -407,24 +407,24 @@
         ],
         "slots": [
           {
-            "name": "[field key]",
-            "description": "Scoped slot for custom data rendering of field data. See docs for scoped data"
+            "name": "[key]",
+            "description": "Scoped slot for custom data rendering of field data. 'key' is hte fields key name. See docs for scoped data"
           },
           {
             "name": "[]",
             "description": "Default scoped slot for custom data rendering of field data. See docs for scoped data"
           },
           {
-            "name": "HEAD[field key]",
-            "description": "Scoped slot for custom rendering of field header. See docs for scoped header"
+            "name": "HEAD[key]",
+            "description": "Scoped slot for custom rendering of field header. 'key' is hte fields key name. See docs for scoped header"
           },
           {
             "name": "HEAD[]",
             "description": "Default scoped slot for custom rendering of field header. See docs for scoped header"
           },
           {
-            "name": "FOOT[field key]",
-            "description": "Scoped slot for custom rendering of field footer. See docs for scoped footer"
+            "name": "FOOT[key]",
+            "description": "Scoped slot for custom rendering of field footer. 'key' is hte fields key name. See docs for scoped footer"
           },
           {
             "name": "FOOT[]",
@@ -445,6 +445,18 @@
           {
             "name": "thead-top",
             "description": "Slot above the column headers in the `thead` element for user-supplied rows (optionally scoped: columns - number of TDs to provide, fields - array of field definition objects)"
+          },
+          {
+            "name": "key",
+            "description": "DEPRECATED in 2.0.0-rc.28. Use slot '[key]' instead"
+          },
+          {
+            "name": "HEAD_key",
+            "description": "DEPRECATED in 2.0.0-rc.28. Use slot 'HEAD[key]' instead"
+          },
+          {
+            "name": "FOOT_key",
+            "description": "DEPRECATED in 2.0.0-rc.28. Use slot 'FOOT[key]' instead"
           }
         ]
       }

--- a/src/mixins/normalize-slot.js
+++ b/src/mixins/normalize-slot.js
@@ -3,14 +3,16 @@ import { concat } from '../utils/array'
 
 export default {
   methods: {
-    hasNormalizedSlot(name) {
+    hasNormalizedSlot(names) {
       // Returns true if the either a $scopedSlot or $slot exists with the specified name
-      return hasNormalizedSlot(name, this.$scopedSlots, this.$slots)
+      // `names` can be a string name or an array of names
+      return hasNormalizedSlot(names, this.$scopedSlots, this.$slots)
     },
-    normalizeSlot(name, scope = {}) {
+    normalizeSlot(names, scope = {}) {
       // Returns an array of rendered vNodes if slot found.
       // Returns undefined if not found.
-      const vNodes = normalizeSlot(name, scope, this.$scopedSlots, this.$slots)
+      // `names` can be a string name or an array of names
+      const vNodes = normalizeSlot(names, scope, this.$scopedSlots, this.$slots)
       return vNodes ? concat(vNodes) : vNodes
     }
   }

--- a/src/utils/normalize-slot.js
+++ b/src/utils/normalize-slot.js
@@ -24,7 +24,7 @@ const hasNormalizedSlot = (names, $scopedSlots = {}, $slots = {}) => {
 /**
  * Returns vNodes for named slot either scoped or unscoped
  *
- * @param {String} name
+ * @param {String, Array} name or name[]
  * @param {String} scope
  * @param {Object} scopedSlots
  * @param {Object} slots

--- a/src/utils/normalize-slot.js
+++ b/src/utils/normalize-slot.js
@@ -1,3 +1,4 @@
+import { concat } from './array'
 import { isFunction } from './inspect'
 
 // Note for functional components:
@@ -8,14 +9,16 @@ import { isFunction } from './inspect'
 /**
  * Returns true if either scoped or unscoped named slot exists
  *
- * @param {String} name
+ * @param {String, Array} name or name[]
  * @param {Object} scopedSlots
  * @param {Object} slots
  * @returns {Array|undefined} vNodes
  */
-const hasNormalizedSlot = (name, $scopedSlots = {}, $slots = {}) => {
+const hasNormalizedSlot = (names, $scopedSlots = {}, $slots = {}) => {
+  // Ensure names is an array
+  names = concat(names).filter(Boolean)
   // Returns true if the either a $scopedSlot or $slot exists with the specified name
-  return Boolean($scopedSlots[name] || $slots[name])
+  return names.some(name => $scopedSlots[name] || $slots[name])
 }
 
 /**
@@ -27,9 +30,15 @@ const hasNormalizedSlot = (name, $scopedSlots = {}, $slots = {}) => {
  * @param {Object} slots
  * @returns {Array|undefined} vNodes
  */
-const normalizeSlot = (name, scope = {}, $scopedSlots = {}, $slots = {}) => {
-  // Note: in Vue 2.6.x, all names slots are also scoped slots
-  const slot = $scopedSlots[name] || $slots[name]
+const normalizeSlot = (names, scope = {}, $scopedSlots = {}, $slots = {}) => {
+  // Ensure names is an array
+  names = concat(names).filter(Boolean)
+  let slot
+  for (let i = 0; i < names.length && !slot; i++) {
+    const name = names[i]
+    slot = $scopedSlots[name] || $slots[name]
+  }
+  // Note: in Vue 2.6.x, all named slots are also scoped slots
   return isFunction(slot) ? slot(scope) : slot
 }
 

--- a/src/utils/normalize-slot.spec.js
+++ b/src/utils/normalize-slot.spec.js
@@ -47,5 +47,17 @@ describe('utils/normalizeSlot', () => {
     // Returns undefined if slot name not found
     result = normalizeSlot('baz', {}, $scoped, $slots)
     expect(result).not.toBeDefined()
+
+    // Works with array (named slot)
+    result = normalizeSlot(['none', 'default'], { a: ' foo' }, undefined, $slots)
+    expect(result).toBe('bar')
+
+    // Works with arrays (scoped slot)
+    result = normalizeSlot(['none', 'default'], { a: ' bar' }, $scoped, {})
+    expect(result).toBe('foo bar')
+
+    // Returns undefined if slot name not found with array
+    result = normalizeSlot(['baz', 'bar'], {}, $scoped, $slots)
+    expect(result).not.toBeDefined()
   })
 })


### PR DESCRIPTION
### Describe the PR

Support new bracketed naming convention for table scoped field slots, deprecate old field slot names.

Now allows for fields with key `default`, and prevents possible conflicts between user field keys and other table slots.

Adds support for default/fallback scoped slots for data cells, header cells and footer cells.

| Slot Usage | Current (deprecated) slot name | New slot naming syntax |
| ------- | --------------- | --------------------- |
| **Data cells** | `<key>`  | `[<key>]`  |
| **Default data cells** | n/a | `[]` |
| **Heading cells** | `HEAD_<key>` | `HEAD[<key>]`  |
| **Default heading cells** | n/a | `HEAD[]` |
| **Footer cells** | `FOOT_<key>` | `FOOT[<key>]` |
| **Default footer cells** | n/a | `FOOT[]`  |

Where `<key>` is the field's key name.

Closes #3731

To Do:

- [x] updated unit tests
- [x] documentation update

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other (please describe) Deprecation of old scoped slot names for fields cells, header cells and footer cells.

**Does this PR introduce a breaking change?** (check one)

- [ ] No
- [ ] Yes (please describe)
- [x] Deprecation

The new slot names will be preferred over the old slot names.  In a future release we will remove the old slot naming convention

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
