### PR TITLE
fix(b-dropdown-*): ensure class bindings are placed on root element for all dropdown sub-components (closes #4022)

### DIFF
--- a/src/components/dropdown/dropdown-divider.js
+++ b/src/components/dropdown/dropdown-divider.js
@@ -12,15 +12,17 @@ export const props = {
 export const BDropdownDivider = /*#__PURE__*/ Vue.extend({
   name: 'BDropdownDivider',
   functional: true,
-  inheritAttrs: false,
   props,
   render(h, { props, data }) {
-    return h('li', { attrs: { role: 'presentation' } }, [
+    const $attrs = data.attrs || {}
+    delete data.attrs
+    return h('li', mergeData(data, { attrs: { role: 'presentation' } }), [
       h(
         props.tag,
-        mergeData(data, {
+        {
           staticClass: 'dropdown-divider',
           attrs: {
+            ...$attrs,
             role: 'separator',
             'aria-orientation': 'horizontal'
           },

--- a/src/components/dropdown/dropdown-divider.js
+++ b/src/components/dropdown/dropdown-divider.js
@@ -27,7 +27,7 @@ export const BDropdownDivider = /*#__PURE__*/ Vue.extend({
             'aria-orientation': 'horizontal'
           },
           ref: 'divider'
-        })
+        }
       )
     ])
   }

--- a/src/components/dropdown/dropdown-divider.js
+++ b/src/components/dropdown/dropdown-divider.js
@@ -15,20 +15,17 @@ export const BDropdownDivider = /*#__PURE__*/ Vue.extend({
   props,
   render(h, { props, data }) {
     const $attrs = data.attrs || {}
-    delete data.attrs
+    data.attrs = {}
     return h('li', mergeData(data, { attrs: { role: 'presentation' } }), [
-      h(
-        props.tag,
-        {
-          staticClass: 'dropdown-divider',
-          attrs: {
-            ...$attrs,
-            role: 'separator',
-            'aria-orientation': 'horizontal'
-          },
-          ref: 'divider'
-        }
-      )
+      h(props.tag, {
+        staticClass: 'dropdown-divider',
+        attrs: {
+          ...$attrs,
+          role: 'separator',
+          'aria-orientation': 'horizontal'
+        },
+        ref: 'divider'
+      })
     ])
   }
 })

--- a/src/components/dropdown/dropdown-form.js
+++ b/src/components/dropdown/dropdown-form.js
@@ -5,7 +5,6 @@ import { BForm, props as formProps } from '../form/form'
 export const BDropdownForm = /*#__PURE__*/ Vue.extend({
   name: 'BDropdownForm',
   functional: true,
-  inheritAttrs: false,
   props: {
     ...formProps,
     disabled: {
@@ -14,20 +13,26 @@ export const BDropdownForm = /*#__PURE__*/ Vue.extend({
     }
   },
   render(h, { props, data, children }) {
-    return h('li', { attrs: { role: 'presentation' } }, [
+    const $attrs = data.attrs || {}
+    const $listeners = data.on || {}
+    data.attrs = {}
+    data.on = {}
+    return h('li', mergeData(data, { attrs: { role: 'presentation' } }), [
       h(
         BForm,
-        mergeData(data, {
+        {
           ref: 'form',
           staticClass: 'b-dropdown-form',
           class: { disabled: props.disabled },
           props,
           attrs: {
+            ...$attrs,
             disabled: props.disabled,
             // Tab index of -1 for keyboard navigation
             tabindex: props.disabled ? null : '-1'
-          }
-        }),
+          },
+          on: $listeners
+        },
         children
       )
     ])

--- a/src/components/dropdown/dropdown-group.js
+++ b/src/components/dropdown/dropdown-group.js
@@ -33,11 +33,12 @@ export const props = {
 export const BDropdownGroup = /*#__PURE__*/ Vue.extend({
   name: 'BDropdownGroup',
   functional: true,
-  inheritAttrs: false,
   props,
   render(h, { props, data, slots, scopedSlots }) {
     const $slots = slots()
     const $scopedSlots = scopedSlots || {}
+    const $attrs = data.attrs || {}
+    data.attrs = {}
     let header
     let headerId = null
 
@@ -62,18 +63,19 @@ export const BDropdownGroup = /*#__PURE__*/ Vue.extend({
       .join(' ')
       .trim()
 
-    return h('li', { attrs: { role: 'presentation' } }, [
+    return h('li', mergeData(data, { attrs: { role: 'presentation' } }), [
       header || h(),
       h(
         'ul',
-        mergeData(data, {
+        {
           staticClass: 'list-unstyled',
           attrs: {
+            ...$attrs,
             id: props.id || null,
             role: 'group',
             'aria-describedby': adb || null
           }
-        }),
+        },
         normalizeSlot('default', {}, $scopedSlots, $slots)
       )
     ])

--- a/src/components/dropdown/dropdown-header.js
+++ b/src/components/dropdown/dropdown-header.js
@@ -20,23 +20,25 @@ export const props = {
 export const BDropdownHeader = /*#__PURE__*/ Vue.extend({
   name: 'BDropdownHeader',
   functional: true,
-  inheritAttrs: false,
   props,
   render(h, { props, data, children }) {
-    return h('li', { attrs: { role: 'presentation' } }, [
+    const $attrs = data.attrs || {}
+    data.attrs = {}
+    return h('li', mergeData(data, { attrs: { role: 'presentation' } }), [
       h(
         props.tag,
-        mergeData(data, {
+        {
           staticClass: 'dropdown-header',
           class: {
             [`text-${props.variant}`]: props.variant
           },
           attrs: {
+            ...$attrs,
             id: props.id || null,
             role: 'heading'
           },
           ref: 'header'
-        }),
+        },
         children
       )
     ])

--- a/src/components/dropdown/dropdown-text.js
+++ b/src/components/dropdown/dropdown-text.js
@@ -5,7 +5,6 @@ import { mergeData } from 'vue-functional-data-merge'
 export const BDropdownText = /*#__PURE__*/ Vue.extend({
   name: 'BDropdownText',
   functional: true,
-  inheritAttrs: false,
   props: {
     tag: {
       type: String,
@@ -17,17 +16,20 @@ export const BDropdownText = /*#__PURE__*/ Vue.extend({
     }
   },
   render(h, { props, data, children }) {
-    return h('li', { attrs: { role: 'presentation' } }, [
+    const $attrs = data.attrs || {}
+    data.attrs = {}
+    return h('li', mergeData(data, { attrs: { role: 'presentation' } }), [
       h(
         props.tag,
-        mergeData(data, {
+        {
           staticClass: 'b-dropdown-text',
           class: {
             [`text-${props.variant}`]: props.variant
           },
           props,
+          attrs: $attrs,
           ref: 'text'
-        }),
+        },
         children
       )
     ])


### PR DESCRIPTION
### Describe the PR

Makes all dropdown sub-components behave the same as `<b-drodpown-item>` and `<b-dropdown-item-button>` when it comes to class bindings being placed on sub-component's root element

Non prop attributes are transferred to the inner element

Closes #4022 

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
