### PR TITLE
feat(b-form-file, b-form-checkbox, b-form-radio): make input element inherit non-prop attributes (addresses #3752)

### DIFF
--- a/src/components/form-checkbox/form-checkbox.spec.js
+++ b/src/components/form-checkbox/form-checkbox.spec.js
@@ -279,6 +279,20 @@ describe('form-checkbox', () => {
     wrapper.destroy()
   })
 
+  it('has custom attributes transferred to input element', async () => {
+    const wrapper = mount(BFormCheckbox, {
+      propsData: {
+        id: 'foo',
+        foo: 'bar'
+      }
+    })
+    const input = wrapper.find('input')
+    expect(input.attributes('foo')).toBeDefined()
+    expect(input.attributes('foo')).toEqual('bar')
+
+    wrapper.destroy()
+  })
+
   it('default has class custom-control-inline when prop inline=true', async () => {
     const wrapper = mount(BFormCheckbox, {
       propsData: {

--- a/src/components/form-file/form-file.js
+++ b/src/components/form-file/form-file.js
@@ -14,6 +14,7 @@ const NAME = 'BFormFile'
 export const BFormFile = /*#__PURE__*/ Vue.extend({
   name: NAME,
   mixins: [idMixin, formMixin, formStateMixin, formCustomMixin, normalizeSlotMixin],
+  inheritAttrs: false,
   model: {
     prop: 'value',
     event: 'input'
@@ -261,6 +262,7 @@ export const BFormFile = /*#__PURE__*/ Vue.extend({
         this.stateClass
       ],
       attrs: {
+        ...this.$attrs,
         type: 'file',
         id: this.safeId(),
         name: this.name,

--- a/src/components/form-file/form-file.spec.js
+++ b/src/components/form-file/form-file.spec.js
@@ -135,6 +135,20 @@ describe('form-file', () => {
     wrapper.destroy()
   })
 
+  it('default has custom attributes transferred input element', async () => {
+    const wrapper = mount(BFormFile, {
+      propsData: {
+        id: 'foo',
+        foo: 'bar'
+      }
+    })
+    const input = wrapper.find('input')
+    expect(input.attributes('foo')).toBeDefined()
+    expect(input.attributes('foo')).toEqual('bar')
+
+    wrapper.destroy()
+  })
+
   it('default has class focus when input focused', async () => {
     const wrapper = mount(BFormFile, {
       propsData: {

--- a/src/components/form-radio/form-radio.spec.js
+++ b/src/components/form-radio/form-radio.spec.js
@@ -261,6 +261,20 @@ describe('form-radio', () => {
     wrapper.destroy()
   })
 
+  it('has custom attributes transferred to input element', async () => {
+    const wrapper = mount(BFormRadio, {
+      propsData: {
+        id: 'foo',
+        foo: 'bar'
+      }
+    })
+    const input = wrapper.find('input')
+    expect(input.attributes('foo')).toBeDefined()
+    expect(input.attributes('foo')).toEqual('bar')
+
+    wrapper.destroy()
+  })
+
   it('default has class custom-control-inline when prop inline=true', async () => {
     const wrapper = mount(BFormRadio, {
       propsData: {

--- a/src/mixins/form-radio-check.js
+++ b/src/mixins/form-radio-check.js
@@ -3,6 +3,7 @@ import normalizeSlotMixin from './normalize-slot'
 // @vue/component
 export default {
   mixins: [normalizeSlotMixin],
+  inheritAttrs: false,
   model: {
     prop: 'checked',
     event: 'input'
@@ -198,6 +199,7 @@ export default {
         }
       ],
       attrs: {
+        ...this.$attrs,
         id: this.safeId(),
         type: this.isRadio ? 'radio' : 'checkbox',
         name: this.getName,


### PR DESCRIPTION
### Describe the PR

Sets `inheritAttrs: false` and applies `this.$attrs` to the underlying input, so that any non prop attributes are transferred to the input.  Applicable to custom form controls that wrap the input in an outer element.

applies to:

- `<b-form-file>`
- `<b-form-checkbox>`
- `<b-form-radio>`

Closes #3752

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
