### PR TITLE
fix(b-form-input, b-form-textarea): handle change event for all mobile device keyboards (closes #4724)

### DIFF
--- a/src/components/form-input/README.md
+++ b/src/components/form-input/README.md
@@ -96,11 +96,11 @@ rendered and a console warning will be issued.
   `url`, etc) will silently ignore these values (although they will still be rendered on the input
   markup) if values are provided.
 
-**Caveats with mobile keyboards and text-like inputs:**
+**Caveats with predictive text entry and IME composition entry:**
 
 - When using predictive text auto-suggested words, the `v-model` will not update until the
   auto-suggested word is selected (or a space is typed). If an auto suggested word is not selected,
-  the v-model will update with the current displayed text of the input when the input is blurred.
+  the v-model will update with the current _displayed text_ of the input when the input is blurred.
 - When using IME composition (ie. Chinese, Japanese, etc), the `v-model` will not update until the
   IME composition is completed.
 

--- a/src/components/form-input/README.md
+++ b/src/components/form-input/README.md
@@ -94,7 +94,15 @@ rendered and a console warning will be issued.
 - Older version of Firefox may not support `readonly` for `range` type inputs.
 - Input types that do not support `min`, `max` and `step` (i.e. `text`, `password`, `tel`, `email`,
   `url`, etc) will silently ignore these values (although they will still be rendered on the input
-  markup) iv values are provided.
+  markup) if values are provided.
+
+**Caveats with mobile keyboards and text-like inputs:**
+
+- When using predictive text auto-suggested words, the `v-model` will not update until the
+  auto-suggested word is selected (or a space is typed). If an auto suggested word is not selected,
+  the v-model will update with the current displayed text of the input when the input is blurred.
+- When using IME composition (ie. Chinese, Japanese, etc), the `v-model` will not update until the
+  IME composition is completed.
 
 ### Range type input
 
@@ -155,7 +163,7 @@ In the example below, we double the number of steps by using step="0.5".
 convert the value to a native number by using `Number(value)`, `parseInt(value, 10)`,
 `parseFloat(value)`, or use the `number` prop.
 
-**Note:** Bootstrap v4.1 CSS does not include styling for range inputs inside input groups, nor
+**Note:** Bootstrap v4 CSS does not include styling for range inputs inside input groups, nor
 validation styling on range inputs. However, BootstrapVue includes custom styling to handle these
 situations until styling is included in Bootstrap v4.
 

--- a/src/components/form-radio/README.md
+++ b/src/components/form-radio/README.md
@@ -251,14 +251,16 @@ If you want to customize the field property names (for example using `name` fiel
 
 ## Radio value and v-model
 
-`<b-form-radio>` and `<b-form-radio-group>` do not have a value by default. You must explicitly
-supply a value (to which the `v-model` is set to when the radio is checked) via the `value` prop.
+`<b-form-radio>` components do not have a value by default. You must explicitly supply a value via
+the `value` prop on `<b-form-radio>`. This value will be sent to the `v-model` when the radio is
+checked.
 
 The `v-model` of both `<b-form-radio>` and `<b-form-radio-group>` binds to the `checked` prop. To
-pre-check a radio, you must set the `v-model` value to the radio's value. Do not use the `checked`
-prop directly.
+pre-check a radio, you must set the `v-model` value to the one of the radio's value (i.e. must match
+the value of specified on one of the the radio's `value` prop). Do not use the `checked` prop
+directly. Each radio in a radio group _must_ have a unique value.
 
-Radio supports values of many types, such as a `string`, `boolean`, `number`, or an `object`.
+Radios support values of many types, such as a `string`, `boolean`, `number`, or a plain `object`.
 
 ## Inline or stacked radios
 

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -209,12 +209,6 @@ export default {
       this.$emit('input', formattedValue)
     },
     onChange(evt) {
-      // `evt.target.composing` is set by Vue
-      // https://github.com/vuejs/vue/blob/dev/src/platforms/web/runtime/directives/model.js
-      /* istanbul ignore if: hard to test composition events */
-      if (evt.target.composing) {
-        return
-      }
       const value = evt.target.value
       const formattedValue = this.formatValue(value, evt)
       // Exit when the `formatter` function strictly returned `false`

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -191,6 +191,8 @@ export default {
     onInput(evt) {
       // `evt.target.composing` is set by Vue
       // https://github.com/vuejs/vue/blob/dev/src/platforms/web/runtime/directives/model.js
+      // TODO:
+      //   Is this neded now with the latest Vue??
       /* istanbul ignore if: hard to test composition events */
       if (evt.target.composing) {
         return

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -182,7 +182,7 @@ export default {
         // https://github.com/bootstrap-vue/bootstrap-vue/issues/3498
         /* istanbul ignore next: hard to test */
         const $input = this.$refs.input
-        /* istanbul ignore if: hard to test outof sync value */
+        /* istanbul ignore if: hard to test out of sync value */
         if ($input && value !== $input.value) {
           $input.value = value
         }
@@ -191,8 +191,7 @@ export default {
     onInput(evt) {
       // `evt.target.composing` is set by Vue
       // https://github.com/vuejs/vue/blob/dev/src/platforms/web/runtime/directives/model.js
-      // TODO:
-      //   Is this neded now with the latest Vue??
+      // TODO: Is this needed now with the latest Vue?
       /* istanbul ignore if: hard to test composition events */
       if (evt.target.composing) {
         return


### PR DESCRIPTION
### Describe the PR

Stops ignoring change events if `evt.taget.composing` flag is still set by Vue. 

Also adds notes to docs about mobile browser keyboard predictive text handling and IME composition handling.

Closes #4724

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] CodeCov for patch has met target
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
