### PR TITLE
chore: release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ This patch release includes a few minor bug fixes and documentation updates.
   [#4052](https://github.com/bootstrap-vue/bootstrap-vue/issues/4052))
   ([#4055](https://github.com/bootstrap-vue/bootstrap-vue/issues/4055))
   ([9ccfe4c](https://github.com/bootstrap-vue/bootstrap-vue/commit/9ccfe4c))
-- **b-table:** handle filter as an object when using items provider, and prevent duplicate provider calls
-  on mount (fixes [#4065](https://github.com/bootstrap-vue/bootstrap-vue/issues/4065))
+- **b-table:** handle filter as an object when using items provider, and prevent duplicate provider
+  calls on mount (fixes [#4065](https://github.com/bootstrap-vue/bootstrap-vue/issues/4065))
   ([#4068](https://github.com/bootstrap-vue/bootstrap-vue/issues/4068))
   ([9ddd115](https://github.com/bootstrap-vue/bootstrap-vue/commit/9ddd115))
 - **b-table:** remove extra slashes in mixins imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 > [standard-version](https://github.com/conventional-changelog/standard-version) for commit
 > guidelines.
 
+<a name="2.0.2"></a>
+
+## [v2.0.2](https://github.com/bootstrap-vue/bootstrap-vue/compare/v2.0.1...v2.0.2)
+
+Released: 2019-09-20
+
+This patch release includes a few minor bug fixes and documentation updates.
+
+### Bug Fixes v2.0.2
+
+- **b-popover, b-tooltip:** ensure prop `boundary-padding` is passed to popper instance (fixes
+  [#4131](https://github.com/bootstrap-vue/bootstrap-vue/issues/4131))
+  ([#4133](https://github.com/bootstrap-vue/bootstrap-vue/issues/4133))
+  ([a54a647](https://github.com/bootstrap-vue/bootstrap-vue/commit/a54a647))
+- **b-collapse:** make `id` prop not required
+  ([#4109](https://github.com/bootstrap-vue/bootstrap-vue/issues/4109))
+  ([4f935ce](https://github.com/bootstrap-vue/bootstrap-vue/commit/4f935ce))
+- **tables:** add in missing Bootstrap variant class `bg-active` for dark tables
+  ([#4098](https://github.com/bootstrap-vue/bootstrap-vue/issues/4098))
+  ([d9900ab](https://github.com/bootstrap-vue/bootstrap-vue/commit/d9900ab))
+- **tables:** ensure row variant `active` (class `table-active`) takes precedence over other row
+  variants (addresses [#3008](https://github.com/bootstrap-vue/bootstrap-vue/issues/3008))
+  ([#4127](https://github.com/bootstrap-vue/bootstrap-vue/issues/4127))
+  ([fdb8bb6](https://github.com/bootstrap-vue/bootstrap-vue/commit/fdb8bb6))
+- **tooltips, popovers:** hide trigger element `title` attribute during show delay (fixes
+  [#4114](https://github.com/bootstrap-vue/bootstrap-vue/issues/4114))
+  ([#4120](https://github.com/bootstrap-vue/bootstrap-vue/issues/4120))
+  ([2dd8d5a](https://github.com/bootstrap-vue/bootstrap-vue/commit/2dd8d5a))
+
 <a name="2.0.1"></a>
 
 ## [v2.0.1](https://github.com/bootstrap-vue/bootstrap-vue/compare/v2.0.0...v2.0.1)

--- a/docs/markdown/misc/third-party/README.md
+++ b/docs/markdown/misc/third-party/README.md
@@ -1,0 +1,55 @@
+# Third party libraries
+
+> There are several 3rd party modules that you can use to add additional functionality and features
+> to your BootstrapVue project.
+
+Notes:
+
+- The components and libraries listed here are not directly endorsed by BootstrapVue, and are listed
+  here only for convenience, and is by no means a complete list.
+- These libraries may have additional dependencies.
+
+## Components
+
+Note: Many of the 3rd party components listed are lacking accessibility features and may not be
+fully WAI-ARIA compliant, nor accessible to keyboard-only and/or screen-reader users.
+
+### Type Ahead
+
+- [Vue Bootstrap TypeAhead](https://github.com/alexurquhart/vue-bootstrap-typeahead) _Note: This
+  component is keyboard accessible, but is not fully WAI-ARIA compliant_
+
+### Date and Time Pickers
+
+- [Vue AirBnB Style Datepicker](https://mikaeledebro.gitbooks.io/vue-airbnb-style-datepicker/)
+- [Vue Datepicker](https://livelybone.github.io/vue/vue-datepicker/) _Note: Not WAI-ARIA compliant_
+- [Vue date pick](https://dbrekalo.github.io/vue-date-pick/) _Note: Not WAI-ARIA compliant_
+- [Vue2 date range picker](https://innologica.github.io/vue2-daterange-picker/) _Note: Not WAI-ARIA
+  compliant_
+
+### Commenting and discussion
+
+- [Vue Disqus](https://github.com/ktquez/vue-disqus)
+
+### Icons
+
+- [Vue Font Awesome](https://fontawesome.com/how-to-use/on-the-web/using-with/vuejs)
+- [Vue Icon](https://github.com/qinshenxue/vue-icon)
+- [Vue Ionicons](https://mazipan.github.io/vue-ionicons/)
+- [Vue Unicons](https://antonreshetov.github.io/vue-unicons/)
+
+### Charting
+
+- [Vue Chart.js](https://vue-chartjs.org/)
+- [Vue Highcharts](https://github.com/weizhenye/vue-highcharts)
+- [Vue Graph](https://github.com/juijs/vue-graph)
+
+## Form validation
+
+- [VeeValidate](https://logaretm.github.io/vee-validate/)
+- [Vuelidate](https://github.com/vuelidate/vuelidate/)
+
+## Site generation
+
+- [NuxtJS](https://nuxtjs.org) - Static + SPA+ PWA + SSR
+- [Gridsome](https://gridsome.org) - Static + SPA + PWA

--- a/docs/markdown/misc/third-party/meta.json
+++ b/docs/markdown/misc/third-party/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Third party libraries",
+  "slug": "third-party",
+  "description": "There are several 3rd party libraries that you can use to add additional functionality and features to your BootstrapVue project."
+}

--- a/docs/markdown/reference/color-variants/README.md
+++ b/docs/markdown/reference/color-variants/README.md
@@ -16,7 +16,7 @@
 - `dark` - <span class="text-dark">Dark</span>
 
 The base variants will translate to various Bootstrap v4 contextual class names based on the
-component (and variant purpose) where they are used.
+component (and variant purpose) where they are used. See the sections below for details.
 
 ## Background and border variants
 
@@ -24,10 +24,10 @@ All the **base variants** plus:
 
 - `transparent`
 
-These translate to class names `bg-<variant>` for backgrounds and `border-<variant>` for borders.
+These translate to class names `bg-{variant}` for backgrounds and `border-{variant}` for borders.
 
-These variants are used by components (such as `<b-card>`, `<b-jumbotron>` and `<b-modal>`) that
-provide `bg-variant`, `*-bg-variant`, `border-variant` and `*-border-variant` props
+These variants are used by components (such as `<b-card>`, `<b-jumbotron>`, `<b-modal>`, etc.) that
+provide `bg-variant`, `*-bg-variant`, `border-variant` and `*-border-variant` props.
 
 ## Text variants
 
@@ -37,10 +37,10 @@ All the **base variants** plus:
 - `white`
 - `black`
 
-These translate to class names `text-<variant>`
+These translate to class names `text-{variant}`
 
-These variants are used by components (such as `<b-card>`, `<b-jumbotron>` and `<b-modal>`) that
-provide `text-variant` and `*-text-variant` props
+These variants are used by components (such as `<b-card>`, `<b-jumbotron>`, `<b-modal>`, etc.) that
+provide `text-variant` and `*-text-variant` props.
 
 ## Component specific variants
 
@@ -51,22 +51,22 @@ Some Bootstrap v4 components require additional CSS styling, or additional pseud
 
 All the **base variants**
 
-These translate to class names `alert-<variant>`.
+These translate to class names `alert-{variant}`.
 
 ### Badge variants
 
 All the **base variants**
 
-These translate to class names `badge-<variant>`.
+These translate to class names `badge-{variant}`.
 
 ### Button variants
 
 All the **base variants** plus:
 
-- `outline-<base variant>`
-- `link` which renders the button with the look of a link but retains button padding and margins.
+- `outline-{base variant}` which generates an outline button version of the base variant
+- `link` which renders the button with the look of a link but retains button padding and margins
 
-These translate to class names `btn-<variant>` and `btn-outline-<variant>`.
+These translate to class names `btn-{variant}` and `btn-outline-{variant}`.
 
 Note the `link` variant does not have an outline version.
 
@@ -76,27 +76,30 @@ All the **base variants** plus:
 
 - `active`
 
-These variants translate to class names `table-<variant>`.
+These variants translate to class names `table-{variant}`.
 
-When the table has the `dark` prop set, the variants translate to the `bg-<variant>` classes.
+When the table has the `dark` prop set, the variants translate to the `bg-{variant}` classes.
+
+Note that the `active` variant is only applicable to `<tr>` elements within the `<tbody>`, and can
+not be applied to individual table cells or used as the `table-variant`.
 
 ### Popover variants
 
 All the **base variants**
 
-These translate to BootstrapVue custom class names `b-popover-<variant>`.
+These translate to BootstrapVue custom class names `b-popover-{variant}`.
 
 ### Tooltip variants
 
 All the **base variants**
 
-These translate to BootstrapVue custom class names `b-tooltip-<variant>`.
+These translate to BootstrapVue custom class names `b-tooltip-{variant}`.
 
 ### Toast variants
 
 All the **base variants**
 
-These translate to BootstrapVue custom class names `b-toast-<variant>`.
+These translate to BootstrapVue custom class names `b-toast-{variant}`.
 
 ## Using variant classes
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "codesandbox": "^2.1.10",
     "core-js": ">=2.6.5 <3.0.0",
     "cross-env": "^5.2.1",
-    "eslint": "^6.3.0",
+    "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-config-vue": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "babel-plugin-istanbul": "^5.2.0",
     "clean-css-cli": "^4.3.0",
     "codecov": "^3.6.0",
-    "codemirror": "^5.48.4",
+    "codemirror": "^5.49.0",
     "codesandbox": "^2.1.10",
     "core-js": ">=2.6.5 <3.0.0",
     "cross-env": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-istanbul": "^5.2.0",
     "clean-css-cli": "^4.3.0",
-    "codecov": "^3.5.0",
+    "codecov": "^3.6.0",
     "codemirror": "^5.48.4",
     "codesandbox": "^2.1.10",
     "core-js": ">=2.6.5 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "codemirror": "^5.48.4",
     "codesandbox": "^2.1.10",
     "core-js": ">=2.6.5 <3.0.0",
-    "cross-env": "^5.2.1",
+    "cross-env": "^6.0.0",
     "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",
     "eslint-config-standard": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-istanbul": "^5.2.0",
     "clean-css-cli": "^4.3.0",
-    "codecov": "^3.6.0",
+    "codecov": "^3.6.1",
     "codemirror": "^5.49.0",
     "codesandbox": "^2.1.10",
     "core-js": ">=2.6.5 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-markdown": "^1.0.0",
     "eslint-plugin-node": "^10.0.0",
-    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "eslint-plugin-vue": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "nuxt": "^2.9.2",
     "postcss-cli": "^6.1.3",
     "prettier": "1.14.3",
-    "rollup": "^1.21.2",
+    "rollup": "^1.21.3",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-vue",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "BootstrapVue, with over 40 plugins and more than 80 custom components, provides one of the most comprehensive implementations of Bootstrap v4 components and grid system for Vue.js. With extensive and automated WAI-ARIA accessibility markup.",
   "main": "dist/bootstrap-vue.common.js",
   "web": "dist/bootstrap-vue.js",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "nuxt": "^2.9.2",
     "postcss-cli": "^6.1.3",
     "prettier": "1.14.3",
-    "rollup": "^1.21.3",
+    "rollup": "^1.21.4",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -88,6 +88,10 @@ $bv-enable-table-stacked: true !default;
 $b-table-stacked-heading-width: 40% !default;
 $b-table-stacked-gap: 1rem !default;
 
+// Bootstrap v4.3 is missing the "active" variant for dark tables
+// Which translates to `bg-active`, but only for tables
+$table-dark-active-bg: $table-dark-hover-bg !default;
+
 // --- Toasts ---
 
 // Toaster defaults

--- a/src/components/collapse/README.md
+++ b/src/components/collapse/README.md
@@ -63,7 +63,8 @@ the `visible` prop.
 
 Note, when using `v-model` to control `<b-collapse>`, the `aria-*` attributes and class `collapsed`
 are not automatically placed on the trigger button (as is the case when using the `v-b-toggle`
-directive). In this example we must control them ourselves.
+directive). In this example we **must control the attributes ourselves** for proper accessibility
+support.
 
 ```html
 <template>
@@ -120,7 +121,8 @@ multiple target IDs using modifiers:
 ## Accordion support
 
 Turn a group of `<b-collapse>` components into an accordion by supplying an accordion group
-identifier via the `accordion` prop:
+identifier via the `accordion` prop. Note that only one collapse in an accordion group can be open
+at a time.
 
 ```html
 <template>
@@ -192,7 +194,7 @@ identifier via the `accordion` prop:
 - If using the `v-model` feature of `<b-collapse>` in accordion mode, do not bind the `v-model` or
   `visible` prop of all the collapses in the accordion group to the same variable!
 - Ensure, at most, only one `<b-collapse>` in the accordion group has the `visible` prop and/or
-  `v-model` set to `true`.
+  `v-model` set to `true`. Only one collapse in an accordion group can be open at a time.
 
 ## Hiding and showing content in the toggle button based on collapse state
 

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -1,4 +1,5 @@
 import Vue from '../../utils/vue'
+import idMixin from '../../mixins/id'
 import listenOnRootMixin from '../../mixins/listen-on-root'
 import normalizeSlotMixin from '../../mixins/normalize-slot'
 import { isBrowser } from '../../utils/env'
@@ -32,16 +33,12 @@ const EventOptions = { passive: true, capture: false }
 // @vue/component
 export const BCollapse = /*#__PURE__*/ Vue.extend({
   name: 'BCollapse',
-  mixins: [listenOnRootMixin, normalizeSlotMixin],
+  mixins: [idMixin, listenOnRootMixin, normalizeSlotMixin],
   model: {
     prop: 'visible',
     event: 'input'
   },
   props: {
-    id: {
-      type: String,
-      required: true
-    },
     isNav: {
       type: Boolean,
       default: false
@@ -105,7 +102,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
     })
     // Listen for "Sync state" requests from `v-b-toggle`
     this.listenOnRoot(EVENT_STATE_REQUEST, id => {
-      if (id === this.id) {
+      if (id === this.safeId()) {
         this.$nextTick(this.emitSync)
       }
     })
@@ -174,17 +171,17 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
     emitState() {
       this.$emit('input', this.show)
       // Let v-b-toggle know the state of this collapse
-      this.$root.$emit(EVENT_STATE, this.id, this.show)
+      this.$root.$emit(EVENT_STATE, this.safeId(), this.show)
       if (this.accordion && this.show) {
         // Tell the other collapses in this accordion to close
-        this.$root.$emit(EVENT_ACCORDION, this.id, this.accordion)
+        this.$root.$emit(EVENT_ACCORDION, this.safeId(), this.accordion)
       }
     },
     emitSync() {
       // Emit a private event every time this component updates to ensure
       // the toggle button is in sync with the collapse's state
       // It is emitted regardless if the visible state changes
-      this.$root.$emit(EVENT_STATE_SYNC, this.id, this.show)
+      this.$root.$emit(EVENT_STATE_SYNC, this.safeId(), this.show)
     },
     checkDisplayBlock() {
       // Check to see if the collapse has `display: block !important;` set.
@@ -211,7 +208,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
       }
     },
     handleToggleEvt(target) {
-      if (target !== this.id) {
+      if (target !== this.safeId()) {
         return
       }
       this.toggle()
@@ -220,7 +217,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
       if (!this.accordion || accordion !== this.accordion) {
         return
       }
-      if (openedId === this.id) {
+      if (openedId === this.safeId()) {
         // Open this collapse if not shown
         if (!this.show) {
           this.toggle()
@@ -243,7 +240,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
       {
         class: this.classObject,
         directives: [{ name: 'show', value: this.show }],
-        attrs: { id: this.id || null },
+        attrs: { id: this.safeId() },
         on: { click: this.clickHandler }
       },
       [this.normalizeSlot('default')]

--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -623,7 +623,32 @@ hidden. You can disable this behaviour by setting the `no-close-on-backdrop` pro
 To disable the fading transition/animation when modal opens and closes, just set the prop `no-fade`
 on the `<b-modal>` component.
 
-### Disabling built-in buttons
+### Footer button sizing
+
+Fancy smaller or larger buttons in the default footer? Simply set the `button-size` prop to `'sm'`
+for small buttons, or `'lg'` for larger buttons.
+
+```html
+<div>
+  <b-button v-b-modal.modal-footer-sm>Small Footer Buttons</b-button>
+  <b-button v-b-modal.modal-footer-lg>Large Footer Buttons</b-button>
+
+  <b-modal id="modal-footer-sm" title="BootstrapVue" button-size="sm">
+    <p class="my-2">This modal has small footer buttons</p>
+  </b-modal>
+
+  <b-modal id="modal-footer-lg" title="BootstrapVue" button-size="lg">
+    <p class="my-2">This modal has large footer buttons</p>
+  </b-modal>
+</div>
+
+<!-- modal-footer-btn-sizes.vue -->
+```
+
+The prop `button-size` has no effect if you have provided your own footer via the
+[`modal-footer`](#custom-rendering-with-slots) slot.
+
+### Disabling built-in footer buttons
 
 You can disable the built-in footer buttons programmatically.
 

--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -27,7 +27,7 @@ using the `ok-title` and `cancel-title` props, or using the named slots `modal-o
 
 `<b-modal>` supports close on ESC (enabled by default), close on backdrop click (enabled by
 default), and the `X` close button in the header (enabled by default). These features may be
-disabled by setting the the props `no-close-on-esc`, `no-close-on-backdrop`, and `hide-header-close`
+disabled by setting the props `no-close-on-esc`, `no-close-on-backdrop`, and `hide-header-close`
 respectively.
 
 You can override the modal title via the named slot `modal-title`, override the header completely

--- a/src/components/popover/package.json
+++ b/src/components/popover/package.json
@@ -165,11 +165,11 @@
         "slots": [
           {
             "name": "title",
-            "description": "Optional slot for title (HTML supported)"
+            "description": "Optional slot for title (HTML/components supported)"
           },
           {
             "name": "default",
-            "description": "Slot for content (HTML supported)"
+            "description": "Slot for content (HTML/components supported)"
           }
         ]
       }

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -47,7 +47,7 @@ export const BPopover = /*#__PURE__*/ Vue.extend({
       default: () => getComponentConfig(NAME, 'boundary')
     },
     boundaryPadding: {
-      type: Number,
+      type: [Number, String],
       default: () => getComponentConfig(NAME, 'boundaryPadding')
     }
   },
@@ -59,7 +59,7 @@ export const BPopover = /*#__PURE__*/ Vue.extend({
     updateContent() {
       // Tooltip: Default slot is `title`
       // Popover: Default slot is `content`, `title` slot is title
-      // We pass a scoped slot function by default (v2.6x)
+      // We pass a scoped slot function references by default (Vue v2.6x)
       // And pass the title prop as a fallback
       this.setContent(this.$scopedSlots.default || this.content)
       this.setTitle(this.$scopedSlots.title || this.title)

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -1039,7 +1039,7 @@ footer cells that do not have an explicit scoped slot provided.
 
       <!-- A custom formatted header cell for field 'name' -->
       <template v-slot:head(name)="data">
-        <span class="text-info">{{ data.label.toUpperCase() }}</b>
+        <span class="text-info">{{ data.label.toUpperCase() }}</span>
       </template>
 
       <!-- A custom formatted footer cell for field 'name' -->

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -1525,10 +1525,17 @@ element. Rows that are selected rows will have a class of `b-row-selected` appli
 element.
 
 Use the prop `selected-variant` to apply a Bootstrap theme color to the selected row(s). Note, due
-to the order that the table variants are defined in Bootstrap's CSS, any row-variant may take
+to the order that the table variants are defined in Bootstrap's CSS, any row-variant _might_ take
 precedence over the `selected-variant`. You can set `selected-variant` to an empty string if you
 will be using other means to convey that a row is selected (such as a scoped field slot in the below
 example).
+
+The `selected-variant` can be any of the
+[standard (or custom) bootstrap base color variants](/docs/reference/color-variants), or the special
+[table `active` variant](/docs/reference/color-variants#table-variants).
+
+For accessibility reasons (specifically for color blind users), it is highly recommended to always
+provide some other visual means of conveying that a row is selected, as shown in the example below.
 
 ```html
 <template>
@@ -1541,7 +1548,7 @@ example).
       ref="selectableTable"
       selectable
       :select-mode="selectMode"
-      selected-variant="success"
+      selected-variant="active"
       :items="items"
       :fields="fields"
       @row-selected="onRowSelected"

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -1532,10 +1532,12 @@ example).
 
 The `selected-variant` can be any of the
 [standard (or custom) bootstrap base color variants](/docs/reference/color-variants), or the special
-[table `active` variant](/docs/reference/color-variants#table-variants).
+[table `active` variant](/docs/reference/color-variants#table-variants) which takes precedence over
+any specific row or cell variants.
 
-For accessibility reasons (specifically for color blind users), it is highly recommended to always
-provide some other visual means of conveying that a row is selected, as shown in the example below.
+For accessibility reasons (specifically for color blind users, or users with color contrast issues),
+it is highly recommended to always provide some other visual means of conveying that a row is
+selected, such as shown in the example below.
 
 ```html
 <template>

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -35,6 +35,30 @@
     }
   }
 
+  // Re-declare `table-active` class here so that it can take
+  // precedence over row variants when used on selectable rows
+  // Class can only be applied to rows and not individual cells
+  > tbody > .table-active {
+    &,
+    > th,
+    > td {
+      background-color: $table-active-bg;
+    }
+  }
+
+  // Add special hover styling for `table-active` row variant
+  &.table-hover > tbody > tr.table-active:hover {
+    td,
+    th {
+      color: $table-hover-color;
+      // `$table-hover-bg` default is a very transparent black
+      // We overlay it over the background color to achieve the
+      // same color effect while keeping the background solid
+      background-image: linear-gradient($table-hover-bg, $table-hover-bg);
+      background-repeat: no-repeat;
+    }
+  }
+
   // Add in missing `bg-active` class for table tbody rows
   // Bootstrap v4.3 is missing this for dark tables
   // `bg-active` class cannot be applied to individual cells
@@ -42,7 +66,22 @@
     &,
     > th,
     > td {
-      background-color: $table-dark-active-bg;
+      // Important is needed to override the standard `bg-variants`
+      // as the also use `!important`
+      background-color: $table-dark-active-bg !important;
+    }
+  }
+
+  // Add special hover styling for `bg-active` row variant (dark tables)
+  &.table-hover.table-dark > tbody > tr.bg-active:hover {
+    td,
+    th {
+      color: $table-dark-hover-color;
+      // `$table-dark-hover-bg` default is a very transparent white
+      // We overlay it over the background color to achieve the
+      // same color effect while keeping the background solid
+      background-image: linear-gradient($table-dark-hover-bg, $table-dark-hover-bg);
+      background-repeat: no-repeat;
     }
   }
 }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -34,6 +34,17 @@
       caption-side: top !important;
     }
   }
+
+  // Add in missing `bg-active` class for table tbody rows
+  // Bootstrap v4.3 is missing this for dark tables
+  // `bg-active` class cannot be applied to individual cells
+  > tbody > .bg-active {
+    &,
+    > th,
+    > td {
+      background-color: $table-dark-active-bg;
+    }
+  }
 }
 
 // --- Table sticky header styling ---

--- a/src/components/toast/README.md
+++ b/src/components/toast/README.md
@@ -481,12 +481,13 @@ for generating more complex toast content:
 
 <!-- toasts-advanced.vue -->
 ```
+
 ## Alerts versus toasts
 
-In some cases you may need just a simple alert style message (i.e. cookie usage notifications, etc.).
-In these cases is is usually better to use an fixed position alert instead of a toast, by applying a
-few Bootstrap [utility classes](/docs/reference/utility-classes) and a small bit of custom styling
-on a [`<b-alert>`](/docs/components/alert) component:
+In some cases you may need just a simple alert style message (i.e. cookie usage notifications,
+etc.). In these cases is is usually better to use an fixed position alert instead of a toast, by
+applying a few Bootstrap [utility classes](/docs/reference/utility-classes) and a small bit of
+custom styling on a [`<b-alert>`](/docs/components/alert) component:
 
 ```html
 <template>
@@ -533,12 +534,12 @@ export default {
 <!-- fixed-position-alerts.vue -->
 ```
 
-We use class `position-fixed` to set the positioning to fixed within the user's viewport, and
-either class `fixed-bottom` or `fixed-top` to position the alert on the bottom or top of the
-viewport. Class `m-0` removes the default margins around the alert and `rounded-0` removes the
-default rounded corners.  We also set the `z-index` to a large value to ensure the alert apepars
-over any other content on the page (the default for `fixed-top` and `fixed-bottom` is `1030`). You
-may need to adjust the `z-index` for your specific layout.
+We use class `position-fixed` to set the positioning to fixed within the user's viewport, and either
+class `fixed-bottom` or `fixed-top` to position the alert on the bottom or top of the viewport.
+Class `m-0` removes the default margins around the alert and `rounded-0` removes the default rounded
+corners. We also set the `z-index` to a large value to ensure the alert appears over any other
+content on the page (the default for `fixed-top` and `fixed-bottom` is `1030`). You may need to
+adjust the `z-index` for your specific layout.
 
 Since the alert markup remains in the DOM where you placed the `<b-alert>` component, it's tab
 sequence (for accessing the dismiss button) is easily accessible to screen reader and keyboard-only

--- a/src/components/toast/README.md
+++ b/src/components/toast/README.md
@@ -481,6 +481,68 @@ for generating more complex toast content:
 
 <!-- toasts-advanced.vue -->
 ```
+## Alerts versus toasts
+
+In some cases you may need just a simple alert style message (i.e. cookie usage notifications, etc.).
+In these cases is is usually better to use an fixed position alert instead of a toast, by applying a
+few Bootstrap [utility classes](/docs/reference/utility-classes) and a small bit of custom styling
+on a [`<b-alert>`](/docs/components/alert) component:
+
+```html
+<template>
+  <div>
+    <b-button size="sm" @click="showBottom = !showBottom">
+      {{ showBottom ? 'Hide' : 'Show' }} Fixed bottom Alert
+    </b-button>
+    <b-alert
+      v-model="showBottom"
+      class="position-fixed fixed-bottom m-0 rounded-0"
+      style="z-index: 2000;"
+      variant="warning"
+      dismissible
+    >
+      Fixed position (bottom) alert!
+    </b-alert>
+
+    <b-button size="sm" @click="showTop = !showTop">
+      {{ showTop ? 'Hide' : 'Show' }} Fixed top Alert
+    </b-button>
+    <b-alert
+      v-model="showTop"
+      class="position-fixed fixed-top m-0 rounded-0"
+      style="z-index: 2000;"
+      variant="success"
+      dismissible
+    >
+      Fixed position (top) alert!
+    </b-alert>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      showBottom: false,
+      showTop: false
+    }
+  }
+}
+</script>
+
+<!-- fixed-position-alerts.vue -->
+```
+
+We use class `position-fixed` to set the positioning to fixed within the user's viewport, and
+either class `fixed-bottom` or `fixed-top` to position the alert on the bottom or top of the
+viewport. Class `m-0` removes the default margins around the alert and `rounded-0` removes the
+default rounded corners.  We also set the `z-index` to a large value to ensure the alert apepars
+over any other content on the page (the default for `fixed-top` and `fixed-bottom` is `1030`). You
+may need to adjust the `z-index` for your specific layout.
+
+Since the alert markup remains in the DOM where you placed the `<b-alert>` component, it's tab
+sequence (for accessing the dismiss button) is easily accessible to screen reader and keyboard-only
+users.
 
 ## Accessibility
 
@@ -492,6 +554,9 @@ Additionally, `aria-atomic="true"` is automatically set to ensure that the entir
 announced as a single (atomic) unit, rather than announcing what was changed (which could lead to
 problems if you only update part of the toast's content, or if displaying the same toast content at
 a later point in time).
+
+If you just need a single simple message to appear along the bottom or top of the user's window, use
+a [fixed position `<b-alert>`](#alerts-versus-toasts) instead.
 
 ### Accessibility tips
 

--- a/src/components/tooltip/helpers/bv-tooltip.js
+++ b/src/components/tooltip/helpers/bv-tooltip.js
@@ -414,6 +414,8 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
       const tip = this.getTemplateElement()
       if (!tip || !this.localShow) {
         /* istanbul ignore next */
+        this.restoreTitle()
+        /* istanbul ignore next */
         return
       }
 
@@ -613,7 +615,7 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
       const target = this.getTarget()
       if (target && hasAttr(target, 'data-original-title')) {
         setAttr(target, 'title', getAttr(target, 'data-original-title') || '')
-        setAttr(target, 'data-original-title', '')
+        removeAttr(target, 'data-original-title')
       }
     },
     //
@@ -886,9 +888,14 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
       if (!this.computedDelay.show) {
         this.show()
       } else {
+        // Hide any title attribute while enter delay is active
+        this.fixTitle()
         this.hoverTimeout = setTimeout(() => {
+          /* istanbul ignore else */
           if (this.$_hoverState === 'in') {
             this.show()
+          } else if (!this.localShow) {
+            this.restoreTitle()
           }
         }, this.computedDelay.show)
       }

--- a/src/components/tooltip/helpers/bv-tooltip.js
+++ b/src/components/tooltip/helpers/bv-tooltip.js
@@ -285,11 +285,12 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
           html: this.html,
           placement: this.placement,
           fallbackPlacement: this.fallbackPlacement,
-          offset: this.offset,
-          arrowPadding: this.arrowPadding,
-          boundaryPadding: this.boundaryPadding,
+          target: this.getPlacementTarget(),
           boundary: this.getBoundary(),
-          target: this.getPlacementTarget()
+          // Ensure the following are integers
+          offset: parseInt(this.offset, 10) || 0,
+          arrowPadding: parseInt(this.arrowPadding, 10) || 0,
+          boundaryPadding: parseInt(this.boundaryPadding, 10) || 0
         }
       }))
       // We set the initial reactive data (values that can be changed while open)

--- a/src/components/tooltip/package.json
+++ b/src/components/tooltip/package.json
@@ -165,7 +165,7 @@
         "slots": [
           {
             "name": "default",
-            "description": "Slot for tooltip content (HTML supported)"
+            "description": "Slot for tooltip content (HTML/components supported)"
           }
         ]
       }

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -66,7 +66,7 @@ export const BTooltip = /*#__PURE__*/ Vue.extend({
       default: () => getComponentConfig(NAME, 'boundary')
     },
     boundaryPadding: {
-      type: Number,
+      type: [Number, String],
       default: () => getComponentConfig(NAME, 'boundaryPadding')
     },
     offset: {
@@ -122,6 +122,7 @@ export const BTooltip = /*#__PURE__*/ Vue.extend({
         customClass: this.customClass,
         container: this.container,
         boundary: this.boundary,
+        boundaryPadding: this.boundaryPadding,
         delay: this.delay,
         offset: this.offset,
         noFade: this.noFade,
@@ -244,19 +245,21 @@ export const BTooltip = /*#__PURE__*/ Vue.extend({
       // Overridden by BPopover
       // Tooltip: Default slot is `title`
       // Popover: Default slot is `content`, `title` slot is title
-      // We pass a scoped slot function by default (v2.6x)
+      // We pass a scoped slot function reference by default (Vue v2.6x)
       // And pass the title prop as a fallback
       this.setTitle(this.$scopedSlots.default || this.title)
     },
     // Helper methods for `updateContent()`
     setTitle(val) {
       val = isUndefinedOrNull(val) ? '' : val
+      // We only update the value if it has changed
       if (this.localTitle !== val) {
         this.localTitle = val
       }
     },
     setContent(val) {
       val = isUndefinedOrNull(val) ? '' : val
+      // We only update the value if it has changed
       if (this.localContent !== val) {
         this.localContent = val
       }

--- a/src/directives/popover/README.md
+++ b/src/directives/popover/README.md
@@ -446,11 +446,11 @@ Where `[mod]` can be (all optional):
 - `nofade` to turn off animation.
 - `html` to enable rendering raw HTML. by default HTML is escaped and converted to text.
 - A delay value in the format of `d###` (where `###` is in ms, defaults to `50`), applied to both
-  `hide` and `show` (affects `hover` and `focus` only)
+  `hide` and `show`.
 - A show delay value in the format of `ds###` (where `###` is in ms, defaults to `50`), applied to
-  `show` trigger only (affects `hover` and `focus` only)
+  `show` trigger only.
 - A hide delay value in the format of `dh###` (where `###` is in ms, defaults to `50`), applied to
-  `hide` trigger only (affects `hover` and `focus` only)
+  `hide` trigger only.
 - An offset value in pixels in the format of `o###` (where `###` is the number of pixels, defaults
   to `0`. Negative values are allowed). Note if an offset is supplied, then the alignment positions
   will fallback to one of `top`, `bottom`, `left`, or `right`.

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -5,8 +5,8 @@ import { getComponentConfig } from '../../utils/config'
 import { isBrowser } from '../../utils/env'
 import {
   isFunction,
-  isObject,
   isNumber,
+  isPlainObject,
   isString,
   isUndefined,
   isUndefinedOrNull
@@ -71,7 +71,7 @@ const parseBindings = (bindings, vnode) => /* istanbul ignore next: not easy to 
   } else if (isFunction(bindings.value)) {
     // Content generator function
     config.content = bindings.value
-  } else if (isObject(bindings.value)) {
+  } else if (isPlainObject(bindings.value)) {
     // Value is config object, so merge
     config = { ...config, ...bindings.value }
   }
@@ -91,10 +91,10 @@ const parseBindings = (bindings, vnode) => /* istanbul ignore next: not easy to 
   }
 
   // Normalize delay
-  if (!isObject(config.delay)) {
+  if (!isPlainObject(config.delay)) {
     config.delay = {
-      show: config.delay,
-      hide: config.delay
+      show: parseInt(config.delay, 10) || 0,
+      hide: parseInt(config.delay, 10) || 0
     }
   }
 

--- a/src/directives/tooltip/README.md
+++ b/src/directives/tooltip/README.md
@@ -309,24 +309,24 @@ Where `[modX]` can be (all optional):
 
 - Positioning: `top`, `bottom`, `left`, `right`, `auto`, `topleft`, `topright`, `bottomleft`,
   `bottomright`, `lefttop`, `leftbottom`, `righttop`, or `rightbottom` (last one found wins,
-  defaults to `top`)
+  defaults to `top`).
 - Event trigger: `click`, `hover`, `focus`, `blur` (if none specified, defaults to `focus` and
   `hover`. `blur` is a close handler only, and if specified by itself, will be converted to
   `focus`). Use `manual` if you only want to control the visibility manually.
-- `nofade` to turn off animation
+- `nofade` to turn off animation.
 - `html` to enable rendering raw HTML. By default HTML is escaped and converted to text
 - A delay value in the format of `d###` (where `###` is in ms, defaults to `50`), applied to both
-  `hide` and `show` (affects `hover` and `focus` only)
+  `hide` and `show`.
 - A show delay value in the format of `ds###` (where `###` is in ms, defaults to `50`), applied to
-  `show` trigger only (affects `hover` and `focus` only)
+  `show` trigger only.
 - A hide delay value in the format of `dh###` (where `###` is in ms, defaults to `50`), applied to
-  `hide` trigger only (affects `hover` and `focus` only)
+  `hide` trigger only.
 - An offset value in pixels in the format of `o###` (where `###` is the number of pixels, defaults
-  to `0`. Negative values allowed)
+  to `0`. Negative values allowed).
 - A boundary setting of `window` or `viewport`. The element to constrain the visual placement of the
   tooltip. If not specified, the boundary defaults to the trigger element's scroll parent (in most
-  cases this will suffice)
-- A contextual variant in the form of `v-XXX` (where `XXX` is the color variant name)
+  cases this will suffice).
+- A contextual variant in the form of `v-XXX` (where `XXX` is the color variant name).
 
 Where `<value>` can be (optional):
 

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -6,7 +6,7 @@ import { isBrowser } from '../../utils/env'
 import {
   isFunction,
   isNumber,
-  isObject,
+  isPlainObject,
   isString,
   isUndefined,
   isUndefinedOrNull
@@ -71,7 +71,7 @@ const parseBindings = (bindings, vnode) => /* istanbul ignore next: not easy to 
   } else if (isFunction(bindings.value)) {
     // Title generator function
     config.title = bindings.value
-  } else if (isObject(bindings.value)) {
+  } else if (isPlainObject(bindings.value)) {
     // Value is config object, so merge
     config = { ...config, ...bindings.value }
   }
@@ -84,10 +84,10 @@ const parseBindings = (bindings, vnode) => /* istanbul ignore next: not easy to 
   }
 
   // Normalize delay
-  if (!isObject(config.delay)) {
+  if (!isPlainObject(config.delay)) {
     config.delay = {
-      show: config.delay,
-      hide: config.delay
+      show: parseInt(config.delay, 10) || 0,
+      hide: parseInt(config.delay, 10) || 0
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1576,10 +1576,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.1.tgz#d5544f6de0aae03eefbb63d5120f6c8be0691946"
   integrity sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ==
 
-"@types/node@^12.7.4":
-  version "12.7.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.4.tgz#64db61e0359eb5a8d99b55e05c729f130a678b04"
-  integrity sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==
+"@types/node@^12.7.5":
+  version "12.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
+  integrity sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -10619,13 +10619,13 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.21.2:
-  version "1.21.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.21.2.tgz#eaabd07d0bd309587ad8bebf731fca6fcb96f4d0"
-  integrity sha512-sCAHlcQ/PExU5t/kRwkEWHdhGmQrZ2IgdQzbjPVNfhWbKHMMZGYqkASVTpQqRPLtQKg15xzEscc+BnIK/TE7/Q==
+rollup@^1.21.3:
+  version "1.21.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.21.3.tgz#2d957e04b230b06a85b8c617bf594f92c37c4d5d"
+  integrity sha512-43CgeUtHhfiqBOUd0uJo5NEOg2FuheF3SqGN8BqgvnqB4xM2TbfPdudeSdllDcMKpagHb//qtpaAADBurT4GzA==
   dependencies:
     "@types/estree" "0.0.39"
-    "@types/node" "^12.7.4"
+    "@types/node" "^12.7.5"
     acorn "^7.0.0"
 
 rsvp@^4.8.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3255,10 +3255,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.5.0.tgz#3d0748932f9cb41e1ad7f21fa346ef1b2b1bed47"
-  integrity sha512-/OsWOfIHaQIr7aeZ4pY0UC1PZT6kimoKFOFYFNb6wxo3iw12nRrh+mNGH72rnXxNsq6SGfesVPizm/6Q3XqcFQ==
+codecov@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.0.tgz#6915561b7064c064e30a588ea23c1384b14d744b"
+  integrity sha512-d9SEDdgEZ1PDXLY52itsk5pMmxVbqmT4+8OCzmZOHUUOxWpmnPK2Fgz35yYUipT8QqkrDRihIvIJKjRynUdk4g==
   dependencies:
     argv "^0.0.2"
     ignore-walk "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,10 +4816,10 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.3.0.tgz#1f1a902f67bfd4c354e7288b81e40654d927eb6a"
-  integrity sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==
+eslint@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.4.0.tgz#5aa9227c3fbe921982b2eda94ba0d7fae858611a"
+  integrity sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10619,10 +10619,10 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.21.3:
-  version "1.21.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.21.3.tgz#2d957e04b230b06a85b8c617bf594f92c37c4d5d"
-  integrity sha512-43CgeUtHhfiqBOUd0uJo5NEOg2FuheF3SqGN8BqgvnqB4xM2TbfPdudeSdllDcMKpagHb//qtpaAADBurT4GzA==
+rollup@^1.21.4:
+  version "1.21.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.21.4.tgz#00a41a30f90095db890301b226cbe2918e4cf54d"
+  integrity sha512-Pl512XVCmVzgcBz5h/3Li4oTaoDcmpuFZ+kdhS/wLreALz//WuDAMfomD3QEYl84NkDu6Z6wV9twlcREb4qQsw==
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "^12.7.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3810,12 +3810,12 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.1.tgz#b2c76c1ca7add66dc874d11798466094f551b34d"
-  integrity sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==
+cross-env@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.0.tgz#3c8e71440ea20aa6faaf5aec541235efc565dac6"
+  integrity sha512-G/B6gtkjgthT8AP/xN1wdj5Xe18fVyk58JepK8GxpUbqcz3hyWxegocMbvnZK+KoTslwd0ACZ3woi/DVUdVjyQ==
   dependencies:
-    cross-spawn "^6.0.5"
+    cross-spawn "^7.0.0"
 
 cross-spawn@^3.0.0:
   version "3.0.1"
@@ -3842,6 +3842,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     nice-try "^1.0.4"
     path-key "^2.0.1"
     semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.0.tgz#21ef9470443262f33dba80b2705a91db959b2e03"
+  integrity sha512-6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==
+  dependencies:
+    path-key "^3.1.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -9018,7 +9027,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.0.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
   integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4759,10 +4759,10 @@ eslint-plugin-node@^10.0.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-prettier@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
-  integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
+eslint-plugin-prettier@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"
+  integrity sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3255,10 +3255,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.0.tgz#6915561b7064c064e30a588ea23c1384b14d744b"
-  integrity sha512-d9SEDdgEZ1PDXLY52itsk5pMmxVbqmT4+8OCzmZOHUUOxWpmnPK2Fgz35yYUipT8QqkrDRihIvIJKjRynUdk4g==
+codecov@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.1.tgz#f39fc49413445555f81f8e3ca5730992843b4517"
+  integrity sha512-IUJB6WG47nWK7o50etF8jBadxdMw7DmoQg05yIljstXFBGB6clOZsIj6iD4P82T2YaIU3qq+FFu8K9pxgkCJDQ==
   dependencies:
     argv "^0.0.2"
     ignore-walk "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3266,10 +3266,10 @@ codecov@^3.6.0:
     teeny-request "^3.11.3"
     urlgrey "^0.4.4"
 
-codemirror@^5.48.4:
-  version "5.48.4"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.48.4.tgz#4210fbe92be79a88f0eea348fab3ae78da85ce47"
-  integrity sha512-pUhZXDQ6qXSpWdwlgAwHEkd4imA0kf83hINmUEzJpmG80T/XLtDDEzZo8f6PQLuRCcUQhmzqqIo3ZPTRaWByRA==
+codemirror@^5.49.0:
+  version "5.49.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.49.0.tgz#adedbffcc81091e4a0334bcb96b1ae3b7ada5e3f"
+  integrity sha512-Hyzr0HToBdZpLBN9dYFO/KlJAsKH37/cXVHPAqa+imml0R92tb9AkmsvjnXL+SluEvjjdfkDgRjc65NG5jnMYA==
 
 codesandbox-import-util-types@^2.1.9:
   version "2.1.9"


### PR DESCRIPTION
Preparation for release v2.0.2

### Fixes

- `tables`: add in missing Bootstrap v4.3 variant class `bg-active` for dark tables
- `tables`: ensure row variant `active` takes precedence over other row variants
- `tooltips, popovers`: hide trigger element `title` attribute during show delay
- `b-collapse`: don't make `id` prop required
- `b-popover`, `b-tooltip`: ensure `boundary-padding` is passed to popper instance

### Docs

Additional docs updates and fixes
