### PR TITLE
chore: tooltip/popover directives execute title/content if function before each show

### DIFF
--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -180,6 +180,20 @@ const applyPopover = (el, bindings, vnode) => {
       _scopeId: getScopId($parent, undefined)
     })
     el[BV_POPOVER].__bv_prev_data__ = {}
+    el[BV_POPOVER].$on('show', () => {
+      // Before showing the popover, we update the title
+      // and content if they are functions
+      const data = {}
+      if (isFunction(config.title)) {
+        data.title = config.title()
+      }
+      if (isFunction(config.content)) {
+        data.content = config.content()
+      }
+      if (keys(data).length > 0) {
+        el[BV_POPOVER].updateData(data)
+      }
+    })
   }
   const data = {
     title: config.title,

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -180,7 +180,7 @@ const applyPopover = (el, bindings, vnode) => {
       _scopeId: getScopId($parent, undefined)
     })
     el[BV_POPOVER].__bv_prev_data__ = {}
-    el[BV_POPOVER].$on('show', () => {
+    el[BV_POPOVER].$on('show', () => /* istanbul ignore next: for now */ {
       // Before showing the popover, we update the title
       // and content if they are functions
       const data = {}

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -181,6 +181,14 @@ const applyTooltip = (el, bindings, vnode) => {
       _scopeId: getScopId($parent, undefined)
     })
     el[BV_TOOLTIP].__bv_prev_data__ = {}
+    el[BV_TOOLTIP].$on('show', () => /* istanbul ignore next: for now */ {
+      // Before showing the tooltip, we update the title if it is a function
+      if (isFunction(config.title)) {
+        el[BV_TOOLTIP].updateData({
+          title: config.title()
+        })
+      }
+    })
   }
   const data = {
     title: config.title,


### PR DESCRIPTION
### Describe the PR

Restores revious functionality on the tooltip/popover directives. Ensures, if title/content is a function, that the function is called before the tooltip/popover is opened.

I had missed this when revamping tooltips and popovers.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other (please describe) Fixing a peice of code that I missed when revamping tooltips and popovers

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
