### PR TITLE
fix(v-b-tooltip, v-b-popover): ensure reference to trigger element is passed to title/content function (fixes #4331)

### DIFF
--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -193,10 +193,10 @@ const applyPopover = (el, bindings, vnode) => {
       // and content if they are functions
       const data = {}
       if (isFunction(config.title)) {
-        data.title = config.title()
+        data.title = config.title(el)
       }
       if (isFunction(config.content)) {
-        data.content = config.content()
+        data.content = config.content(el)
       }
       if (keys(data).length > 0) {
         el[BV_POPOVER].updateData(data)
@@ -233,7 +233,7 @@ const applyPopover = (el, bindings, vnode) => {
         // If title/content is a function, we execute it here
         newData[prop] =
           (prop === 'title' || prop === 'content') && isFunction(data[prop])
-            ? data[prop]()
+            ? data[prop](el)
             : data[prop]
       }
     })

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -193,7 +193,7 @@ const applyTooltip = (el, bindings, vnode) => {
       // Before showing the tooltip, we update the title if it is a function
       if (isFunction(config.title)) {
         el[BV_TOOLTIP].updateData({
-          title: config.title()
+          title: config.title(el)
         })
       }
     })
@@ -225,7 +225,7 @@ const applyTooltip = (el, bindings, vnode) => {
       // We only pass data properties that have changed
       if (data[prop] !== oldData[prop]) {
         // if title is a function, we execute it here
-        newData[prop] = prop === 'title' && isFunction(data[prop]) ? data[prop]() : data[prop]
+        newData[prop] = prop === 'title' && isFunction(data[prop]) ? data[prop](el) : data[prop]
       }
     })
     el[BV_TOOLTIP].updateData(newData)


### PR DESCRIPTION
### Describe the PR

During the re-write of the popover and tooltip directives the element reference passed to the title/content functions (if they are a function) was inadvertently left out.  This PR adds passing the element reference back in.

Fixes #4331

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
