### PR TITLE
docs(tabs): document load tab content only when active (closes #4352)

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -392,11 +392,11 @@ deactivated (hidden):
 ```html
 <b-tabs>
   <b-tab title="abc">
-    <!-- this component will always be mounted -->
-    <my-abc-component></my-abc-component>
+    <!-- this content will always be mounted -->
+    <div>Tab ABC content</div>
   </b-tab>
   <b-tab title="xyz" lazy>
-    <!-- this component will not be mounted until this tab is shown -->
+    <!-- this content will not be mounted until this tab is shown -->
     <!-- and will be un-mounted when hidden -->
     <my-xyz-component></my-xyz-component>
   </b-tab>
@@ -408,12 +408,12 @@ One can also make all tab's lazy by setting the `lazy` prop on the parent `<b-ta
 ```html
 <b-tabs lazy>
   <b-tab title="abc">
-    <!-- this component will not be mounted until this tab is shown -->
+    <!-- this content will not be mounted until this tab is shown -->
     <!-- and will be un-mounted when hidden -->
-    <my-abc-component></my-abc-component>
+    <div>Tab ABC content</div>
   </b-tab>
   <b-tab title="xyz">
-    <!-- this component will not be mounted until this tab is shown -->
+    <!-- this content will not be mounted until this tab is shown -->
     <!-- and will be un-mounted when hidden -->
     <my-xyz-component></my-xyz-component>
   </b-tab>

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -380,6 +380,43 @@ need to accommodate your custom classes for this._
 <!-- b-tabs-with-classes.vue -->
 ```
 
+## Load tab content only when active
+
+Sometimes it's preferred to load components & data only when activating a tab, instead of loading all tabs (and associated data) when rendering the `<b-tabs>` set.
+
+Individual `<b-tab>` components can be lazy loaded via the `lazy` prop, which when set doesn't mount the content of the `<b-tab>` until it is shown/activated, and will be un-mounted when the tab is deactivated/hidden:
+
+```html
+<b-tabs>
+  <b-tab title="abc">
+    <!-- this component will always be mounted -->
+    <my-abc-component></my-abc-component>
+  </b-tab>
+  <b-tab title="xyz" lazy>
+    <!-- this component will not be mounted until this tab is shown -->
+    <!-- and will be un-mounted when hidden -->
+    <my-xyz-component></my-xyz-component>
+  </b-tab>
+</b-tabs>
+```
+
+One can also make all tab's lazy by setting the `lazy` prop on the parent `<b-tabs>` component:
+
+```html
+<b-tabs lazy>
+  <b-tab title="abc">
+    <!-- this component will not be mounted until this tab is shown -->
+    <!-- and will be un-mounted when hidden -->
+    <my-abc-component></my-abc-component>
+  </b-tab>
+  <b-tab title="xyz">
+    <!-- this component will not be mounted until this tab is shown -->
+    <!-- and will be un-mounted when hidden -->
+    <my-xyz-component></my-xyz-component>
+  </b-tab>
+</b-tabs>
+```
+
 ## Keyboard navigation
 
 Keyboard navigation is enabled by default for ARIA compliance with tablists when a tab button has

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -380,11 +380,14 @@ need to accommodate your custom classes for this._
 <!-- b-tabs-with-classes.vue -->
 ```
 
-## Load tab content only when active
+## Lazy loading tab content
 
-Sometimes it's preferred to load components & data only when activating a tab, instead of loading all tabs (and associated data) when rendering the `<b-tabs>` set.
+Sometimes it's preferred to load components & data only when activating a tab, instead of loading
+all tabs (and associated data) when rendering the `<b-tabs>` set.
 
-Individual `<b-tab>` components can be lazy loaded via the `lazy` prop, which when set doesn't mount the content of the `<b-tab>` until it is shown/activated, and will be un-mounted when the tab is deactivated/hidden:
+Individual `<b-tab>` components can be lazy loaded via the `lazy` prop, which when set doesn't mount
+the content of the `<b-tab>` until it is activated (shown), and will be un-mounted when the tab is
+deactivated (hidden):
 
 ```html
 <b-tabs>


### PR DESCRIPTION
### Describe the PR

Updated docs to include lazy loaded tab content use case in #4352

closes #4352

### PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**
