### PR TITLE
feat(b-collapse): add optional scoping to default slot

### DIFF
--- a/src/components/collapse/README.md
+++ b/src/components/collapse/README.md
@@ -267,10 +267,10 @@ this.$root.$emit('bv::toggle::collapse', 'my-collapse-id')
 
 The default slot can be optionally scoped. The following scope properties are available:
 
-| Property | Type     | Description                          |
-| -------- | -------- | ------------------------------------ |
-| visible  | Boolean  | Visible state of the collapse        |
-| close    | Function | When called, will close the collapse |
+| Property   | Type     | Description                          |
+| ---------- | -------- | ------------------------------------ |
+| `visible`  | Boolean  | Visible state of the collapse        |
+| `close`    | Function | When called, will close the collapse |
 
 ## Accessibility
 

--- a/src/components/collapse/README.md
+++ b/src/components/collapse/README.md
@@ -261,6 +261,17 @@ To toggle (open/close) a **specific collapse**, pass the collapse `id`:
 this.$root.$emit('bv::toggle::collapse', 'my-collapse-id')
 ```
 
+## Optionally scoped default slot
+
+<span class="badge badge-info small">New in v2.2.0</span>
+
+The default slot can be optionally scoped. The following scope properties are available:
+
+| Property | Type     | Description                          |
+| -------- | -------- | ------------------------------------ |
+| visible  | Boolean  | Visible state of the collapse        |
+| close    | Function | When called, will close the collapse |
+
 ## Accessibility
 
 The `v-b-toggle` directive will automatically add the ARIA attributes `aria-controls` and

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -232,7 +232,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
   },
   render(h) {
     const scope = {
-      close: this.toggle
+      close: () => (this.show = false)
     }
     const content = h(
       this.tag,

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -231,6 +231,9 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
     }
   },
   render(h) {
+    const scope = {
+      hide: () => this.show = false
+    }
     const content = h(
       this.tag,
       {
@@ -239,7 +242,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
         attrs: { id: this.safeId() },
         on: { click: this.clickHandler }
       },
-      [this.normalizeSlot('default')]
+      [this.normalizeSlot('default', scope)]
     )
     return h(
       BVCollapse,

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -232,7 +232,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
   },
   render(h) {
     const scope = {
-      hide: () => this.show = false
+      close: () => this.show = false
     }
     const content = h(
       this.tag,

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -232,7 +232,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
   },
   render(h) {
     const scope = {
-      close: () => this.show = false
+      close: this.toggle
     }
     const content = h(
       this.tag,

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -232,6 +232,7 @@ export const BCollapse = /*#__PURE__*/ Vue.extend({
   },
   render(h) {
     const scope = {
+      visible: this.show,
       close: () => (this.show = false)
     }
     const content = h(

--- a/src/components/collapse/collapse.spec.js
+++ b/src/components/collapse/collapse.spec.js
@@ -577,7 +577,7 @@ describe('collapse', () => {
         visible: true
       },
       scopedSlots: {
-        default: props => {
+        default(props) {
           scope = props
           return this.$createElement('div', 'foobar')
         }

--- a/src/components/collapse/collapse.spec.js
+++ b/src/components/collapse/collapse.spec.js
@@ -566,4 +566,59 @@ describe('collapse', () => {
 
     wrapper.destroy()
   })
+
+  it('default slot scope works', async () => {
+    let scope = null
+    const wrapper = mount(BCollapse, {
+      attachToDocument: true,
+      propsData: {
+        // 'id' is a required prop
+        id: 'test',
+        visible: true
+      },
+      scopedSlots: {
+        default: props => {
+          scope = scope
+          return this.$createElement('div', 'foobar')
+        }
+      },
+      stubs: {
+        // Disable use of default test transitionStub component
+        transition: false
+      }
+    })
+    const rootWrapper = createWrapper(wrapper.vm.$root)
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    expect(wrapper.element.style.display).toEqual('')
+    expect(wrapper.emitted('show')).not.toBeDefined() // Does not emit show when initially visible
+    expect(wrapper.emitted('input')).toBeDefined()
+    expect(wrapper.emitted('input').length).toBe(1)
+    expect(wrapper.emitted('input')[0][0]).toBe(true)
+    expect(rootWrapper.emitted(EVENT_ACCORDION)).not.toBeDefined()
+    expect(rootWrapper.emitted(EVENT_STATE)).toBeDefined()
+    expect(rootWrapper.emitted(EVENT_STATE).length).toBe(1)
+    expect(rootWrapper.emitted(EVENT_STATE)[0][0]).toBe('test') // ID
+    expect(rootWrapper.emitted(EVENT_STATE)[0][1]).toBe(true) // Visible state
+    expect(rootWrapper.emitted(EVENT_STATE_SYNC)).not.toBeDefined()
+
+    expect(scope).not.toBe(null)
+    expect(scope.visible).toBe(true)
+    expect(typeof scope.close).toBe('function')
+
+    scope.close()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+
+    expect(rootWrapper.emitted(EVENT_STATE_SYNC)).toBeDefined()
+    expect(rootWrapper.emitted(EVENT_STATE_SYNC).length).toBe(1)
+    expect(rootWrapper.emitted(EVENT_STATE_SYNC)[0][0]).toBe('test') // ID
+    expect(rootWrapper.emitted(EVENT_STATE_SYNC)[0][1]).toBe(true) // Visible state
+
+    expect(scope).not.toBe(null)
+    expect(scope.visible).toBe(false)
+    expect(typeof scope.close).toBe('function')
+
+    wrapper.destroy()
+  })
 })

--- a/src/components/collapse/collapse.spec.js
+++ b/src/components/collapse/collapse.spec.js
@@ -611,9 +611,9 @@ describe('collapse', () => {
     await waitRAF()
 
     expect(rootWrapper.emitted(EVENT_STATE_SYNC)).toBeDefined()
-    expect(rootWrapper.emitted(EVENT_STATE_SYNC).length).toBe(1)
-    expect(rootWrapper.emitted(EVENT_STATE_SYNC)[0][0]).toBe('test') // ID
-    expect(rootWrapper.emitted(EVENT_STATE_SYNC)[0][1]).toBe(true) // Visible state
+    expect(rootWrapper.emitted(EVENT_STATE_SYNC).length).toBe(2)
+    expect(rootWrapper.emitted(EVENT_STATE_SYNC)[1][0]).toBe('test') // ID
+    expect(rootWrapper.emitted(EVENT_STATE_SYNC)[1][1]).toBe(false) // Visible state
 
     expect(scope).not.toBe(null)
     expect(scope.visible).toBe(false)

--- a/src/components/collapse/collapse.spec.js
+++ b/src/components/collapse/collapse.spec.js
@@ -578,7 +578,7 @@ describe('collapse', () => {
       },
       scopedSlots: {
         default: props => {
-          scope = scope
+          scope = props
           return this.$createElement('div', 'foobar')
         }
       },

--- a/src/components/collapse/package.json
+++ b/src/components/collapse/package.json
@@ -40,6 +40,24 @@
             "description": "When set, and prop 'visible' is true on mount, will animate on initial mount"
           }
         ],
+        "slots": [
+          {
+            "name": "default",
+            "version": "2.2.0",
+            "scope": [
+              {
+                "prop": "visible",
+                "type": "Boolean",
+                "description": "Visible state of the collapse: true if the collapse is visible"
+              },
+              {
+                "prop": "close",
+                "type": "Function",
+                "description": "Method for closing the collapse"
+              }
+            ]
+          }
+        ],
         "events": [
           {
             "event": "input",


### PR DESCRIPTION
### Describe the PR

Optionally scoped default slot:

Scope:

- `close()` method for closing the collapse
- `visible` visible state of collapse (boolean)

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples, fix typos`, `chore: fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [x] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
