### PR TITLE
fix(v-b-modal): only unbind/rebind if trigger element or modal ID changes (closes #4669)

### DIFF
--- a/src/directives/modal/modal.js
+++ b/src/directives/modal/modal.js
@@ -79,8 +79,8 @@ const bind = (el, binding, vnode) => {
 
 const unbind = el => {
   const oldProp = el[PROPERTY] || {}
-  const trigger = oldProp[PROPERTY].trigger
-  const handler = oldProp[PROPERTY].handler
+  const trigger = oldProp.trigger
+  const handler = oldProp.handler
   if (trigger && handler) {
     eventOff(trigger, 'click', handler, EVENT_OPTS)
     eventOff(trigger, 'keydown', handler, EVENT_OPTS)

--- a/src/directives/modal/modal.js
+++ b/src/directives/modal/modal.js
@@ -16,7 +16,7 @@ import { keys } from '../../utils/object'
 const EVENT_SHOW = 'bv::show::modal'
 
 // Prop name we use to store info on root element
-const HANDLER = '__bv_modal_directive__'
+const PROPERTY = '__bv_modal_directive__'
 
 const EVENT_OPTS = { passive: true }
 
@@ -64,7 +64,7 @@ const bind = (el, binding, vnode) => {
         }
       }
     }
-    el[HANDLER] = handler
+    el[PROPERTY] = { handler, target, trigger }
     // If element is not a button, we add `role="button"` for accessibility
     setRole(trigger)
     // Listen for click events
@@ -79,18 +79,26 @@ const bind = (el, binding, vnode) => {
 
 const unbind = el => {
   const trigger = getTriggerElement(el)
-  const handler = el ? el[HANDLER] : null
+  const handler = el && el[PROPERTY] ? el[PROPERTY].handler : null
   if (trigger && handler) {
     eventOff(trigger, 'click', handler, EVENT_OPTS)
     eventOff(trigger, 'keydown', handler, EVENT_OPTS)
   }
-  delete el[HANDLER]
+  delete el[PROPERTY]
 }
 
 const componentUpdated = (el, binding, vnode) => {
-  // We bind and rebind just in case target changes
-  unbind(el, binding, vnode)
-  bind(el, binding, vnode)
+  const oldProp = el[PROPERTY] || {}
+  const target = getTarget(binding)
+  const trigger = getTriggerElement(el)
+  if (target !== oldProp.target || trigger !== oldProp.trigger) {
+    // We bind and rebind if the target or trigger changes
+    unbind(el, binding, vnode)
+    bind(el, binding, vnode)
+  }
+  // If trigger element is not a button, ensure `role="button"`
+  // is still set for accessibility
+  setRole(trigger)
 }
 
 const updated = () => {}

--- a/src/directives/modal/modal.js
+++ b/src/directives/modal/modal.js
@@ -78,11 +78,14 @@ const bind = (el, binding, vnode) => {
 }
 
 const unbind = el => {
-  const trigger = getTriggerElement(el)
-  const handler = el && el[PROPERTY] ? el[PROPERTY].handler : null
+  const oldProp = el[PROPERTY] || {}
+  const trigger = oldProp[PROPERTY].trigger
+  const handler = oldProp[PROPERTY].handler
   if (trigger && handler) {
     eventOff(trigger, 'click', handler, EVENT_OPTS)
     eventOff(trigger, 'keydown', handler, EVENT_OPTS)
+    eventOff(el, 'click', handler, EVENT_OPTS)
+    eventOff(el, 'keydown', handler, EVENT_OPTS)
   }
   delete el[PROPERTY]
 }


### PR DESCRIPTION
### Describe the PR

Prevent un-necessary unbind/rebind when parent component updates, by checking if values have changed (modal ID or triiger element).

In some cases when the parent component re-rendered due to a state change on a click handler, the directive would rebind and the modal open event would not have a chance to emit.

Fixes #4669  

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] CodeCov for patch has met target
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
