### PR TITLE
chore(table meta): `transition-list` => `transition-group`

### DIFF
--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -93,11 +93,11 @@
           },
           {
             "prop": "tbodyTransitionProps",
-            "description": "Vue 'transition-list' properties. When provided will make the tbody a Vue 'transition-list' component"
+            "description": "Vue 'transition-group' properties. When provided will make the tbody a Vue 'transition-group' component"
           },
           {
             "prop": "tbodyTransitionHandlers",
-            "description": "Vue 'transition-list' event handlers. When provided will make the tbody a Vue 'transition-list' component"
+            "description": "Vue 'transition-group' event handlers. When provided will make the tbody a Vue 'transition-group' component"
           },
           {
             "prop": "caption",
@@ -1017,11 +1017,11 @@
           },
           {
             "prop": "tbodyTransitionProps",
-            "description": "Vue 'transition-list' properties. When provided will make the tbody a Vue 'transition-list' component"
+            "description": "Vue 'transition-group' properties. When provided will make the tbody a Vue 'transition-group' component"
           },
           {
             "prop": "tbodyTransitionHandlers",
-            "description": "Vue 'transition-list' event handlers. When provided will make the tbody a Vue 'transition-list' component"
+            "description": "Vue 'transition-group' event handlers. When provided will make the tbody a Vue 'transition-group' component"
           },
           {
             "prop": "caption",
@@ -1572,11 +1572,11 @@
         "props": [
           {
             "prop": "tbodyTransitionProps",
-            "description": "Vue 'transition-list' properties. When provided will make the tbody a Vue 'transition-list' component"
+            "description": "Vue 'transition-group' properties. When provided will make the tbody a Vue 'transition-group' component"
           },
           {
             "prop": "tbodyTransitionHandlers",
-            "description": "Vue 'transition-list' event handlers. When provided will make the tbody a Vue 'transition-list' component"
+            "description": "Vue 'transition-group' event handlers. When provided will make the tbody a Vue 'transition-group' component"
           }
         ]
       },


### PR DESCRIPTION
### Describe the PR

Corrects table package.json meta prop descriptions: transition-list=> transition-group

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
