### PR TITLE
docs(dropdown): show example of opening modal from dropdown item (closes #4149)

### DIFF
--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -607,6 +607,21 @@ When a menu item doesn't trigger navigation, it is recommended to use the `<b-dr
 sub-component (which is not announced as a link) instead of `<b-dropdown-item>` (which is presented
 as a link to the user).
 
+### Triggering modals with dropdown items
+
+Avoid using the `v-b-modal` directive directly on `<b-dropdown-item>` or `<b-dropdown-item-button>`
+child components. The directive attaches itself to the root element of the drodpown item, which is
+an `<li>`, and not to the child `<a>` or `<button>` elements. This can cause accessibility issues as
+the `v-b-modal` directive sees the `<li>` element as non-interactive and changes it's role to be
+`button`.  Instead, use `this.$bvModal` to trigger the modal to open via the dropdown item's click
+handler:
+
+```html
+<b-dropdown-item-button @click="$bvModal.show('modal-1')">
+  Open Modal
+</b-dropdown-item-button>
+```
+
 ### Headers and accessibility
 
 When using `<b-dropdown-header>` components in the dropdown menu, it is recommended to add an `id`

--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -610,10 +610,10 @@ as a link to the user).
 ### Triggering modals with dropdown items
 
 Avoid using the `v-b-modal` directive directly on `<b-dropdown-item>` or `<b-dropdown-item-button>`
-child components. The directive attaches itself to the root element of the drodpown item, which is
+child components. The directive attaches itself to the root element of the dropdown item, which is
 an `<li>`, and not to the child `<a>` or `<button>` elements. This can cause accessibility issues as
 the `v-b-modal` directive sees the `<li>` element as non-interactive and changes it's role to be
-`button`.  Instead, use `this.$bvModal` to trigger the modal to open via the dropdown item's click
+`button`. Instead, use `this.$bvModal` to trigger the modal to open via the dropdown item's click
 handler:
 
 ```html


### PR DESCRIPTION
### Describe the PR

In dropdown accessibility docs, show example of opening a modal from a dropdown item.

Closes #4149 

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [x] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
