### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 > [standard-version](https://github.com/conventional-changelog/standard-version) for commit
 > guidelines.
 
+<a name="2.4.0"></a>
+
+## [v2.4.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v2.3.0...v2.4.0)
+
+Released: 2020-02-01
+
+### Features v2.4.0
+
+- **b-modal:** add `ignore-enforce-focus-selector` prop (closes
+  [#4537](https://github.com/bootstrap-vue/bootstrap-vue/issues/4537))
+  ([#4702](https://github.com/bootstrap-vue/bootstrap-vue/issues/4702))
+  ([c3ac992](https://github.com/bootstrap-vue/bootstrap-vue/commit/c3ac99283927b5261d1df05d3c479c534011d7c5))
+- **b-nav-item-dropdown:** add `boundary` prop, applicable when not in `b-navbar` (closes
+  [#4684](https://github.com/bootstrap-vue/bootstrap-vue/issues/4684))
+  ([#4691](https://github.com/bootstrap-vue/bootstrap-vue/issues/4691))
+  ([3a50ad8](https://github.com/bootstrap-vue/bootstrap-vue/commit/3a50ad85e85e1c6dc55a36665062180687078708))
+
+### Bug Fixes v2.4.0
+
+- **b-dropdown:** focus-in handling for Safari and Firefox on macOS/iOS (closes
+  [#4328](https://github.com/bootstrap-vue/bootstrap-vue/issues/4328))
+  ([#4426](https://github.com/bootstrap-vue/bootstrap-vue/issues/4426))
+  ([2eab55b](https://github.com/bootstrap-vue/bootstrap-vue/commit/2eab55b4672a35a487b30f0f64c63b887b361473))
+- **b-form-input, b-form-textarea:** properly handle out-of-sync values (closes
+  [#4695](https://github.com/bootstrap-vue/bootstrap-vue/issues/4695))
+  ([#4701](https://github.com/bootstrap-vue/bootstrap-vue/issues/4701))
+  ([954176d](https://github.com/bootstrap-vue/bootstrap-vue/commit/954176d733dccdd074f5b6cb31c4041081a3b206))
+
 <a name="2.3.0"></a>
 
 ## [v2.3.0](https://github.com/bootstrap-vue/bootstrap-vue/compare/v2.2.2...v2.3.0)

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "babel-plugin-istanbul": "^6.0.0",
     "bootstrap-icons": "^1.0.0-alpha2",
     "clean-css-cli": "^4.3.0",
-    "codecov": "^3.6.2",
+    "codecov": "^3.6.3",
     "codemirror": "^5.51.0",
     "codesandbox": "^2.1.11",
     "core-js": ">=2.6.5 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "husky": "^4.2.1",
     "jest": "^25.1.0",
     "jest-environment-jsdom-fourteen": "^1.0.1",
-    "lint-staged": "^10.0.3",
+    "lint-staged": "^10.0.4",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "postcss-cli": "^7.1.0",
     "prettier": "1.14.3",
     "require-context": "^1.1.0",
-    "rollup": "^1.30.0",
+    "rollup": "^1.30.1",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "husky": "^4.2.1",
     "jest": "^25.1.0",
     "jest-environment-jsdom-fourteen": "^1.0.1",
-    "lint-staged": "^10.0.2",
+    "lint-staged": "^10.0.3",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "eslint-plugin-vue": "^6.1.2",
     "esm": "^3.2.25",
     "gh-pages": "^2.2.0",
-    "highlight.js": "^9.18.0",
+    "highlight.js": "^9.18.1",
     "html-loader": "^0.5.5",
     "husky": "^4.2.1",
     "jest": "^25.1.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "husky": "^4.2.1",
     "jest": "^25.1.0",
     "jest-environment-jsdom-fourteen": "^1.0.1",
-    "lint-staged": "^10.0.6",
+    "lint-staged": "^10.0.7",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-vue",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "BootstrapVue, with over 40 plugins and more than 80 custom components, custom directives, and over 300 icons, provides one of the most comprehensive implementations of Bootstrap v4 components and grid system for Vue.js. With extensive and automated WAI-ARIA accessibility markup.",
   "main": "dist/bootstrap-vue.common.js",
   "web": "dist/bootstrap-vue.js",
@@ -28,24 +28,24 @@
       "url": "https://github.com/tmorehouse"
     },
     {
-      "name": "SirLamer",
-      "url": "https://github.com/SirLamer"
+      "name": "Jacob Müller",
+      "url": "https://github.com/jackmu95"
     },
     {
       "name": "Vitaly Mosin",
       "url": "https://github.com/mosinve"
     },
     {
-      "name": "vizo",
-      "url": "https://github.com/vizo"
-    },
-    {
       "name": "Alex Regan",
       "url": "https://github.com/alexsasharegan"
     },
     {
-      "name": "Jacob Müller",
-      "url": "https://github.com/jackmu95"
+      "name": "SirLamer",
+      "url": "https://github.com/SirLamer"
+    },
+    {
+      "name": "vizo",
+      "url": "https://github.com/vizo"
     }
   ],
   "files": [

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "postcss-cli": "^7.1.0",
     "prettier": "1.14.3",
     "require-context": "^1.1.0",
-    "rollup": "^1.30.1",
+    "rollup": "^1.31.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "husky": "^4.2.1",
     "jest": "^25.1.0",
     "jest-environment-jsdom-fourteen": "^1.0.1",
-    "lint-staged": "^10.0.4",
+    "lint-staged": "^10.0.5",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "husky": "^4.2.1",
     "jest": "^25.1.0",
     "jest-environment-jsdom-fourteen": "^1.0.1",
-    "lint-staged": "^10.0.5",
+    "lint-staged": "^10.0.6",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "postcss-cli": "^7.1.0",
     "prettier": "1.14.3",
     "require-context": "^1.1.0",
-    "rollup": "^1.29.1",
+    "rollup": "^1.30.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -96,12 +96,12 @@
     "vue-functional-data-merge": "^3.1.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.8.4",
     "@babel/plugin-transform-modules-commonjs": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
-    "@babel/standalone": "^7.8.3",
+    "@babel/preset-env": "^7.8.4",
+    "@babel/standalone": "^7.8.4",
     "@nuxtjs/google-analytics": "^2.2.3",
     "@nuxtjs/pwa": "^3.0.0-beta.19",
     "@vue/test-utils": "1.0.0-beta.29",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "babel-plugin-istanbul": "^6.0.0",
     "bootstrap-icons": "^1.0.0-alpha2",
     "clean-css-cli": "^4.3.0",
-    "codecov": "^3.6.3",
+    "codecov": "^3.6.4",
     "codemirror": "^5.51.0",
     "codesandbox": "^2.1.11",
     "core-js": ">=2.6.5 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "core-js": ">=2.6.5 <3.0.0",
     "cross-env": "^7.0.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.9.0",
+    "eslint-config-prettier": "^6.10.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-config-vue": "^2.0.2",
     "eslint-plugin-import": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "codemirror": "^5.51.0",
     "codesandbox": "^2.1.11",
     "core-js": ">=2.6.5 <3.0.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-config-standard": "^14.1.0",

--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -708,13 +708,6 @@ The `.dropdown-menu` is the `<ul>` element, while dropdown items (items, buttons
 headers, and dividers) are wrapped in an `<li>` element. If creating custom items to place inside
 the dropdown menu, ensure they are wrapped with a plain `<li>`.
 
-On touch-enabled devices, opening a `<b-dropdown>` adds empty (noop) `mouseover` handlers to the
-immediate children of the `<body>` element. This admittedly ugly hack is necessary to work around a
-[quirk in iOS' event delegation](https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html),
-which would otherwise prevent a tap anywhere outside of the dropdown from triggering the code that
-closes the dropdown. Once the dropdown is closed, these additional empty `mouseover` handlers are
-removed.
-
 ## See also
 
 - [`<b-nav-item-dropdown>`](/docs/components/nav#dropdown-support) for dropdown support inside

--- a/src/components/dropdown/dropdown-item-button.js
+++ b/src/components/dropdown/dropdown-item-button.js
@@ -1,5 +1,5 @@
 import Vue from '../../utils/vue'
-import nomalizeSlotMixin from '../../mixins/normalize-slot'
+import normalizeSlotMixin from '../../mixins/normalize-slot'
 
 export const props = {
   active: {
@@ -23,7 +23,7 @@ export const props = {
 // @vue/component
 export const BDropdownItemButton = /*#__PURE__*/ Vue.extend({
   name: 'BDropdownItemButton',
-  mixins: [nomalizeSlotMixin],
+  mixins: [normalizeSlotMixin],
   inheritAttrs: false,
   inject: {
     bvDropdown: {

--- a/src/components/dropdown/dropdown-item.js
+++ b/src/components/dropdown/dropdown-item.js
@@ -1,6 +1,6 @@
 import Vue from '../../utils/vue'
 import { requestAF } from '../../utils/dom'
-import nomalizeSlotMixin from '../../mixins/normalize-slot'
+import normalizeSlotMixin from '../../mixins/normalize-slot'
 import { BLink, propsFactory as linkPropsFactory } from '../link/link'
 
 export const props = linkPropsFactory()
@@ -8,7 +8,7 @@ export const props = linkPropsFactory()
 // @vue/component
 export const BDropdownItem = /*#__PURE__*/ Vue.extend({
   name: 'BDropdownItem',
-  mixins: [nomalizeSlotMixin],
+  mixins: [normalizeSlotMixin],
   inheritAttrs: false,
   inject: {
     bvDropdown: {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -146,7 +146,7 @@ export const BDropdown = /*#__PURE__*/ Vue.extend({
             id: this.safeId('_BV_button_')
           },
           on: {
-            click: this.click
+            click: this.onSplitClick
           }
         },
         [buttonContent]
@@ -171,8 +171,9 @@ export const BDropdown = /*#__PURE__*/ Vue.extend({
           'aria-expanded': this.visible ? 'true' : 'false'
         },
         on: {
-          click: this.toggle, // click
-          keydown: this.toggle // enter, space, down
+          mousedown: this.onMousedown,
+          click: this.toggle,
+          keydown: this.toggle // Handle ENTER, SPACE and DOWN
         }
       },
       [this.split ? h('span', { class: ['sr-only'] }, [this.toggleText]) : buttonContent]
@@ -189,7 +190,7 @@ export const BDropdown = /*#__PURE__*/ Vue.extend({
           'aria-labelledby': this.safeId(this.split ? '_BV_button_' : '_BV_toggle_')
         },
         on: {
-          keydown: this.onKeydown // up, down, esc
+          keydown: this.onKeydown // Handle UP, DOWN and ESC
         }
       },
       !this.lazy || this.visible ? this.normalizeSlot('default', { hide: this.hide }) : [h()]

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2,7 +2,6 @@ import Vue from '../../utils/vue'
 import { arrayIncludes } from '../../utils/array'
 import { stripTags } from '../../utils/html'
 import { getComponentConfig } from '../../utils/config'
-import { HTMLElement } from '../../utils/safe-types'
 import idMixin from '../../mixins/id'
 import dropdownMixin from '../../mixins/dropdown'
 import normalizeSlotMixin from '../../mixins/normalize-slot'
@@ -72,12 +71,6 @@ export const props = {
   role: {
     type: String,
     default: 'menu'
-  },
-  boundary: {
-    // String: `scrollParent`, `window` or `viewport`
-    // HTMLElement: HTML Element reference
-    type: [String, HTMLElement],
-    default: 'scrollParent'
   }
 }
 

--- a/src/components/form-input/README.md
+++ b/src/components/form-input/README.md
@@ -354,7 +354,7 @@ Formatting does not occur if a `formatter` is not provided.
         id="input-formatter"
         v-model="text1"
         placeholder="Enter your name"
-        :formatter="format"
+        :formatter="formatter"
       ></b-form-input>
     </b-form-group>
     <p><b>Value:</b> {{ text1 }}</p>
@@ -370,7 +370,7 @@ Formatting does not occur if a `formatter` is not provided.
         v-model="text2"
         placeholder="Enter your name"
         lazy-formatter
-        :formatter="format"
+        :formatter="formatter"
       ></b-form-input>
     </b-form-group>
     <p class="mb-0"><b>Value:</b> {{ text2 }}</p>
@@ -386,7 +386,7 @@ Formatting does not occur if a `formatter` is not provided.
       }
     },
     methods: {
-      format(value, event) {
+      formatter(value) {
         return value.toLowerCase()
       }
     }

--- a/src/components/form-textarea/README.md
+++ b/src/components/form-textarea/README.md
@@ -270,7 +270,7 @@ Formatting does not occur if a `formatter` is not provided.
         id="textarea-formatter"
         v-model="text1"
         placeholder="Enter your text"
-        :formatter="format"
+        :formatter="formatter"
       ></b-form-textarea>
     </b-form-group>
     <p style="white-space: pre-line"><b>Value:</b> {{ text1 }}</p>
@@ -286,7 +286,7 @@ Formatting does not occur if a `formatter` is not provided.
         v-model="text2"
         placeholder="Enter your text"
         lazy-formatter
-        :formatter="format"
+        :formatter="formatter"
       ></b-form-textarea>
     </b-form-group>
     <p class="mb-0" style="white-space: pre-line"><b>Value:</b> {{ text2 }}</p>
@@ -302,7 +302,7 @@ Formatting does not occur if a `formatter` is not provided.
       }
     },
     methods: {
-      format(value, event) {
+      formatter(value) {
         return value.toLowerCase()
       }
     }

--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -1156,8 +1156,11 @@ Avoid setting `tabindex` on elements within the modal to any value other than `0
 will make it difficult for people who rely on assistive technology to navigate and operate page
 content and can make some of your elements unreachable via keyboard navigation.
 
-In some circumstances, you may need to disable the enforce focus feature. You can do this by setting
-the prop `no-enforce-focus`, although this is highly discouraged.
+If some elements outside the modal need to be focusable (i.e. for TinyMCE), you can add them to the
+`ignore-enforce-focus-selector` prop.
+
+In some circumstances, you may need to disable the enforce focus feature completely. You can do this
+by setting the prop `no-enforce-focus`, although this is highly discouraged.
 
 ### `v-b-modal` directive accessibility
 

--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -1156,11 +1156,23 @@ Avoid setting `tabindex` on elements within the modal to any value other than `0
 will make it difficult for people who rely on assistive technology to navigate and operate page
 content and can make some of your elements unreachable via keyboard navigation.
 
-If some elements outside the modal need to be focusable (i.e. for TinyMCE), you can add them to the
-`ignore-enforce-focus-selector` prop.
+If some elements outside the modal need to be focusable (i.e. for TinyMCE), you can add them as CSS
+selectors to the `ignore-enforce-focus-selector` prop
+<span class="badge badge-secondary">2.4.0+</span>, e.g.:
+
+```html
+<b-modal
+  id="some-modal-id"
+  title="Modal with TinyMCE Editor"
+  ignore-enforce-focus-selector=".tox-tinymce-aux, .moxman-window, .tam-assetmanager-root"
+>
+  <!-- Modal content with TinyMCE editor here -->
+</b-modal>
+```
 
 In some circumstances, you may need to disable the enforce focus feature completely. You can do this
-by setting the prop `no-enforce-focus`, although this is highly discouraged.
+by setting the prop `no-enforce-focus`, although this is _highly discouraged_ for accessibility
+reasons.
 
 ### `v-b-modal` directive accessibility
 

--- a/src/components/modal/modal.spec.js
+++ b/src/components/modal/modal.spec.js
@@ -179,7 +179,7 @@ describe('modal', () => {
         },
         propsData: {
           static: false,
-          id: 'testtarget',
+          id: 'test-target',
           visible: true
         }
       })
@@ -190,7 +190,7 @@ describe('modal', () => {
       expect(wrapper.isEmpty()).toBe(true)
       expect(wrapper.element.nodeType).toEqual(Node.COMMENT_NODE)
 
-      const outer = document.getElementById('testtarget___BV_modal_outer_')
+      const outer = document.getElementById('test-target___BV_modal_outer_')
       expect(outer).toBeDefined()
       expect(outer).not.toBe(null)
 
@@ -205,7 +205,7 @@ describe('modal', () => {
       await waitNT(wrapper.vm)
       await waitRAF()
 
-      // Should no longer be in document.
+      // Should no longer be in document
       expect(outer.parentElement).toEqual(null)
     })
 
@@ -358,14 +358,14 @@ describe('modal', () => {
       const $cancel = $buttons.at(0)
       expect($cancel.attributes('type')).toBe('button')
       expect($cancel.text()).toContain('cancel')
-      // v-html is applied to a span
+      // `v-html` is applied to a span
       expect($cancel.html()).toContain('<span><em>cancel</em></span>')
 
       // OK button (right-most button)
       const $ok = $buttons.at(1)
       expect($ok.attributes('type')).toBe('button')
       expect($ok.text()).toContain('ok')
-      // v-html is applied to a span
+      // `v-html` is applied to a span
       expect($ok.html()).toContain('<span><em>ok</em></span>')
 
       wrapper.destroy()
@@ -1161,8 +1161,8 @@ describe('modal', () => {
       const App = localVue.extend({
         render(h) {
           return h('div', {}, [
-            h('button', { class: 'trigger', attrs: { id: 'trigger', type: 'button' } }, 'trigger'),
-            h(BModal, { props: { static: true, id: 'test', visible: true } }, 'modal content')
+            h('button', { attrs: { id: 'button', type: 'button' } }, 'Button'),
+            h(BModal, { props: { static: true, id: 'test', visible: true } }, 'Modal content')
           ])
         }
       })
@@ -1185,7 +1185,7 @@ describe('modal', () => {
       await waitNT(wrapper.vm)
       await waitRAF()
 
-      const $button = wrapper.find('button.trigger')
+      const $button = wrapper.find('#button')
       expect($button.exists()).toBe(true)
       expect($button.is('button')).toBe(true)
 
@@ -1198,54 +1198,196 @@ describe('modal', () => {
       expect(document.activeElement).not.toBe(document.body)
       expect(document.activeElement).toBe($content.element)
 
-      // Try and set focusin on external button
+      // Try and focus the external button
+      $button.element.focus()
       $button.trigger('focusin')
-      await waitNT(wrapper.vm)
       expect(document.activeElement).not.toBe($button.element)
       expect(document.activeElement).toBe($content.element)
 
-      // Try and set focusin on external button
-      $button.trigger('focus')
-      await waitNT(wrapper.vm)
-      expect(document.activeElement).not.toBe($button.element)
-      expect(document.activeElement).toBe($content.element)
-
-      // Emulate TAB by focusing the `bottomTrap` span element.
+      // Emulate TAB by focusing the `bottomTrap` span element
       // Should focus first button in modal (in the header)
       const $bottomTrap = wrapper.find(BModal).find({ ref: 'bottomTrap' })
       expect($bottomTrap.exists()).toBe(true)
       expect($bottomTrap.is('span')).toBe(true)
-      // Find the close (x) button (it is the only one with the .close class)
+      // Find the close (x) button (it is the only one with the `.close` class)
       const $closeButton = $modal.find('button.close')
       expect($closeButton.exists()).toBe(true)
       expect($closeButton.is('button')).toBe(true)
-      // focus the tab trap
+      // Focus the tab trap
+      $bottomTrap.element.focus()
       $bottomTrap.trigger('focusin')
-      $bottomTrap.trigger('focus')
       await waitNT(wrapper.vm)
       expect(document.activeElement).not.toBe($bottomTrap.element)
       expect(document.activeElement).not.toBe($content.element)
       // The close (x) button (first tabable in modal) should be focused
       expect(document.activeElement).toBe($closeButton.element)
 
-      // Emulate CTRL-TAB by focusing the `topTrap` div element.
+      // Emulate CTRL-TAB by focusing the `topTrap` div element
       // Should focus last button in modal (in the footer)
       const $topTrap = wrapper.find(BModal).find({ ref: 'topTrap' })
       expect($topTrap.exists()).toBe(true)
       expect($topTrap.is('span')).toBe(true)
-      // Find the OK button (it is the only one with .btn-primary class)
+      // Find the OK button (it is the only one with `.btn-primary` class)
       const $okButton = $modal.find('button.btn.btn-primary')
       expect($okButton.exists()).toBe(true)
       expect($okButton.is('button')).toBe(true)
-      // focus the tab trap
+      // Focus the tab trap
+      $topTrap.element.focus()
       $topTrap.trigger('focusin')
-      $topTrap.trigger('focus')
       await waitNT(wrapper.vm)
       expect(document.activeElement).not.toBe($topTrap.element)
       expect(document.activeElement).not.toBe($bottomTrap.element)
       expect(document.activeElement).not.toBe($content.element)
       // The OK button (last tabbable in modal) should be focused
       expect(document.activeElement).toBe($okButton.element)
+
+      wrapper.destroy()
+    })
+
+    it('it allows focus for elements when "no-enforce-focus" enabled', async () => {
+      const App = localVue.extend({
+        render(h) {
+          return h('div', {}, [
+            h('button', { attrs: { id: 'button1', type: 'button' } }, 'Button 1'),
+            h('button', { attrs: { id: 'button2', type: 'button' } }, 'Button 2'),
+            h(
+              BModal,
+              {
+                props: {
+                  static: true,
+                  id: 'test',
+                  visible: true,
+                  noEnforceFocus: true
+                }
+              },
+              'Modal content'
+            )
+          ])
+        }
+      })
+      const wrapper = mount(App, {
+        attachToDocument: true,
+        localVue: localVue,
+        stubs: {
+          transition: false
+        }
+      })
+
+      expect(wrapper.isVueInstance()).toBe(true)
+
+      await waitNT(wrapper.vm)
+      await waitRAF()
+      await waitNT(wrapper.vm)
+      await waitRAF()
+      await waitNT(wrapper.vm)
+      await waitRAF()
+      await waitNT(wrapper.vm)
+      await waitRAF()
+
+      const $button1 = wrapper.find('#button1')
+      expect($button1.exists()).toBe(true)
+      expect($button1.is('button')).toBe(true)
+
+      const $button2 = wrapper.find('#button2')
+      expect($button2.exists()).toBe(true)
+      expect($button2.is('button')).toBe(true)
+
+      const $modal = wrapper.find('div.modal')
+      expect($modal.exists()).toBe(true)
+      const $content = $modal.find('div.modal-content')
+      expect($content.exists()).toBe(true)
+
+      expect($modal.element.style.display).toEqual('block')
+      expect(document.activeElement).not.toBe(document.body)
+      expect(document.activeElement).toBe($content.element)
+
+      // Try to focus button1
+      $button1.element.focus()
+      $button1.trigger('focusin')
+      await waitNT(wrapper.vm)
+      expect(document.activeElement).toBe($button1.element)
+      expect(document.activeElement).not.toBe($content.element)
+
+      // Try to focus button2
+      $button2.element.focus()
+      $button2.trigger('focusin')
+      await waitNT(wrapper.vm)
+      expect(document.activeElement).toBe($button2.element)
+      expect(document.activeElement).not.toBe($content.element)
+
+      wrapper.destroy()
+    })
+
+    it('it allows focus for elements in "ignore-enforce-focus-selector" prop', async () => {
+      const App = localVue.extend({
+        render(h) {
+          return h('div', {}, [
+            h('button', { attrs: { id: 'button1', type: 'button' } }, 'Button 1'),
+            h('button', { attrs: { id: 'button2', type: 'button' } }, 'Button 2'),
+            h(
+              BModal,
+              {
+                props: {
+                  static: true,
+                  id: 'test',
+                  visible: true,
+                  ignoreEnforceFocusSelector: '#button1'
+                }
+              },
+              'Modal content'
+            )
+          ])
+        }
+      })
+      const wrapper = mount(App, {
+        attachToDocument: true,
+        localVue: localVue,
+        stubs: {
+          transition: false
+        }
+      })
+
+      expect(wrapper.isVueInstance()).toBe(true)
+
+      await waitNT(wrapper.vm)
+      await waitRAF()
+      await waitNT(wrapper.vm)
+      await waitRAF()
+      await waitNT(wrapper.vm)
+      await waitRAF()
+      await waitNT(wrapper.vm)
+      await waitRAF()
+
+      const $button1 = wrapper.find('#button1')
+      expect($button1.exists()).toBe(true)
+      expect($button1.is('button')).toBe(true)
+
+      const $button2 = wrapper.find('#button2')
+      expect($button2.exists()).toBe(true)
+      expect($button2.is('button')).toBe(true)
+
+      const $modal = wrapper.find('div.modal')
+      expect($modal.exists()).toBe(true)
+      const $content = $modal.find('div.modal-content')
+      expect($content.exists()).toBe(true)
+
+      expect($modal.element.style.display).toEqual('block')
+      expect(document.activeElement).not.toBe(document.body)
+      expect(document.activeElement).toBe($content.element)
+
+      // Try to focus button1
+      $button1.element.focus()
+      $button1.trigger('focusin')
+      await waitNT(wrapper.vm)
+      expect(document.activeElement).toBe($button1.element)
+      expect(document.activeElement).not.toBe($content.element)
+
+      // Try to focus button2
+      $button2.element.focus()
+      $button2.trigger('focusin')
+      await waitNT(wrapper.vm)
+      expect(document.activeElement).not.toBe($button2.element)
+      expect(document.activeElement).toBe($content.element)
 
       wrapper.destroy()
     })

--- a/src/components/modal/package.json
+++ b/src/components/modal/package.json
@@ -94,6 +94,11 @@
             "description": "Disables the enforce focus routine which maintains focus inside the modal"
           },
           {
+            "prop": "ignoreEnforceFocusSelector",
+            "version": "2.4.0",
+            "description": "Ignore certain elements from the enforce focus routine, specified by css selector(s)"
+          },
+          {
             "prop": "titleSrOnly",
             "description": "Wraps the title in an '.sr-only' wrapper"
           },

--- a/src/components/nav/nav-item-dropdown.js
+++ b/src/components/nav/nav-item-dropdown.js
@@ -54,8 +54,9 @@ export const BNavItemDropdown = /*#__PURE__*/ Vue.extend({
           'aria-expanded': this.visible ? 'true' : 'false'
         },
         on: {
+          mousedown: this.onMousedown,
           click: this.toggle,
-          keydown: this.toggle // space, enter, down
+          keydown: this.toggle // Handle ENTER, SPACE and DOWN
         }
       },
       [
@@ -75,7 +76,7 @@ export const BNavItemDropdown = /*#__PURE__*/ Vue.extend({
           'aria-labelledby': this.safeId('_BV_button_')
         },
         on: {
-          keydown: this.onKeydown // up, down, esc
+          keydown: this.onKeydown // Handle UP, DOWN and ESC
         }
       },
       !this.lazy || this.visible ? this.normalizeSlot('default', { hide: this.hide }) : [h()]

--- a/src/components/nav/package.json
+++ b/src/components/nav/package.json
@@ -143,6 +143,11 @@
           {
             "prop": "noCaret",
             "description": "Hide the caret indicator on the toggle button"
+          },
+          {
+            "prop": "boundary",
+            "version": "2.4.0",
+            "description": "The boundary constraint of the menu: 'scrollParent', 'window', 'viewport', or a reference to an HTMLElement. Has no effect when dropdown is inside a b-navbar"
           }
         ],
         "slots": [

--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -1,7 +1,7 @@
 import Vue from '../../utils/vue'
-import { mergeData } from 'vue-functional-data-merge'
 import { getComponentConfig, getBreakpoints } from '../../utils/config'
 import { isString } from '../../utils/inspect'
+import normalizeSlotMixin from '../../mixins/normalize-slot'
 
 const NAME = 'BNavbar'
 
@@ -38,33 +38,45 @@ export const props = {
 // @vue/component
 export const BNavbar = /*#__PURE__*/ Vue.extend({
   name: NAME,
-  functional: true,
+  mixins: [normalizeSlotMixin],
   props,
-  render(h, { props, data, children }) {
-    let breakpoint = ''
-    const xs = getBreakpoints()[0]
-    if (props.toggleable && isString(props.toggleable) && props.toggleable !== xs) {
-      breakpoint = `navbar-expand-${props.toggleable}`
-    } else if (props.toggleable === false) {
-      breakpoint = 'navbar-expand'
+  provide() {
+    return { bvNavbar: this }
+  },
+  computed: {
+    breakpointClass() {
+      let breakpoint = null
+      const xs = getBreakpoints()[0]
+      const toggleable = this.toggleable
+      if (toggleable && isString(toggleable) && toggleable !== xs) {
+        breakpoint = `navbar-expand-${toggleable}`
+      } else if (toggleable === false) {
+        breakpoint = 'navbar-expand'
+      }
+
+      return breakpoint
     }
+  },
+  render(h) {
     return h(
-      props.tag,
-      mergeData(data, {
+      this.tag,
+      {
         staticClass: 'navbar',
-        class: {
-          'd-print': props.print,
-          'sticky-top': props.sticky,
-          [`navbar-${props.type}`]: props.type,
-          [`bg-${props.variant}`]: props.variant,
-          [`fixed-${props.fixed}`]: props.fixed,
-          [`${breakpoint}`]: breakpoint
-        },
+        class: [
+          {
+            'd-print': this.print,
+            'sticky-top': this.sticky,
+            [`navbar-${this.type}`]: this.type,
+            [`bg-${this.variant}`]: this.variant,
+            [`fixed-${this.fixed}`]: this.fixed
+          },
+          this.breakpointClass
+        ],
         attrs: {
-          role: props.tag === 'nav' ? null : 'navigation'
+          role: this.tag === 'nav' ? null : 'navigation'
         }
-      }),
-      children
+      },
+      [this.normalizeSlot('default')]
     )
   }
 })

--- a/src/components/navbar/navbar.spec.js
+++ b/src/components/navbar/navbar.spec.js
@@ -19,9 +19,7 @@ describe('navbar', () => {
 
   it('accepts custom tag', async () => {
     const wrapper = mount(BNavbar, {
-      context: {
-        props: { tag: 'div' }
-      }
+      propsData: { tag: 'div' }
     })
     expect(wrapper.is('div')).toBe(true)
     expect(wrapper.attributes('role')).toBeDefined()
@@ -30,9 +28,7 @@ describe('navbar', () => {
 
   it('accepts breakpoint via toggleable prop', async () => {
     const wrapper = mount(BNavbar, {
-      context: {
-        props: { toggleable: 'lg' }
-      }
+      propsData: { toggleable: 'lg' }
     })
     expect(wrapper.classes()).toContain('navbar')
     expect(wrapper.classes()).toContain('navbar-expand-lg')
@@ -42,9 +38,7 @@ describe('navbar', () => {
 
   it('toggleable=true has expected classes', async () => {
     const wrapper = mount(BNavbar, {
-      context: {
-        props: { toggleable: true }
-      }
+      propsData: { toggleable: true }
     })
     expect(wrapper.classes()).toContain('navbar')
     expect(wrapper.classes()).toContain('navbar-light')
@@ -53,9 +47,7 @@ describe('navbar', () => {
 
   it('toggleable=xs has expected classes', async () => {
     const wrapper = mount(BNavbar, {
-      context: {
-        props: { toggleable: 'xs' }
-      }
+      propsData: { toggleable: 'xs' }
     })
     expect(wrapper.classes()).toContain('navbar')
     expect(wrapper.classes()).toContain('navbar-light')
@@ -64,9 +56,7 @@ describe('navbar', () => {
 
   it('has class "fixed-top" when fixed="top"', async () => {
     const wrapper = mount(BNavbar, {
-      context: {
-        props: { fixed: 'top' }
-      }
+      propsData: { fixed: 'top' }
     })
     expect(wrapper.classes()).toContain('fixed-top')
     expect(wrapper.classes()).toContain('navbar')
@@ -77,9 +67,7 @@ describe('navbar', () => {
 
   it('has class "fixed-top" when fixed="top"', async () => {
     const wrapper = mount(BNavbar, {
-      context: {
-        props: { fixed: 'top' }
-      }
+      propsData: { fixed: 'top' }
     })
     expect(wrapper.classes()).toContain('fixed-top')
     expect(wrapper.classes()).toContain('navbar')
@@ -90,9 +78,7 @@ describe('navbar', () => {
 
   it('has class "sticky-top" when sticky=true', async () => {
     const wrapper = mount(BNavbar, {
-      context: {
-        props: { sticky: true }
-      }
+      propsData: { sticky: true }
     })
     expect(wrapper.classes()).toContain('sticky-top')
     expect(wrapper.classes()).toContain('navbar')
@@ -103,9 +89,7 @@ describe('navbar', () => {
 
   it('accepts variant prop', async () => {
     const wrapper = mount(BNavbar, {
-      context: {
-        props: { variant: 'primary' }
-      }
+      propsData: { variant: 'primary' }
     })
     expect(wrapper.classes()).toContain('bg-primary')
     expect(wrapper.classes()).toContain('navbar')

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -575,6 +575,21 @@ values: `sm`, `md`, `lg`, or `xl`.
 - _Possible vertical clipping/truncation_. Responsive tables make use of `overflow-y: hidden`, which
   clips off any content that goes beyond the bottom or top edges of the table. In particular, this
   may clip off dropdown menus and other third-party widgets.
+- Using props `responsive` and `fixed` together will **not** work as expected. Fixed table layout
+  uses the first row (table header in this case) to compute the width required by each column (and
+  the overall table width) to fit within the width of the parent container &mdash; without taking
+  cells in the `<tbody>` into consideration &mdash; resulting in table that may not be resposive. To
+  get around this limitation, you would need to specify widths for the columns (or certain columns)
+  via one of the following methods:
+  - Use `<col>` elements within the [`table-colgroup` slot](#table-colgroup) that have widths set
+    (e.g. `<col style="width: 20rem">`), or
+  - Wrap header cells in `<div>` elements, via the use of
+    [custom header rendering](#header-and-footer-custom-rendering-via-scoped-slots), which have a
+    minimum width set on them, or
+  - Use the `thStyle` property of the [field definition object](#field-definition-reference) to
+    set a width for the column(s), or
+  - Use custom CSS to define classes to apply to the columns to set widths, via the `thClass` or
+    `class` properties of the [field definition object](#field-definition-reference).
 
 ### Stacked tables
 

--- a/src/icons/README.md
+++ b/src/icons/README.md
@@ -561,38 +561,38 @@ font scaled by 125%).
     <b-button-toolbar>
       <b-button-group class="mr-1">
         <b-button title="Save file">
-          <b-icon icon="cloud-upload" aria-hidden="true">
+          <b-icon icon="cloud-upload" aria-hidden="true"></b-icon>
         </b-button>
         <b-button title="Load file">
-          <b-icon icon="cloud-download" aria-hidden="true">
+          <b-icon icon="cloud-download" aria-hidden="true"></b-icon>
         </b-button>
         <b-button title="New document">
-          <b-icon icon="document" aria-hidden="true">
+          <b-icon icon="document" aria-hidden="true"></b-icon>
         </b-button>
       </b-button-group>
       <b-button-group class="mr-1">
         <b-button title="Align left">
-          <b-icon icon="text-left" aria-hidden="true">
+          <b-icon icon="text-left" aria-hidden="true"></b-icon>
         </b-button>
         <b-button title="Align center">
-          <b-icon icon="text-center" aria-hidden="true">
+          <b-icon icon="text-center" aria-hidden="true"></b-icon>
         </b-button>
         <b-button title="Align right">
-          <b-icon icon="text-right" aria-hidden="true">
+          <b-icon icon="text-right" aria-hidden="true"></b-icon>
         </b-button>
       </b-button-group>
       <b-button-group>
         <b-button title="Bold">
-          <b-icon icon="type-bold" aria-hidden="true">
+          <b-icon icon="type-bold" aria-hidden="true"></b-icon>
         </b-button>
         <b-button title="Italic">
-          <b-icon icon="type-italic" aria-hidden="true">
+          <b-icon icon="type-italic" aria-hidden="true"></b-icon>
         </b-button>
         <b-button title="Underline">
-          <b-icon icon="type-underline" aria-hidden="true">
+          <b-icon icon="type-underline" aria-hidden="true"></b-icon>
         </b-button>
         <b-button title="Strikethrough">
-          <b-icon icon="type-strikethrough" aria-hidden="true">
+          <b-icon icon="type-strikethrough" aria-hidden="true"></b-icon>
         </b-button>
       </b-button-group>
     </b-button-toolbar>

--- a/src/mixins/click-out.js
+++ b/src/mixins/click-out.js
@@ -29,7 +29,7 @@ export default {
       this.clickOutElement = document
     }
     if (!this.clickOutEventName) {
-      this.clickOutEventName = 'ontouchstart' in document.documentElement ? 'touchstart' : 'click'
+      this.clickOutEventName = 'click'
     }
     if (this.listenForClickOut) {
       eventOn(this.clickOutElement, this.clickOutEventName, this._clickOutHandler, eventOptions)

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -4,6 +4,7 @@ import { BvEvent } from '../utils/bv-event.class'
 import { closest, contains, isVisible, requestAF, selectAll } from '../utils/dom'
 import { hasTouchSupport } from '../utils/env'
 import { isNull } from '../utils/inspect'
+import { HTMLElement } from '../utils/safe-types'
 import { warn } from '../utils/warn'
 import clickOutMixin from './click-out'
 import focusInMixin from './focus-in'
@@ -108,6 +109,12 @@ export default {
     popperOpts: {
       // type: Object,
       default: () => {}
+    },
+    boundary: {
+      // String: `scrollParent`, `window` or `viewport`
+      // HTMLElement: HTML Element reference
+      type: [String, HTMLElement],
+      default: 'scrollParent'
     }
   },
   data() {

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -67,10 +67,6 @@ export default {
     }
   },
   computed: {
-    computedDebounce() {
-      // Ensure we have a positive number equal to or greater than 0
-      return Math.max(toInteger(this.debounce) || 0, 0)
-    },
     computedClass() {
       return [
         {
@@ -98,6 +94,13 @@ export default {
       }
       // Most likely a string value (which could be the string 'true')
       return this.ariaInvalid
+    },
+    computedDebounce() {
+      // Ensure we have a positive number equal to or greater than 0
+      return Math.max(toInteger(this.debounce) || 0, 0)
+    },
+    hasFormatter() {
+      return isFunction(this.formatter)
     }
   },
   watch: {
@@ -132,7 +135,7 @@ export default {
     },
     formatValue(value, evt, force = false) {
       value = toString(value)
-      if ((!this.lazyFormatter || force) && isFunction(this.formatter)) {
+      if (this.hasFormatter && (!this.lazyFormatter || force)) {
         value = this.formatter(value, evt)
       }
       return value
@@ -151,7 +154,6 @@ export default {
     },
     updateValue(value, force = false) {
       const lazy = this.lazy
-      const ms = this.computedDebounce
       if (lazy && !force) {
         return
       }
@@ -162,12 +164,27 @@ export default {
           this.vModelValue = value
           this.$emit('update', value)
         }
-        if (ms > 0 && !lazy && !force) {
-          // Change/Blur/Force will not be debounced
-          this.$_inputDebounceTimer = setTimeout(doUpdate, ms)
+        const debounce = this.computedDebounce
+        // Only debounce the value update when a value greater than `0`
+        // is set and we are not in lazy mode or this is a forced update
+        if (debounce > 0 && !lazy && !force) {
+          this.$_inputDebounceTimer = setTimeout(doUpdate, debounce)
         } else {
           // Immediately update the v-model
           doUpdate()
+        }
+      } else if (this.hasFormatter) {
+        // When the `vModelValue` hasn't changed but the actual input value
+        // is out of sync, make sure to change it to the given one
+        // Usually caused by browser autocomplete and how it triggers the
+        // change or input event, or depending on the formatter function
+        // https://github.com/bootstrap-vue/bootstrap-vue/issues/2657
+        // https://github.com/bootstrap-vue/bootstrap-vue/issues/3498
+        /* istanbul ignore next: hard to test */
+        const $input = this.$refs.input
+        /* istanbul ignore if: hard to test outof sync value */
+        if ($input && value !== $input.value) {
+          $input.value = value
         }
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11687,10 +11687,10 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.29.1:
-  version "1.29.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.29.1.tgz#8715d0a4ca439be3079f8095989ec8aa60f637bc"
-  integrity sha512-dGQ+b9d1FOX/gluiggTAVnTvzQZUEkCi/TwZcax7ujugVRHs0nkYJlV9U4hsifGEMojnO+jvEML2CJQ6qXgbHA==
+rollup@^1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.30.0.tgz#ae9c893804e8eaa8f8f74b0aaf7e7fb4374a9d01"
+  integrity sha512-ANcmfaSQwpcJtZUTA0ZMNBtFcQ1B4A5FldlNqEK0WdWm9sHSKu93ffa2KV1ux8HA/yKIV/ZARV28m7rNdXJgEw==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8436,10 +8436,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.0.3:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.3.tgz#fd27e25c308fb857d9cb44caa5fa845408d07df4"
-  integrity sha512-N071+M0yxKX0u67UOB8emFms29ekzrKoX1UlPcLS615O/rhx3+xRk5so8uU4tjdg4yNsD3ntdPSsuZnUPzblLA==
+lint-staged@^10.0.4:
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.4.tgz#89212e005890595e4edb2df63afb486ad8d5ad78"
+  integrity sha512-lTmhvbFCyKKV8wcyuENTccjlsHP9bYtl/Xxe5ZMTwEZ7Qvar78jOGomkf6nzHuQns6vKRUYWS6L9N8s7x+jnXQ==
   dependencies:
     chalk "^3.0.0"
     commander "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5434,10 +5434,10 @@ escodegen@^1.11.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.9.0.tgz#430d24822e82f7deb1e22a435bfa3999fae4ad64"
-  integrity sha512-k4E14HBtcLv0uqThaI6I/n1LEqROp8XaPu6SO9Z32u5NlGRC07Enu1Bh2KEFw4FNHbekH8yzbIU9kUGxbiGmCA==
+eslint-config-prettier@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz#7b15e303bf9c956875c948f6b21500e48ded6a7f"
+  integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==
   dependencies:
     get-stdin "^6.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6831,10 +6831,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.0.tgz#6b1763cfcd53744313bd3f31f1210f7beb962c79"
-  integrity sha512-A97kI1KAUzKoAiEoaGcf2O9YPS8nbDTCRFokaaeBhnqjQTvbAuAJrQMm21zw8s8xzaMtCQBtgbyGXLGxdxQyqQ==
+highlight.js@^9.18.1:
+  version "9.18.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
+  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8436,10 +8436,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.2.tgz#cfdd9fa5080b05fc6e29536897da1795bc67c7f9"
-  integrity sha512-ZldhtIfT7bynVa7nmU/1jbK05r9hYQXbIQqZSotqdBCAcGJDEUqaUB7kG3ZCdoe9Qkj6HUM3x2yjCGJRxPUQLA==
+lint-staged@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.3.tgz#fd27e25c308fb857d9cb44caa5fa845408d07df4"
+  integrity sha512-N071+M0yxKX0u67UOB8emFms29ekzrKoX1UlPcLS615O/rhx3+xRk5so8uU4tjdg4yNsD3ntdPSsuZnUPzblLA==
   dependencies:
     chalk "^3.0.0"
     commander "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11687,10 +11687,10 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.30.0.tgz#ae9c893804e8eaa8f8f74b0aaf7e7fb4374a9d01"
-  integrity sha512-ANcmfaSQwpcJtZUTA0ZMNBtFcQ1B4A5FldlNqEK0WdWm9sHSKu93ffa2KV1ux8HA/yKIV/ZARV28m7rNdXJgEw==
+rollup@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.30.1.tgz#3fd28d6198beb2f3cd1640732047d5ec16c2d3a0"
+  integrity sha512-Uus8mwQXwaO+ZVoNwBcXKhT0AvycFCBW/W8VZtkpVGsotRllWk9oldfCjqWmTnFRI0y7x6BnEqSqc65N+/YdBw==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8467,10 +8467,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.0.6:
-  version "10.0.6"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.6.tgz#62d3f49a09a12e4df876dd8667a09d9a2d39495c"
-  integrity sha512-pz3k0J2/+sy2a2pUsMMCpbsChcK8nIyDIf73xAHPqXQRPogBedb0r/nHDKgrtu9v9cZ96Fc60NieoNMQoQU65Q==
+lint-staged@^10.0.7:
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.7.tgz#d205f92d9359419a23bc6aa3b6f8546b1998da64"
+  integrity sha512-Byj0F4l7GYUpYYHEqyFH69NiI6ICTg0CeCKbhRorL+ickbzILKUlZLiyCkljZV02wnoh7yH7PmFyYm9PRNwk9g==
   dependencies:
     chalk "^3.0.0"
     commander "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4514,12 +4514,12 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
-  integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
+cross-env@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.0.tgz#5a3b2ddce51ec713ea58f2fb79ce22e65b4f5479"
+  integrity sha512-rV6M9ldNgmwP7bx5u6rZsTbYidzwvrwIYZnT08hSGLcQCcggofgFW+sNe7IhA1SRauPS0QuLbbX+wdNtpqE5CQ==
   dependencies:
-    cross-spawn "^7.0.0"
+    cross-spawn "^7.0.1"
 
 cross-spawn@^3.0.0:
   version "3.0.1"
@@ -4549,7 +4549,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8467,10 +8467,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.0.5:
-  version "10.0.5"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.5.tgz#871a968a078533dd47bad69599c318b8cc47d758"
-  integrity sha512-Y6V53LnwGxxUD0CCPTCGDlQx2l3RkW0gebgc5XBxKWEf1r0K1b1imedA1owQF7c3+lC9fp7AjWMrRiBsHSCmNQ==
+lint-staged@^10.0.6:
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.6.tgz#62d3f49a09a12e4df876dd8667a09d9a2d39495c"
+  integrity sha512-pz3k0J2/+sy2a2pUsMMCpbsChcK8nIyDIf73xAHPqXQRPogBedb0r/nHDKgrtu9v9cZ96Fc60NieoNMQoQU65Q==
   dependencies:
     chalk "^3.0.0"
     commander "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8436,10 +8436,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.0.4:
-  version "10.0.4"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.4.tgz#89212e005890595e4edb2df63afb486ad8d5ad78"
-  integrity sha512-lTmhvbFCyKKV8wcyuENTccjlsHP9bYtl/Xxe5ZMTwEZ7Qvar78jOGomkf6nzHuQns6vKRUYWS6L9N8s7x+jnXQ==
+lint-staged@^10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.5.tgz#871a968a078533dd47bad69599c318b8cc47d758"
+  integrity sha512-Y6V53LnwGxxUD0CCPTCGDlQx2l3RkW0gebgc5XBxKWEf1r0K1b1imedA1owQF7c3+lC9fp7AjWMrRiBsHSCmNQ==
   dependencies:
     chalk "^3.0.0"
     commander "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,6 +2586,18 @@ agent-base@4, agent-base@^4.1.0, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
+agent-base@6:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.0.tgz#5d0101f19bbfaed39980b22ae866de153b93f09a"
+  integrity sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==
+  dependencies:
+    debug "4"
+
 agentkeepalive@^3.3.0:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz#a113924dd3fa24a0bc3b78108c450c2abee00f67"
@@ -2748,7 +2760,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-argv@^0.0.2:
+argv@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
   integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
@@ -3961,17 +3973,17 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.2.tgz#9503533d744233f6864f8f3ead9435d285ed3f47"
-  integrity sha512-i1VYZYY3M8Lodk/QRsIWYVimkuhl0oMSiM2itxbTbEIjB0PCSWP1cI7cscu5P0MayggoTl6I/jkXV2go8Ub8/Q==
+codecov@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.3.tgz#2ea98e71111312cf102b51f17b8c07b78bda4ee6"
+  integrity sha512-wxUdYS+ajCbbWcDUUiJL8H3q03Sn/R53wmLbJ4ixnLsudqNdBg+mttFlSuSCtJsl1PsJbeIUkjh4vBLfh2WhgQ==
   dependencies:
-    argv "^0.0.2"
-    ignore-walk "^3.0.1"
-    js-yaml "^3.13.1"
-    teeny-request "^3.11.3"
-    urlgrey "^0.4.4"
-    validator "^12.1.0"
+    argv "0.0.2"
+    ignore-walk "3.0.3"
+    js-yaml "3.13.1"
+    teeny-request "6.0.1"
+    urlgrey "0.4.4"
+    validator "12.2.0"
 
 codemirror@^5.51.0:
   version "5.51.0"
@@ -4916,17 +4928,17 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -6984,6 +6996,14 @@ http-proxy-agent@^2.0.0:
     agent-base "4"
     debug "3.1.0"
 
+http-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.0.tgz#6b74d332e1934a1107b97e97de4a00e267c790fe"
+  integrity sha512-GX0FA6+IcDf4Oxc/FBWgYj4zKgo/DnZrksaG9jyuQLExs6xlX+uI5lcA8ymM3JaZTRrF/4s2UX19wJolyo7OBA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -6998,13 +7018,21 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^2.1.0, https-proxy-agent@^2.2.1:
+https-proxy-agent@^2.1.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
   integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
+
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -7071,7 +7099,7 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
-ignore-walk@^3.0.1:
+ignore-walk@3.0.3, ignore-walk@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
   integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
@@ -8211,7 +8239,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.1:
+js-yaml@3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -12399,6 +12427,13 @@ stream-each@^1.1.0:
     end-of-stream "^1.1.0"
     stream-shift "^1.0.0"
 
+stream-events@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.5.tgz#bbc898ec4df33a4902d892333d47da9bf1c406d5"
+  integrity sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==
+  dependencies:
+    stubs "^3.0.0"
+
 stream-http@^2.7.2:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
@@ -12601,6 +12636,11 @@ strip-url-auth@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
   integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
 
+stubs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
+  integrity sha1-6NK6H6nJBXAwPAMLaQD31fiavls=
+
 style-resources-loader@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/style-resources-loader/-/style-resources-loader-1.3.2.tgz#dee034e33e84060ded0b1980f866453e98589873"
@@ -12748,13 +12788,15 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-teeny-request@^3.11.3:
-  version "3.11.3"
-  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-3.11.3.tgz#335c629f7645e5d6599362df2f3230c4cbc23a55"
-  integrity sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==
+teeny-request@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-6.0.1.tgz#9b1f512cef152945827ba7e34f62523a4ce2c5b0"
+  integrity sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==
   dependencies:
-    https-proxy-agent "^2.2.1"
+    http-proxy-agent "^4.0.0"
+    https-proxy-agent "^4.0.0"
     node-fetch "^2.2.0"
+    stream-events "^1.0.5"
     uuid "^3.3.2"
 
 term-size@^1.2.0:
@@ -13385,7 +13427,7 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urlgrey@^0.4.4:
+urlgrey@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
   integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
@@ -13466,10 +13508,10 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validator@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-12.1.0.tgz#a3a7315d5238cbc15e46ad8d5e479aafa7119925"
-  integrity sha512-gIC2RBuFRi574Rb9vewGCJ7TCLxHXNx6EKthEgs+Iz0pYa9a9Te1VLG/bGLsAyGWrqR5FfR7tbFUI7FEF2LiGA==
+validator@12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-12.2.0.tgz#660d47e96267033fd070096c3b1a6f2db4380a0a"
+  integrity sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ==
 
 vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3973,10 +3973,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@^3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.3.tgz#2ea98e71111312cf102b51f17b8c07b78bda4ee6"
-  integrity sha512-wxUdYS+ajCbbWcDUUiJL8H3q03Sn/R53wmLbJ4ixnLsudqNdBg+mttFlSuSCtJsl1PsJbeIUkjh4vBLfh2WhgQ==
+codecov@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.4.tgz#c993a58704ad5f15dcdd6aa3c3af22070c69eb18"
+  integrity sha512-R9zEcTR5/IDLepdGUHAkRMZOIKhBE1NRGS1N2H96zhBOskhdW9Q22GtYYyecbZL1aheU00D2F21nNBGRISui0A==
   dependencies:
     argv "0.0.2"
     ignore-walk "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@babel/cli@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.3.tgz#121beb7c273e0521eb2feeb3883a2b7435d12328"
-  integrity sha512-K2UXPZCKMv7KwWy9Bl4sa6+jTNP7JyDiHKzoOiUUygaEDbC60vaargZDnO9oFMvlq8pIKOOyUUgeMYrsaN9djA==
+"@babel/cli@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.4.tgz#505fb053721a98777b2b175323ea4f090b7d3c1c"
+  integrity sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==
   dependencies:
     commander "^4.0.1"
     convert-source-map "^1.1.0"
@@ -32,21 +32,12 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
-"@babel/compat-data@^7.8.0":
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.8.0.tgz#1d3a9fbda3c58774395cd617d263a196dfa45d92"
-  integrity sha512-ixPUWJpnd9hHvRkyIE3mJ6PY5DEWmR08UkcpdqI5kV5g/d6knT8Wth1LE5v5sVTIJkm9dGpQsXnhwxcf2/PjAg==
+"@babel/compat-data@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.8.4.tgz#bbe65d05a291667a8394fe8a0e0e277ef22b0d2a"
+  integrity sha512-lHLhlsvFjJAqNU71b7k6Vv9ewjmTXKvqaMv7n0G1etdCabWLw3nEYE8mmgoVOxMIFE07xOvo7H7XBASirX6Rrg==
   dependencies:
-    browserslist "^4.8.2"
-    invariant "^2.2.4"
-    semver "^7.1.1"
-
-"@babel/compat-data@^7.8.1":
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.8.1.tgz#fc0bbbb7991e4fb2b47e168e60f2cc2c41680be9"
-  integrity sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==
-  dependencies:
-    browserslist "^4.8.2"
+    browserslist "^4.8.5"
     invariant "^2.2.4"
     semver "^5.5.0"
 
@@ -90,17 +81,17 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.3.tgz#30b0ebb4dd1585de6923a0b4d179e0b9f5d82941"
-  integrity sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==
+"@babel/core@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.4.tgz#d496799e5c12195b3602d0fddd77294e3e38e80e"
+  integrity sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==
   dependencies:
     "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.8.3"
-    "@babel/helpers" "^7.8.3"
-    "@babel/parser" "^7.8.3"
+    "@babel/generator" "^7.8.4"
+    "@babel/helpers" "^7.8.4"
+    "@babel/parser" "^7.8.4"
     "@babel/template" "^7.8.3"
-    "@babel/traverse" "^7.8.3"
+    "@babel/traverse" "^7.8.4"
     "@babel/types" "^7.8.3"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
@@ -125,6 +116,16 @@
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.3.tgz#0e22c005b0a94c1c74eafe19ef78ce53a4d45c03"
   integrity sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
+  dependencies:
+    "@babel/types" "^7.8.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.4.tgz#35bbc74486956fe4251829f9f6c48330e8d0985e"
+  integrity sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==
   dependencies:
     "@babel/types" "^7.8.3"
     jsesc "^2.5.1"
@@ -179,15 +180,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-compilation-targets@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz#2deedc816fd41dca7355ef39fd40c9ea69f0719a"
-  integrity sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==
+"@babel/helper-compilation-targets@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz#03d7ecd454b7ebe19a254f76617e61770aed2c88"
+  integrity sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==
   dependencies:
-    "@babel/compat-data" "^7.8.1"
-    browserslist "^4.8.2"
+    "@babel/compat-data" "^7.8.4"
+    browserslist "^4.8.5"
     invariant "^2.2.4"
-    levenary "^1.1.0"
+    levenary "^1.1.1"
     semver "^5.5.0"
 
 "@babel/helper-create-class-features-plugin@^7.7.4":
@@ -506,13 +507,13 @@
     "@babel/traverse" "^7.7.4"
     "@babel/types" "^7.7.4"
 
-"@babel/helpers@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.3.tgz#382fbb0382ce7c4ce905945ab9641d688336ce85"
-  integrity sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==
+"@babel/helpers@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.4.tgz#754eb3ee727c165e0a240d6c207de7c455f36f73"
+  integrity sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==
   dependencies:
     "@babel/template" "^7.8.3"
-    "@babel/traverse" "^7.8.3"
+    "@babel/traverse" "^7.8.4"
     "@babel/types" "^7.8.3"
 
 "@babel/highlight@^7.0.0":
@@ -547,6 +548,11 @@
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
   integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
+
+"@babel/parser@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
+  integrity sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.7.4":
   version "7.7.4"
@@ -969,10 +975,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-for-of@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.3.tgz#15f17bce2fc95c7d59a24b299e83e81cedc22e18"
-  integrity sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==
+"@babel/plugin-transform-for-of@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz#6fe8eae5d6875086ee185dd0b098a8513783b47d"
+  integrity sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -1146,10 +1152,10 @@
     "@babel/helper-get-function-arity" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-parameters@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz#7890576a13b17325d8b7d44cb37f21dc3bbdda59"
-  integrity sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==
+"@babel/plugin-transform-parameters@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz#1d5155de0b65db0ccf9971165745d3bb990d77d3"
+  integrity sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==
   dependencies:
     "@babel/helper-call-delegate" "^7.8.3"
     "@babel/helper-get-function-arity" "^7.8.3"
@@ -1284,10 +1290,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-typeof-symbol@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.3.tgz#5cffb216fb25c8c64ba6bf5f76ce49d3ab079f4d"
-  integrity sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==
+"@babel/plugin-transform-typeof-symbol@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz#ede4062315ce0aaf8a657a920858f1a2f35fc412"
+  integrity sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -1364,13 +1370,13 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.8.3.tgz#dc0fb2938f52bbddd79b3c861a4b3427dd3a6c54"
-  integrity sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==
+"@babel/preset-env@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.8.4.tgz#9dac6df5f423015d3d49b6e9e5fa3413e4a72c4e"
+  integrity sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==
   dependencies:
-    "@babel/compat-data" "^7.8.0"
-    "@babel/helper-compilation-targets" "^7.8.3"
+    "@babel/compat-data" "^7.8.4"
+    "@babel/helper-compilation-targets" "^7.8.4"
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-proposal-async-generator-functions" "^7.8.3"
@@ -1399,7 +1405,7 @@
     "@babel/plugin-transform-dotall-regex" "^7.8.3"
     "@babel/plugin-transform-duplicate-keys" "^7.8.3"
     "@babel/plugin-transform-exponentiation-operator" "^7.8.3"
-    "@babel/plugin-transform-for-of" "^7.8.3"
+    "@babel/plugin-transform-for-of" "^7.8.4"
     "@babel/plugin-transform-function-name" "^7.8.3"
     "@babel/plugin-transform-literals" "^7.8.3"
     "@babel/plugin-transform-member-expression-literals" "^7.8.3"
@@ -1410,7 +1416,7 @@
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.8.3"
     "@babel/plugin-transform-new-target" "^7.8.3"
     "@babel/plugin-transform-object-super" "^7.8.3"
-    "@babel/plugin-transform-parameters" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.8.4"
     "@babel/plugin-transform-property-literals" "^7.8.3"
     "@babel/plugin-transform-regenerator" "^7.8.3"
     "@babel/plugin-transform-reserved-words" "^7.8.3"
@@ -1418,13 +1424,13 @@
     "@babel/plugin-transform-spread" "^7.8.3"
     "@babel/plugin-transform-sticky-regex" "^7.8.3"
     "@babel/plugin-transform-template-literals" "^7.8.3"
-    "@babel/plugin-transform-typeof-symbol" "^7.8.3"
+    "@babel/plugin-transform-typeof-symbol" "^7.8.4"
     "@babel/plugin-transform-unicode-regex" "^7.8.3"
     "@babel/types" "^7.8.3"
-    browserslist "^4.8.2"
+    browserslist "^4.8.5"
     core-js-compat "^3.6.2"
     invariant "^2.2.2"
-    levenary "^1.1.0"
+    levenary "^1.1.1"
     semver "^5.5.0"
 
 "@babel/runtime@^7.6.3":
@@ -1441,10 +1447,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/standalone@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.8.3.tgz#0674730a8c5fbb9352de5342bf0c0c040d658380"
-  integrity sha512-WRYZUuGBYpmfUL50f2h3Cvw7s1F4wTVT5iIeT01tHo+LyB9QwrTJ6GF5J6YrtJHQqxMxt8zEl1d7I0Uhyz9NyQ==
+"@babel/standalone@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.8.4.tgz#c50ed8a93c12141e638ea87ca4cdf6b4665a0bac"
+  integrity sha512-c/PomWPyLeCAnldfMGL2wNbu4OcseDObGhpK6WGfwqHWW+t9TNB7ENF/uWw/GtWv1wOnbPOb6U+uj2Q5ki1HLg==
 
 "@babel/template@^7.4.0", "@babel/template@^7.7.4":
   version "7.7.4"
@@ -1489,6 +1495,21 @@
     "@babel/helper-function-name" "^7.8.3"
     "@babel/helper-split-export-declaration" "^7.8.3"
     "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/traverse@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.4.tgz#f0845822365f9d5b0e312ed3959d3f827f869e3c"
+  integrity sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.4"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.8.4"
     "@babel/types" "^7.8.3"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -3376,15 +3397,6 @@ browserslist@^4.8.0:
     electron-to-chromium "^1.3.317"
     node-releases "^1.1.41"
 
-browserslist@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.2.tgz#b45720ad5fbc8713b7253c20766f701c9a694289"
-  integrity sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==
-  dependencies:
-    caniuse-lite "^1.0.30001015"
-    electron-to-chromium "^1.3.322"
-    node-releases "^1.1.42"
-
 browserslist@^4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.3.tgz#65802fcd77177c878e015f0e3189f2c4f627ba44"
@@ -3393,6 +3405,15 @@ browserslist@^4.8.3:
     caniuse-lite "^1.0.30001017"
     electron-to-chromium "^1.3.322"
     node-releases "^1.1.44"
+
+browserslist@^4.8.5:
+  version "4.8.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.6.tgz#96406f3f5f0755d272e27a66f4163ca821590a7e"
+  integrity sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
+  dependencies:
+    caniuse-lite "^1.0.30001023"
+    electron-to-chromium "^1.3.341"
+    node-releases "^1.1.47"
 
 bser@^2.0.0:
   version "2.1.1"
@@ -3667,7 +3688,7 @@ caniuse-lite@^1.0.30001012:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz#da2440d4d266a17d40eb79bd19c0c8cc1d029c72"
   integrity sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==
 
-caniuse-lite@^1.0.30001015, caniuse-lite@^1.0.30001016:
+caniuse-lite@^1.0.30001016:
   version "1.0.30001016"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz#16ea48d7d6e8caf3cad3295c2d746fe38c4e7f66"
   integrity sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==
@@ -3676,6 +3697,11 @@ caniuse-lite@^1.0.30001017, caniuse-lite@^1.0.30001020:
   version "1.0.30001020"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz#3f04c1737500ffda78be9beb0b5c1e2070e15926"
   integrity sha512-yWIvwA68wRHKanAVS1GjN8vajAv7MBFshullKCeq/eKpK7pJBVDgFFEqvgWTkcP2+wIDeQGYFRXECjKZnLkUjA==
+
+caniuse-lite@^1.0.30001023:
+  version "1.0.30001023"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz#b82155827f3f5009077bdd2df3d8968bcbcc6fc4"
+  integrity sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5229,6 +5255,11 @@ electron-to-chromium@^1.3.317, electron-to-chromium@^1.3.322:
   version "1.3.322"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz#a6f7e1c79025c2b05838e8e344f6e89eb83213a8"
   integrity sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==
+
+electron-to-chromium@^1.3.341:
+  version "1.3.343"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.343.tgz#a60f76a8b9980d44e39276c199fbfb6a39e8b115"
+  integrity sha512-zSPaMbYuNpas96cCf4hcKB1Zs/1ClntnsH3S+CvFi75LBBsa767Xnmo5jhCI1HiG0za6rJMRk5n2MCgd8w2iYA==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -8416,10 +8447,10 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-levenary@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.0.tgz#fc146fe75f32dc483a0a2c64aef720f602cd6210"
-  integrity sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==
+levenary@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.1.tgz#842a9ee98d2075aa7faeedbe32679e9205f46f77"
+  integrity sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
   dependencies:
     leven "^3.1.0"
 
@@ -9370,17 +9401,17 @@ node-releases@^1.1.40, node-releases@^1.1.41:
   dependencies:
     semver "^6.3.0"
 
-node-releases@^1.1.42:
-  version "1.1.43"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.43.tgz#2c6ca237f88ce11d49631f11190bb01f8d0549f2"
-  integrity sha512-Rmfnj52WNhvr83MvuAWHEqXVoZXCcDQssSOffU4n4XOL9sPrP61mSZ88g25NqmABDvH7PiAlFCzoSCSdzA293w==
-  dependencies:
-    semver "^6.3.0"
-
 node-releases@^1.1.44:
   version "1.1.45"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.45.tgz#4cf7e9175d71b1317f15ffd68ce63bce1d53e9f2"
   integrity sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==
+  dependencies:
+    semver "^6.3.0"
+
+node-releases@^1.1.47:
+  version "1.1.47"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.47.tgz#c59ef739a1fd7ecbd9f0b7cf5b7871e8a8b591e4"
+  integrity sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==
   dependencies:
     semver "^6.3.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11718,10 +11718,10 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.30.1.tgz#3fd28d6198beb2f3cd1640732047d5ec16c2d3a0"
-  integrity sha512-Uus8mwQXwaO+ZVoNwBcXKhT0AvycFCBW/W8VZtkpVGsotRllWk9oldfCjqWmTnFRI0y7x6BnEqSqc65N+/YdBw==
+rollup@^1.31.0:
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.31.0.tgz#e2a87212e96aa7850f3eb53fdd02cf89f2d2fe9a"
+  integrity sha512-9C6ovSyNeEwvuRuUUmsTpJcXac1AwSL1a3x+O5lpmQKZqi5mmrjauLeqIjvREC+yNRR8fPdzByojDng+af3nVw==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"


### PR DESCRIPTION
### Features

- `b-modal`: new `ignore-enforce-focus-selector` prop (closes #4537)
- `b-nav-item-dropdown`: add `boundary` prop, applicable when not in `b-navbar` (closes #4684)

### Fixes

- `b-dropdown`: focus-in handling for Safari and Firefox on macOS/iOS (closes #4328)
- `b-form-input`, `b-form-textarea`: properly handle out-of-sync values (closes #4695)

### Other

- dev dependencies update
- minor docs updates
