### PR TITLE
fix(b-form-spinbutton): prevent buttons from re-ordering when parent element is RTL

### DIFF
--- a/src/components/form-spinbutton/_spinbutton.scss
+++ b/src/components/form-spinbutton/_spinbutton.scss
@@ -9,6 +9,14 @@
     height: auto;
     width: auto;
   }
+  
+  @at-root {
+    // Prevent the buttons from reversing order on in horizontal RTL mode
+    [dir="rtl"] &:not(.flex-column),
+    &[dir="rtl"]:not(.flex-column) {
+      flex-direction: row-reverse;
+    }
+  }
 
   output {
     font-size: inherit;

--- a/src/components/form-spinbutton/form-spinbutton.js
+++ b/src/components/form-spinbutton/form-spinbutton.js
@@ -546,10 +546,7 @@ export const BFormSpinbutton = /*#__PURE__*/ Vue.extend({
           ...this.$attrs,
           role: 'group',
           lang: this.computedLocale,
-          tabindex: isDisabled ? null : '-1',
-          // We want to keep the order of the buttons regardless
-          // of locale (flex will re-order based on rtl/ltr)
-          dir: 'ltr'
+          tabindex: isDisabled ? null : '-1'
         },
         on: {
           keydown: this.onKeydown,

--- a/src/components/form-spinbutton/form-spinbutton.spec.js
+++ b/src/components/form-spinbutton/form-spinbutton.spec.js
@@ -17,8 +17,6 @@ describe('form-spinbutton', () => {
     expect(wrapper.classes()).toContain('align-items-stretch')
     expect(wrapper.attributes('role')).toEqual('group')
     expect(wrapper.attributes('tabindex')).toEqual('-1')
-    // We always have LTR to ensure the flex order stays ltr
-    expect(wrapper.attributes('dir')).toEqual('ltr')
 
     // Should have 3 child elements (btn, output, btn)
     expect(wrapper.findAll('.b-form-spinbutton > *').length).toBe(3)
@@ -77,8 +75,6 @@ describe('form-spinbutton', () => {
     expect(wrapper.classes()).toContain('align-items-stretch')
     expect(wrapper.attributes('role')).toEqual('group')
     expect(wrapper.attributes('tabindex')).toEqual('-1')
-    // We always have LTR to ensure the flex order stays ltr
-    expect(wrapper.attributes('dir')).toEqual('ltr')
 
     // Should have 3 child elements (btn, output, btn)
     expect(wrapper.findAll('.b-form-spinbutton > *').length).toBe(3)
@@ -136,8 +132,6 @@ describe('form-spinbutton', () => {
     expect(wrapper.classes()).toContain('align-items-stretch')
     expect(wrapper.attributes('role')).toEqual('group')
     expect(wrapper.attributes('tabindex')).toEqual('-1')
-    // We always have LTR to ensure the flex order stays ltr
-    expect(wrapper.attributes('dir')).toEqual('ltr')
 
     // Should have 3 child elements (btn, output, btn)
     expect(wrapper.findAll('.b-form-spinbutton > *').length).toBe(3)
@@ -187,8 +181,6 @@ describe('form-spinbutton', () => {
     expect(wrapper.classes()).not.toContain('align-items-stretch')
     expect(wrapper.attributes('role')).toEqual('group')
     expect(wrapper.attributes('tabindex')).toEqual('-1')
-    // We always have LTR to ensure the flex order stays ltr
-    expect(wrapper.attributes('dir')).toEqual('ltr')
 
     // Should have 3 child elements (btn, output, btn)
     expect(wrapper.findAll('.b-form-spinbutton > *').length).toBe(3)
@@ -774,8 +766,6 @@ describe('form-spinbutton', () => {
     expect(wrapper.classes()).not.toContain('focus')
     expect(wrapper.attributes('role')).toEqual('group')
     expect(wrapper.attributes('tabindex')).toEqual('-1')
-    // We always have LTR to ensure the flex order stays ltr
-    expect(wrapper.attributes('dir')).toEqual('ltr')
 
     const $output = wrapper.find('output')
     expect($output.exists()).toBe(true)


### PR DESCRIPTION
### Describe the PR

Use CSS to avoid having to place `dir="ltr"` on the flex container to prevent flex column re-ordering

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] CodeCov for patch has met target
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
