### PR TITLE
docs(form-radio): add clarification to v-model section (closes #4736)

### DIFF
--- a/src/components/form-radio/README.md
+++ b/src/components/form-radio/README.md
@@ -251,14 +251,16 @@ If you want to customize the field property names (for example using `name` fiel
 
 ## Radio value and v-model
 
-`<b-form-radio>` and `<b-form-radio-group>` do not have a value by default. You must explicitly
-supply a value (to which the `v-model` is set to when the radio is checked) via the `value` prop.
+`<b-form-radio>` components do not have a value by default. You must explicitly supply a value via
+the `value` prop on `<b-form-radio>`. This value will be sent to the `v-model` when the radio is
+checked.
 
 The `v-model` of both `<b-form-radio>` and `<b-form-radio-group>` binds to the `checked` prop. To
-pre-check a radio, you must set the `v-model` value to the radio's value. Do not use the `checked`
-prop directly.
+pre-check a radio, you must set the `v-model` value to the one of the radio's value (i.e. must match
+the value of specified on one of the the radio's `value` prop). Do not use the `checked` prop
+directly. Each radio in a radio group _must_ have a unique value.
 
-Radio supports values of many types, such as a `string`, `boolean`, `number`, or an `object`.
+Radios support values of many types, such as a `string`, `boolean`, `number`, or a plain `object`.
 
 ## Inline or stacked radios
 


### PR DESCRIPTION
### Describe the PR

Add clarification to v-model section

Closes #4736 

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [ ] CodeCov for patch has met target
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
