### PR TITLE
chore(b-toaster): clean out old toaster scss comments

### DIFF
--- a/src/components/toast/_toaster-transition.scss
+++ b/src/components/toast/_toaster-transition.scss
@@ -1,6 +1,5 @@
 // --- <b-toast> custom transition SCSS ---
 
-// This is still a work in progress... will be changing
 // PortalVue appears to have issues with transition classes on portaled items
 
 .b-toaster {
@@ -41,47 +40,6 @@
 
       &.b-toaster-leave-to {
       }
-
-      /*
-      &.b-toaster-enter-active,
-      &.b-toaster-enter-to {
-        .toast.fade {
-          // Delay the appearance of the toast until
-          // the move transition has completed
-          transition-delay: 0.175s;
-        }
-      }
-
-      &.b-toaster-move {
-        transition: transform 0.175s;
-        // transition-delay: 0.175s;
-      }
-
-      &.b-toaster-enter-active {
-        z-index: 0;
-      }
-
-      &.b-toaster-leave-active {
-        transition: transform 0.175s;
-      }
-
-      &.b-toaster-leave,
-      &.b-toaster-leave-active {
-        position: absolute;
-        z-index: 0;
-        transition-delay: 0.175s;
-
-        .toast.fade {
-          transition-delay: 0s;
-        }
-      }
-
-      &.b-toaster-leave {
-      }
-
-      &.b-toaster-leave-to {
-      }
-      */
     }
   }
 }

--- a/src/components/toast/_toaster.scss
+++ b/src/components/toast/_toaster.scss
@@ -1,8 +1,5 @@
 // --- <b-toaster> custom SCSS ---
 
-// NOTE:
-// This SCSS is prelimiary, and may change in the future.
-
 // Base toaster styling
 .b-toaster {
   z-index: $b-toaster-zindex;


### PR DESCRIPTION
### Describe the PR

Cleans out the old commented out sections of b-toaster scss

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [x] Other (please describe) cleanup

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
