### PR TITLE
perf(b-table): cache cell slot names each render cycle (addresses #4008)

### DIFF
--- a/src/components/table/helpers/mixin-tbody-row.js
+++ b/src/components/table/helpers/mixin-tbody-row.js
@@ -205,10 +205,11 @@ export default {
       // v-slot attributes are lower-cased by the browser.
       // Switched to round bracket syntax to prevent confusion with
       // dynamic slot name syntax.
-      const slotNames = [`cell(${key})`, `cell(${key.toLowerCase()})`, 'cell()']
-      let $childNodes = this.hasNormalizedSlot(slotNames)
-        ? this.normalizeSlot(slotNames, slotScope)
-        : toString(formatted)
+      // const slotNames = [`cell(${key})`, `cell(${key.toLowerCase()})`, 'cell()']
+      // Slot names are now cached by mixin tbody in `this.$_bodyFieldSlotNameCache`
+      // Will be `null` if no slot (or fallback slot) exists
+      const slotName = this.$_bodyFieldSlotNameCache[key]
+      let $childNodes = slotName ? this.normalizeSlot(slotName, slotScope) : toString(formatted)
       if (this.isStacked) {
         // We wrap in a DIV to ensure rendered as a single cell when visually stacked!
         $childNodes = [h('div', {}, [$childNodes])]

--- a/src/components/table/helpers/mixin-tbody-row.js
+++ b/src/components/table/helpers/mixin-tbody-row.js
@@ -205,7 +205,7 @@ export default {
       // v-slot attributes are lower-cased by the browser.
       // Switched to round bracket syntax to prevent confusion with
       // dynamic slot name syntax.
-      // const slotNames = [`cell(${key})`, `cell(${key.toLowerCase()})`, 'cell()']
+      // We look for slots in this order: `cell(${key})`, `cell(${key.toLowerCase()})`, 'cell()'
       // Slot names are now cached by mixin tbody in `this.$_bodyFieldSlotNameCache`
       // Will be `null` if no slot (or fallback slot) exists
       const slotName = this.$_bodyFieldSlotNameCache[key]

--- a/src/components/table/helpers/mixin-tbody.js
+++ b/src/components/table/helpers/mixin-tbody.js
@@ -37,16 +37,14 @@ export default {
         const cache = {}
         this.computedFields.forEach(field => {
           const key = field.key
-          // Default cell slot name
-          cache[key] = 'cell()'
-          // Data cell slot names can also be one of the following:
-          const slotNames = [`cell(${key})`, `cell(${key.toLowerCase()})`]
-          for (let i = 0; i < slotNames.length && !cache[key]; i++) {
-            const name = slotNames[i]
-            if (this.hasNormalizedSlot(name)) {
-              cache[key] = name
-            }
-          }
+          const fullName = `cell(${key})`
+          const lowerName = `cell(${key.toLowerCase()})`
+          cache[key] =
+            this.hasNormalizedSlot(fullName)
+              ? fullName
+              : this.hasNormalizedSlot(lowerName)
+                ? lowerName
+                : 'cell()'
         })
         // Created as a non-reactive property so to not trigger component updates.
         this.$_bodyFieldSlotNameCache = cache

--- a/src/components/table/helpers/mixin-tbody.js
+++ b/src/components/table/helpers/mixin-tbody.js
@@ -39,12 +39,11 @@ export default {
           const key = field.key
           const fullName = `cell(${key})`
           const lowerName = `cell(${key.toLowerCase()})`
-          cache[key] =
-            this.hasNormalizedSlot(fullName)
-              ? fullName
-              : this.hasNormalizedSlot(lowerName)
-                ? lowerName
-                : 'cell()'
+          cache[key] = this.hasNormalizedSlot(fullName)
+            ? fullName
+            : this.hasNormalizedSlot(lowerName)
+              ? lowerName
+              : 'cell()'
         })
         // Created as a non-reactive property so to not trigger component updates.
         // Must be a fresh object each render.

--- a/src/components/table/helpers/mixin-tbody.js
+++ b/src/components/table/helpers/mixin-tbody.js
@@ -47,6 +47,7 @@ export default {
                 : 'cell()'
         })
         // Created as a non-reactive property so to not trigger component updates.
+        // Must be a fresh object each render.
         this.$_bodyFieldSlotNameCache = cache
 
         // Add static Top Row slot (hidden in visibly stacked mode as we can't control data-label attr)

--- a/src/components/table/helpers/mixin-tbody.js
+++ b/src/components/table/helpers/mixin-tbody.js
@@ -35,6 +35,7 @@ export default {
         // Slots could be dynamic (i.e. `v-if`), so we must compute on each render.
         // Used by tbodyRow mixin render helper.
         const cache = {}
+        const defaultSlotName = this.hasNormalizedSlot('cell()') ? 'cell()' : null
         this.computedFields.forEach(field => {
           const key = field.key
           const fullName = `cell(${key})`
@@ -43,7 +44,7 @@ export default {
             ? fullName
             : this.hasNormalizedSlot(lowerName)
               ? lowerName
-              : 'cell()'
+              : defaultSlotName
         })
         // Created as a non-reactive property so to not trigger component updates.
         // Must be a fresh object each render.

--- a/src/components/table/helpers/mixin-tbody.js
+++ b/src/components/table/helpers/mixin-tbody.js
@@ -30,6 +30,27 @@ export default {
       } else {
         // Table isn't busy, or we don't have a busy slot
 
+        // Create a slot cache for improved performace when looking up cell slot names.
+        // Values will be keyed by the field's `key` and will store the slot's name.
+        // Slots could be dynamic (i.e. `v-if`), so we must compute on each render.
+        // Used by tbodyRow mixin render helper.
+        const cache = {}
+        this.computedFields.forEach(field => {
+          const key = field.key
+          // Default cell slot name
+          cache[key] = 'cell()'
+          // Data cell slot names can also be one of the following:
+          const slotNames = [`cell(${key})`, `cell(${key.toLowerCase()})`]
+          for (let i = 0; i < slotNames.length && !cache[key]; i++) {
+            const name = slotNames[i]
+            if (this.hasNormalizedSlot(name)) {
+              cache[key] = name
+            }
+          }
+        })
+        // Created as a non-reactive property so to not trigger component updates.
+        this.$_bodyFieldSlotNameCache = cache
+
         // Add static Top Row slot (hidden in visibly stacked mode as we can't control data-label attr)
         $rows.push(this.renderTopRow ? this.renderTopRow() : h())
 


### PR DESCRIPTION
### Describe the PR

Will help improve performance (slightly) by not having to compute the possible slot names for each row rendered.

The cell slot names will only be looked-up once each render cycle.

Uses a non-reactive property on the table instance to store the cache.

Closes #4008 (partially)

Performance is still slow when table has 1000+ rows displayed, but is slightly improved.

User should be presenting paginated data (e.g. 100 rows at a time) rather than generating 1000 rows on screen.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other (please describe) performance

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
