### PR TITLE
feat(b-tabs): emit cancelable BvEvent before changing tabs via new `activate-tab` event (closes #4273)

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -419,6 +419,23 @@ methods are `.activate()` and `.deactivate()`, respectively. If activation or de
 will remain active and the method will return `false`. You will need a reference to the `<b-tab>` in
 order to use these methods.
 
+## Preventing a `<b-tab>` from being activated
+
+To prevent a tab from activating, simply set the `disabled` prop on the `<b-tab>` component.
+
+Alternatively, you can listen for the `activate-tab` event, which provides an option to prevent the
+tab from activating. The `activate-tab` event is emitted with three arguments:
+
+- `newTabIndex`: The index of the tab that is going to be activated
+- `prevTabIndex`: The index of the currently active tab
+- `bvEvent`: The `BvEvent` object. Call `bvEvt.preventDefault()` to prevent `newTabIndex` from being
+  activated
+
+For accessibility reasons, when using the `activate-tab` event to prevent a tab from activating, you
+should provide some means of notification to the user as to why the tab is not able to be activated.
+It is recommended to use the `disabled` attribute on the `<b-tab>` component instead of using the
+`activate-tab` event (as `disabled` is more intuitive for screen reader users).
+
 ## Advanced examples
 
 ### External controls using `v-model`

--- a/src/components/tabs/package.json
+++ b/src/components/tabs/package.json
@@ -96,7 +96,7 @@
           {
             "event": "activate-tab",
             "version": "2.1.0",
-            "description": "Emitted just before a tab is shown/activated (excluding tab change via v-model/value prop). Cancelable",
+            "description": "Emitted just before a tab is shown/activated. Cancelable",
             "args": [
               {
                 "arg": "newTabIndex",

--- a/src/components/tabs/package.json
+++ b/src/components/tabs/package.json
@@ -96,7 +96,7 @@
           {
             "event": "activate-tab",
             "version": "2.1.0",
-            "description": "Emitted just before a tab is shown/activated (excluding tab change via v-model). Cancelable",
+            "description": "Emitted just before a tab is shown/activated (excluding tab change via v-model/value prop). Cancelable",
             "args": [
               {
                 "arg": "newTabIndex",

--- a/src/components/tabs/package.json
+++ b/src/components/tabs/package.json
@@ -94,6 +94,28 @@
             ]
           },
           {
+            "event": "activate-tab",
+            "version": "2.1.0",
+            "description": "Emitted just before a tab is shown/activated (excluding tab change via v-model). Cancelable",
+            "args": [
+              {
+                "arg": "newTabIndex",
+                "type": "Number",
+                "description": "Tab being activated (0-based index)"
+              },
+              {
+                "arg": "prevTabIndex",
+                "type": "Number",
+                "description": "Tab that is currently active (0-based index). Will be -1 if no current active tab"
+              },
+              {
+                "arg": "bvEvt",
+                "type": "BvEvent",
+                "description": "BvEvent object. Call bvEvt.preventDefault() to cancel"
+              }
+            ]
+          },
+          {
             "event": "changed",
             "description": "Emitted when a tab is added, removed, or tabs are re-ordered",
             "args": [

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -496,12 +496,10 @@ export const BTabs = /*#__PURE__*/ Vue.extend({
           }
         }
       }
-      if (!result) {
-        // Couldn't set tab, so ensure v-model is set to `this.currentTab`
-        /* istanbul ignore next: should rarely happen */
-        if (this.currentTab !== this.value) {
-          this.$emit('input', this.currentTab)
-        }
+      // Couldn't set tab, so ensure v-model is set to `this.currentTab`
+      /* istanbul ignore next: should rarely happen */
+      if (!result && this.currentTab !== this.value) {
+        this.$emit('input', this.currentTab)
       }
       return result
     },

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -263,7 +263,8 @@ export const BTabs = /*#__PURE__*/ Vue.extend({
         old = parseInt(old, 10) || 0
         const tabs = this.tabs
         if (tabs[val] && !tabs[val].disabled) {
-          this.currentTab = val
+          // this.currentTab = val
+          this.activateTab(tabs[val])
         } else {
           // Try next or prev tabs
           if (val < old) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -263,7 +263,6 @@ export const BTabs = /*#__PURE__*/ Vue.extend({
         old = parseInt(old, 10) || 0
         const tabs = this.tabs
         if (tabs[val] && !tabs[val].disabled) {
-          // this.currentTab = val
           this.activateTab(tabs[val])
         } else {
           // Try next or prev tabs

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -499,7 +499,9 @@ export const BTabs = /*#__PURE__*/ Vue.extend({
       if (!result) {
         // Couldn't set tab, so ensure v-model is set to `this.currentTab`
         /* istanbul ignore next: should rarely happen */
-        this.$emit('input', this.currentTab)
+        if (this.currentTab !== this.value) {
+          this.$emit('input', this.currentTab)
+        }
       }
       return result
     },

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -312,7 +312,6 @@ describe('tabs', () => {
   })
 
   it('`activate-tab` event works', async () => {
-    
     const App = Vue.extend({
       methods: {
         preventTab(next, prev, bvEvt) {
@@ -357,8 +356,8 @@ describe('tabs', () => {
     expect(tabs.emitted('activate-tab').length).toBe(1)
     expect(tabs.emitted('activate-tab')[0][0]).toBe(1)
     expect(tabs.emitted('activate-tab')[0][1]).toBe(0)
-    expect(tabs.emitted('activate-tab')[0][3]).toBeDefined()
-    expect(tabs.emitted('activate-tab')[0][3].vueTarget).toBe(tabs.vm)
+    expect(tabs.emitted('activate-tab')[0][2]).toBeDefined()
+    expect(tabs.emitted('activate-tab')[0][2].vueTarget).toBe(tabs.vm)
 
     // Attempt to set 3rd BTab to be active
     tabs.setProps({ value: 2 })
@@ -371,9 +370,9 @@ describe('tabs', () => {
     expect(tabs.emitted('activate-tab').length).toBe(2)
     expect(tabs.emitted('activate-tab')[1][0]).toBe(2)
     expect(tabs.emitted('activate-tab')[1][1]).toBe(1)
-    expect(tabs.emitted('activate-tab')[1][3]).toBeDefined()
-    expect(tabs.emitted('activate-tab')[1][3].vueTarget).toBe(tabs.vm)
-    expect(tabs.emitted('activate-tab')[1][3].defaultPrevented).toBe(true)
+    expect(tabs.emitted('activate-tab')[1][2]).toBeDefined()
+    expect(tabs.emitted('activate-tab')[1][2].vueTarget).toBe(tabs.vm)
+    expect(tabs.emitted('activate-tab')[1][2].defaultPrevented).toBe(true)
 
     wrapper.destroy()
   })


### PR DESCRIPTION
### Describe the PR

Emit new event `activate-tab` before changing tabs.

New event is emitted with three arguments:

- `newTabIndex` tab index that will be activated
- `prevTabIndex` tab index of the current active tab, or -1 if no active tab
- `bvEvt` BvEvent object instance

Calling `bvEvt.preventDefault()` will prevent the tab from activating.

Ideally users should be setting the `disabled` prop on any `<b-tab>` they don't want users to activate (better for accessibility). If users do use this event to prevent a tab from activating, they should provide feedback to the user as to why the tab cannot be activated (i.e. an alert, etc).

Closes #4273

To Do:

- [x] meta data update
- [x] Get event working with v-model/value update
- [x] documentation update
- [x] unit tests

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
