### PR TITLE
docs(b-toast): show example of using `<b-alert>` as an alternative to a toast

### DIFF
--- a/src/components/toast/README.md
+++ b/src/components/toast/README.md
@@ -494,9 +494,6 @@ on a [`<b-alert>`](/docs/components/alert) component:
     <b-button size="sm" @click="showBottom = !showBottom">
       {{ showBottom ? 'Hide' : 'Show' }} Fixed bottom Alert
     </b-button>
-    <b-button size="sm" @click="showTop = !showTop">
-      {{ showTop ? 'Hide' : 'Show' }} Fixed top Alert
-    </b-button>
     <b-alert
       v-model="showBottom"
       class="position-fixed fixed-bottom m-0 rounded-0"
@@ -506,6 +503,10 @@ on a [`<b-alert>`](/docs/components/alert) component:
     >
       Fixed position (bottom) alert!
     </b-alert>
+
+    <b-button size="sm" @click="showTop = !showTop">
+      {{ showTop ? 'Hide' : 'Show' }} Fixed top Alert
+    </b-button>
     <b-alert
       v-model="showTop"
       class="position-fixed fixed-top m-0 rounded-0"

--- a/src/components/toast/README.md
+++ b/src/components/toast/README.md
@@ -481,6 +481,67 @@ for generating more complex toast content:
 
 <!-- toasts-advanced.vue -->
 ```
+## Alerts versus toasts
+
+In some cases you may need just a simple alert style message (i.e. cookie usage notifications, etc.).
+In these cases is is usually better to use an fixed position alert instead of a toast, by applying a
+few Bootstrap [utility classes](/docs/reference/utility-classes) and a small bit of custom styling
+on a [`<b-alert>`](/docs/components/alert) component:
+
+```html
+<template>
+  <div>
+    <b-button size="sm" @click="showBottom = !showBottom">
+      {{ showBottom ? 'Hide' : 'Show' }} Fixed bottom Alert
+    </b-button>
+    <b-button size="sm" @click="showTop = !showTop">
+      {{ showTop ? 'Hide' : 'Show' }} Fixed top Alert
+    </b-button>
+    <b-alert
+      v-model="showBottom"
+      class="position-fixed fixed-bottom m-0 rounded-0"
+      style="z-index: 2000;"
+      variant="warning"
+      dismissible
+    >
+      Fixed position (bottom) alert!
+    </b-alert>
+    <b-alert
+      v-model="showTop"
+      class="position-fixed fixed-top m-0 rounded-0"
+      style="z-index: 2000;"
+      variant="success"
+      dismissible
+    >
+      Fixed position (top) alert!
+    </b-alert>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      showBottom: false,
+      showTop: false
+    }
+  }
+}
+</script>
+
+<!-- fixed-position-alerts.vue -->
+```
+
+We use class `position-fixed` to set the positioning to fixed within the user's viewport, and
+either class `fixed-bottom` or `fixed-top` to position the alert on the bottom or top of the
+viewport. Class `m-0` removes the default margins around the alert and `rounded-0` removes the
+default rounded corners.  We also set the `z-index` to a large value to ensure the alert apepars
+over any other content on the page (the default for `fixed-top` and `fixed-bottom` is `1030`). You
+may need to adjust the `z-index` for your specific layout.
+
+Since the alert markup remains in the DOM where you placed the `<b-alert>` component, it's tab
+sequence (for accessing the dismiss button) is easily accessible to screen reader and keyboard-only
+users.
 
 ## Accessibility
 
@@ -492,6 +553,9 @@ Additionally, `aria-atomic="true"` is automatically set to ensure that the entir
 announced as a single (atomic) unit, rather than announcing what was changed (which could lead to
 problems if you only update part of the toast's content, or if displaying the same toast content at
 a later point in time).
+
+If you just need a single simple message to appear along the bottom or top of the user's window, use
+a [fixed position `<b-alert>`](#alerts-versus-toasts) instead.
 
 ### Accessibility tips
 


### PR DESCRIPTION
### Describe the PR

Add an example of using a fixed position alert instead of toasts.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
