### PR TITLE
fix(v-b-modal): open modal using `ENTER` key on non-button elements for A11Y

### DIFF
--- a/src/directives/modal/modal.js
+++ b/src/directives/modal/modal.js
@@ -10,6 +10,7 @@ import {
 } from '../../utils/dom'
 import { isString } from '../../utils/inspect'
 import { keys } from '../../utils/object'
+import KeyCodes from '../../utils/key-codes'
 
 // Emitted show event for modal
 const EVENT_SHOW = 'bv::show::modal'
@@ -25,7 +26,7 @@ const getTarget = ({ modifiers = {}, arg, value }) => {
 }
 
 const getTriggerElement = el => {
-  // If root element is a dropdown item or nav item, we
+  // If root element is a dropdown-item or nav-item, we
   // need to target the inner link or button instead
   return el && matches(el, '.dropdown-menu > li, li.nav-item') ? select('a, button', el) || el : el
 }
@@ -46,8 +47,12 @@ const bind = (el, binding, vnode) => {
       const currentTarget = evt.currentTarget
       if (!isDisabled(currentTarget)) {
         const type = evt.type
+        const key = evt.keyCode
         // Open modal only if trigger is not disabled
-        if (type === 'click' || (type === 'keydown' && (evt.keyCode === 13 || evt.keyCode === 32))) {
+        if (
+          type === 'click' ||
+          (type === 'keydown' && (key === KeyCodes.ENTER || key === KeyCodes.SPACE))
+        ) {
           vnode.context.$root.$emit(EVENT_SHOW, target, currentTarget)
         }
       }
@@ -59,7 +64,7 @@ const bind = (el, binding, vnode) => {
     eventOn(trigger, 'click', handler, EVENT_OPTS)
     if (trigger.tagName !== 'BUTTON' && getAttr(trigger, 'role') === 'button') {
       // If trigger isn't a button but has role button,
-      // we also listen for `keydown.space`
+      // we also listen for `keydown.space` && `keydown.enter`
       eventOn(trigger, 'keydown', handler, EVENT_OPTS)
     }
   }

--- a/src/directives/modal/modal.js
+++ b/src/directives/modal/modal.js
@@ -47,7 +47,7 @@ const bind = (el, binding, vnode) => {
       if (!isDisabled(currentTarget)) {
         const type = evt.type
         // Open modal only if trigger is not disabled
-        if (type === 'click' || (type === 'keydown' && evt.keyCode === 32)) {
+        if (type === 'click' || (type === 'keydown' && (evt.keyCode === 13 || evt.keyCode === 32))) {
           vnode.context.$root.$emit(EVENT_SHOW, target, currentTarget)
         }
       }

--- a/src/directives/modal/modal.spec.js
+++ b/src/directives/modal/modal.spec.js
@@ -115,7 +115,7 @@ describe('v-b-modal directive', () => {
     expect(wrapper.find('span').text()).toBe('span')
 
     const $span = wrapper.find('span')
-    $span.trigger('keydown', { keyCode: 32 })
+    $span.trigger('keydown.space')
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toBeCalledWith('test', $span.element)
     expect(wrapper.find('span').attributes('role')).toBe('button')
@@ -155,7 +155,7 @@ describe('v-b-modal directive', () => {
     expect(wrapper.find('span').text()).toBe('span')
 
     const $span = wrapper.find('span')
-    $span.trigger('keydown', { keyCode: 13 })
+    $span.trigger('keydown.enter')
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toBeCalledWith('test', $span.element)
     expect(wrapper.find('span').attributes('role')).toBe('button')

--- a/src/directives/modal/modal.spec.js
+++ b/src/directives/modal/modal.spec.js
@@ -82,4 +82,84 @@ describe('v-b-modal directive', () => {
 
     wrapper.destroy()
   })
+
+  it('works on non-buttons using keydown space', async () => {
+    const localVue = new CreateLocalVue()
+    const spy = jest.fn()
+
+    const App = localVue.extend({
+      directives: {
+        bModal: VBModal
+      },
+      data() {
+        return {
+          text: 'span'
+        }
+      },
+      mounted() {
+        this.$root.$on(EVENT_SHOW, spy)
+      },
+      beforeDestroy() {
+        this.$root.$off(EVENT_SHOW, spy)
+      },
+      template: '<span tabindex="0" v-b-modal.test>{{ text }}</span>'
+    })
+    const wrapper = mount(App, {
+      localVue: localVue
+    })
+
+    expect(wrapper.isVueInstance()).toBe(true)
+    expect(wrapper.is('span')).toBe(true)
+    expect(spy).not.toHaveBeenCalled()
+    expect(wrapper.find('span').attributes('role')).toBe('button')
+    expect(wrapper.find('span').text()).toBe('span')
+
+    const $span = wrapper.find('span')
+    $span.trigger('keydown', { keyCode: 32 })
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toBeCalledWith('test', $span.element)
+    expect(wrapper.find('span').attributes('role')).toBe('button')
+
+    wrapper.destroy()
+  })
+
+  it('works on non-buttons using keydown enter', async () => {
+    const localVue = new CreateLocalVue()
+    const spy = jest.fn()
+
+    const App = localVue.extend({
+      directives: {
+        bModal: VBModal
+      },
+      data() {
+        return {
+          text: 'span'
+        }
+      },
+      mounted() {
+        this.$root.$on(EVENT_SHOW, spy)
+      },
+      beforeDestroy() {
+        this.$root.$off(EVENT_SHOW, spy)
+      },
+      template: '<span tabindex="0" v-b-modal.test>{{ text }}</span>'
+    })
+    const wrapper = mount(App, {
+      localVue: localVue
+    })
+
+    expect(wrapper.isVueInstance()).toBe(true)
+    expect(wrapper.is('span')).toBe(true)
+    expect(spy).not.toHaveBeenCalled()
+    expect(wrapper.find('span').attributes('role')).toBe('button')
+    expect(wrapper.find('span').text()).toBe('span')
+
+    const $span = wrapper.find('span')
+    $span.trigger('keydown', { keyCode: 13 })
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toBeCalledWith('test', $span.element)
+    expect(wrapper.find('span').attributes('role')).toBe('button')
+
+    wrapper.destroy()
+  })
 })


### PR DESCRIPTION
### Describe the PR

When the `v-b-modal` directive is used on non-link elements (`a`), users can only open it using the spacebar. This adds inconsistency where other implementations (because they're link elements) can be opened using the `Enter` key.

From https://www.w3.org/WAI/GL/wiki/Making_actions_keyboard_accessible_by_using_keyboard_event_handlers_with_WAI-ARIA_controls#Example_1:_Using_Space_to_activate_a_button:

> Adding the ARIA role "button" makes it clear that this is a button control and not a link. Because we are using an anchor element, the control is focusable and the browser will automatically call the onclick handler for the Enter keystroke. Since users expect to be able to activate buttons with either Enter or Space, a keyboard handler provides the support for activating the button via the Space character.

> **Note that supporting SPACE in addition to ENTER is not required by WCAG 2.0; this control would still be keyboard accessible without the key event handler for SPACE. However, supporting platform keyboard conventions for controls is strongly encouraged.**

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [x] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [x] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
