### PR TITLE
chore(docs): hotfix slot names in table package.json meta

### DIFF
--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -201,27 +201,27 @@
         ],
         "slots": [
           {
-            "name": "cell[key]",
+            "name": "cell(key)",
             "description": "Scoped slot for custom data rendering of field data. 'key' is the fields key name. See docs for scoped data"
           },
           {
-            "name": "cell[]",
+            "name": "cell()",
             "description": "Default scoped slot for custom data rendering of field data. See docs for scoped data"
           },
           {
-            "name": "head[key]",
+            "name": "head(key)",
             "description": "Scoped slot for custom rendering of field header. 'key' is the fields key name. See docs for scoped header"
           },
           {
-            "name": "head[]",
+            "name": "head()",
             "description": "Default scoped slot for custom rendering of field header. See docs for scoped header"
           },
           {
-            "name": "foot[key]",
+            "name": "foot(key)",
             "description": "Scoped slot for custom rendering of field footer. 'key' is the fields key name. See docs for scoped footer"
           },
           {
-            "name": "foot[]",
+            "name": "foot()",
             "description": "Default scoped slot for custom rendering of field footer. See docs for scoped footer"
           },
           {
@@ -402,27 +402,27 @@
         ],
         "slots": [
           {
-            "name": "cell[key]",
+            "name": "cell(key)",
             "description": "Scoped slot for custom data rendering of field data. 'key' is the fields key name. See docs for scoped data"
           },
           {
-            "name": "cell[]",
+            "name": "cell()",
             "description": "Default scoped slot for custom data rendering of field data. See docs for scoped data"
           },
           {
-            "name": "head[key]",
+            "name": "head(key)",
             "description": "Scoped slot for custom rendering of field header. 'key' is the fields key name. See docs for scoped header"
           },
           {
-            "name": "head[]",
+            "name": "head()",
             "description": "Default scoped slot for custom rendering of field header. See docs for scoped header"
           },
           {
-            "name": "foot[key]",
+            "name": "foot(key)",
             "description": "Scoped slot for custom rendering of field footer. 'key' is the fields key name. See docs for scoped footer"
           },
           {
-            "name": "foot[]",
+            "name": "foot()",
             "description": "Default scoped slot for custom rendering of field footer. See docs for scoped footer"
           },
           {


### PR DESCRIPTION
### Describe the PR

Fixes the published docs (master branch) for table slot names in package.json meta

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
