### PR TITLE
feat(b-calendar, b-form-datepicker): allow customization of in-component displayed date format (closes #4797)

### DIFF
--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -268,8 +268,8 @@ The following table summarizes the valid options for each format property:
 
 Notes:
 
-- leaving out certain options may affect the formatted text string, e.g. the `weekday`.
-- the formatted value will vary according to the resolved locale. Some locales may not support the
+- Leaving out certain options may affect the formatted text string, e.g. the `weekday`
+- The formatted value will vary according to the resolved locale. Some locales may not support the
   `'narrow'` format and will fall back to `'short'` or `long'` (if `'short'` is not available)
 - `year`, `month` and `day` will always be shown. If you need to leave out a value, set the property
   to `undefined`, although this is highly discouraged for accessibility reasons

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -232,7 +232,11 @@ with the component may occur.
 
 ### Date string format
 
-To change format options of the displayed date text inside the component, e.g. in the header or in the placeholder, adjust the `dateFormatOptions` prop according to the elements contained in the `Intl.DateTimeFormat` object (see also [Internationalization](#internationalization)).
+<span class="badge badge-info small">v2.6.0+</span>
+
+To change format options of the displayed date text inside the component, e.g. in the header or in
+the placeholder, adjust the `dateFormatOptions` prop according to the elements contained in the
+`Intl.DateTimeFormat` object (see also [Internationalization](#internationalization)).
 
 ```html
 <template>

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -269,7 +269,7 @@ The following table summarizes the valid options for each format property:
 Notes:
 
 - leaving out certain options may affect the formatted text string, e.g. the `weekday`.
-- the formatted value will vary acorrding to the resolved locale. Some locales may not support the
+- the formatted value will vary according to the resolved locale. Some locales may not support the
   `'narrow'` format and will fall back to `'short'` or `long'` (if `'short'` is not available)
 - `year`, `month` and `day` will always be shown. If you need to leave out a value, set the
   property to `undefined`, although this is highly discouraged for accessibility reasons

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -259,14 +259,27 @@ the placeholder, adjust the `dateFormatOptions` prop according to the elements c
 <!-- b-calendar-dateformat.vue -->
 ```
 
-Note that leaving out certain options may affect the shown text string, e.g. the `weekday`.
+The following table sumarizes the valid options for each format property:
+
+| Property  | Possible values                                              |
+| --------- | ------------------------------------------------------------ |
+| `year`    | `'numeric'`, or `'2-digit'`                                  |
+| `month`   | `'numeric'`, `'2-digit'`, `'long'`, `'short'`, or `'narrow'` |
+| `day`     | `'numeric'`, or `'2-digit'`                                  |
+| `weekday` | `'long'`, `'short'`, or `'narrow'`                           |
+
+Notes:
+
+- leaving out certain options may affect the formatted text string, e.g. the `weekday`.
+- `year`, `month` and `day` will always be shown. If you need to leave out a value, set the
+  property to `undefined`
 
 ### Hiding the top selected date header
 
 By default, the current selected date will be displayed at the top of the calendar component,
 formatted in the locale's language.
 
-You can hide this header via the `hide-header` prop. Note this only visually hides the selected
+You can hide this header via the `hide-header` prop. Note this only _visually hides_ the selected
 date, while keeping it available to screen reader users as an `aria-live` region.
 
 ### Border and padding

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -271,8 +271,8 @@ Notes:
 - leaving out certain options may affect the formatted text string, e.g. the `weekday`.
 - the formatted value will vary according to the resolved locale. Some locales may not support the
   `'narrow'` format and will fall back to `'short'` or `long'` (if `'short'` is not available)
-- `year`, `month` and `day` will always be shown. If you need to leave out a value, set the
-  property to `undefined`, although this is highly discouraged for accessibility reasons
+- `year`, `month` and `day` will always be shown. If you need to leave out a value, set the property
+  to `undefined`, although this is highly discouraged for accessibility reasons
 
 ### Hiding the top selected date header
 
@@ -444,7 +444,7 @@ properties:
 | `selectedFormatted` | The selected date formatted in the current locale. If no date is selected, this will be the value of the `label-no-date-selected` prop                                                                                                                     |
 | `activeYMD`         | The current date of the calendar day button that can receive focus as a string (`YYYY-MM-DD` format)                                                                                                                                                       |
 | `activeDate`        | The current date of the calendar day button that can receive focus as a `Date` object                                                                                                                                                                      |
-| `activeFormated`    | The active date formatted in the current locale                                                                                                                                                                                                            |
+| `activeFormatted`   | The active date formatted in the current locale                                                                                                                                                                                                            |
 | `disabled`          | Will be `true` if active date is disabled, `false` otherwise                                                                                                                                                                                               |
 | `locale`            | The resolved locale (may not be the same as the requested locale)                                                                                                                                                                                          |
 | `calendarLocale`    | The resolved locale used by the calendar, optionally including the calendar type (i.e. 'gregory'). Usually this will be the same as `locale`, but may include the calendar type used, such as `fa-u-ca-gregory` when selecting the Persian locale (`'fa'`) |

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -230,6 +230,33 @@ fit the width of the parent element. The `width` prop has no effect when `block`
 Note it is _not recommended_ to set a width below `260px`, otherwise truncation and layout issues
 with the component may occur.
 
+### Date string format
+
+To change format options of the displayed date text inside the component, e.g. in the header or in the placeholder, adjust the `dateFormatOptions` prop according to the elements contained in the `Intl.DateTimeFormat` object (see also [Internationalization](#internationalization)).
+
+```html
+<template>
+  <div>
+    <label for="datepicker-dateformat1">Long date format</label>
+    <b-form-datepicker
+      id="datepicker-dateformat1"
+      :dateFormatOptions="{year: 'numeric', month: '2-digit', day: '2-digit', weekday: 'long'}"
+      locale="en"
+    ></b-form-datepicker>
+    <label for="datepicker-dateformat2">Short date format</label>
+    <b-form-datepicker
+      id="datepicker-dateformat2"
+      :dateFormatOptions="{year: 'numeric', month: 'numeric', day: 'numeric'}"
+      locale="en"
+    ></b-form-datepicker>
+  </div>
+</template>
+
+<!-- b-form-datepicker-dateformat.vue -->
+```
+
+Note that leaving out certain options may affect the shown text string, e.g. the `weekday`.
+
 ### Hiding the top selected date header
 
 By default, the current selected date will be displayed at the top of the calendar component,

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -243,12 +243,12 @@ the `dateFormatOptions` prop to an object containing the requested format proper
   <div>
     <p>Custom date format:</p>
     <b-calendar
-      :dateFormatOptions="{year: 'numeric', month: 'short', day: '2-digit', weekday: 'short'}"
+      :dateFormatOptions="{ year: 'numeric', month: 'short', day: '2-digit', weekday: 'short' }"
       locale="en"
     ></b-calendar>
     <p class="mt-3">Short date format:</p>
     <b-calendar
-      :dateFormatOptions="{year: 'numeric', month: 'numeric', day: 'numeric'}"
+      :dateFormatOptions="{ year: 'numeric', month: 'numeric', day: 'numeric' }"
       locale="en"
     ></b-calendar>
   </div>

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -252,7 +252,7 @@ To change format options of the displayed date text inside the component, e.g. i
   </div>
 </template>
 
-<!-- b-form-datepicker-dateformat.vue -->
+<!-- b-calendar-dateformat.vue -->
 ```
 
 Note that leaving out certain options may affect the shown text string, e.g. the `weekday`.

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -234,32 +234,30 @@ with the component may occur.
 
 <span class="badge badge-info small">v2.6.0+</span>
 
-To change format options of the displayed date text inside the component, e.g. in the header or in
-the placeholder, adjust the `dateFormatOptions` prop according to the elements contained in the
+To change format options of the displayed date text inside the component, e.g. in the header, set
+the `dateFormatOptions` prop to an object containing the requested format properties for the
 `Intl.DateTimeFormat` object (see also [Internationalization](#internationalization)).
 
 ```html
 <template>
   <div>
-    <label for="datepicker-dateformat1">Long date format</label>
-    <b-form-datepicker
-      id="datepicker-dateformat1"
-      :dateFormatOptions="{year: 'numeric', month: '2-digit', day: '2-digit', weekday: 'long'}"
+    <p>Custom date format:</p>
+    <b-calendar
+      :dateFormatOptions="{year: 'numeric', month: 'short', day: '2-digit', weekday: 'short'}"
       locale="en"
-    ></b-form-datepicker>
-    <label for="datepicker-dateformat2">Short date format</label>
-    <b-form-datepicker
-      id="datepicker-dateformat2"
+    ></b-calendar>
+    <p class="mt-3">Short date format:</p>
+    <b-calendar
       :dateFormatOptions="{year: 'numeric', month: 'numeric', day: 'numeric'}"
       locale="en"
-    ></b-form-datepicker>
+    ></b-calendar>
   </div>
 </template>
 
 <!-- b-calendar-dateformat.vue -->
 ```
 
-The following table sumarizes the valid options for each format property:
+The following table summarizes the valid options for each format property:
 
 | Property  | Possible values                                              |
 | --------- | ------------------------------------------------------------ |

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -269,8 +269,10 @@ The following table summarizes the valid options for each format property:
 Notes:
 
 - leaving out certain options may affect the formatted text string, e.g. the `weekday`.
+- the formatted value will vary acorrding to the resolved locale. Some locales may not support the
+  `'narrow'` format and will fall back to `'short'` or `long'` (if `'short'` is not available)
 - `year`, `month` and `day` will always be shown. If you need to leave out a value, set the
-  property to `undefined`
+  property to `undefined`, although this is highly discouraged for accessibility reasons
 
 ### Hiding the top selected date header
 

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -228,12 +228,14 @@ export const BCalendar = Vue.extend({
     formatLong: {
       // Intl.DateTimeFormat object
       type: Object,
-      default: {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        weekday: 'long',
-        calendar: 'gregory'
+      default() {
+        return {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          calendar: 'gregory'
+        }
       }
     }
   },

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -385,8 +385,9 @@ export const BCalendar = Vue.extend({
     formatDateString() {
       // Returns a date formatter function
       return createDateFormatter(this.calendarLocale, {
-        ...this.dateFormatOptions, 
-        calendar: 'gregory'})
+        ...this.dateFormatOptions,
+        calendar: 'gregory'
+      })
     },
     formatYearMonth() {
       // Returns a date formatter function

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -225,7 +225,7 @@ export const BCalendar = Vue.extend({
       type: String,
       default: () => getComponentConfig(NAME, 'labelHelp')
     },
-    formatLong: {
+    dateFormatOptions: {
       // Intl.DateTimeFormat object
       type: Object,
       default() {
@@ -384,7 +384,9 @@ export const BCalendar = Vue.extend({
     // Computed props that return date formatter functions
     formatDateString() {
       // Returns a date formatter function
-      return createDateFormatter(this.calendarLocale, this.formatLong)
+      return createDateFormatter(this.calendarLocale, {
+        ...this.dateFormatOptions, 
+        calendar: 'gregory'})
     },
     formatYearMonth() {
       // Returns a date formatter function

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -233,8 +233,7 @@ export const BCalendar = Vue.extend({
           year: 'numeric',
           month: 'long',
           day: 'numeric',
-          weekday: 'long',
-          calendar: 'gregory'
+          weekday: 'long'
         }
       }
     }

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -384,7 +384,19 @@ export const BCalendar = Vue.extend({
     formatDateString() {
       // Returns a date formatter function
       return createDateFormatter(this.calendarLocale, {
+        // Ensure we have year, month, day shown for screen readers/ARIA
+        // If users really want to leave one of these out, they can
+        // pass `undefined` for the property value
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        // Merge in user supplied options
         ...this.dateFormatOptions,
+        // Ensure hours/minutes/seconds are not shown
+        hour: undefined,
+        minute: undefined,
+        second: undefined,
+        // Ensure calendar is gregorian
         calendar: 'gregory'
       })
     },

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -224,6 +224,17 @@ export const BCalendar = Vue.extend({
     labelHelp: {
       type: String,
       default: () => getComponentConfig(NAME, 'labelHelp')
+    },
+    formatLong: {
+      // Intl.DateTimeFormat object
+      type: Object,
+      default: {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long',
+        calendar: 'gregory'
+      }
     }
   },
   data() {
@@ -371,13 +382,7 @@ export const BCalendar = Vue.extend({
     // Computed props that return date formatter functions
     formatDateString() {
       // Returns a date formatter function
-      return createDateFormatter(this.calendarLocale, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        weekday: 'long',
-        calendar: 'gregory'
-      })
+      return createDateFormatter(this.calendarLocale, this.formatLong)
     },
     formatYearMonth() {
       // Returns a date formatter function

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -226,16 +226,14 @@ export const BCalendar = Vue.extend({
       default: () => getComponentConfig(NAME, 'labelHelp')
     },
     dateFormatOptions: {
-      // Intl.DateTimeFormat object
+      // `Intl.DateTimeFormat` object
       type: Object,
-      default() {
-        return {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-          weekday: 'long'
-        }
-      }
+      default: () => ({
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long'
+      })
     }
   },
   data() {

--- a/src/components/calendar/package.json
+++ b/src/components/calendar/package.json
@@ -138,6 +138,7 @@
           },
           {
             "prop": "dateFormatOptions",
+            "version": "2.6.0",
             "description": "Format object for displayed text string that is passed to `Intl.DateTimeFormat`"
           }
         ],

--- a/src/components/calendar/package.json
+++ b/src/components/calendar/package.json
@@ -137,8 +137,8 @@
             "description": "Help text that appears at the bottom of the calendar grid"
           },
           {
-            "prop": "formatLong",
-            "description": "Format object for displayed text string"
+            "prop": "dateFormatOptions",
+            "description": "Format object for displayed text string that is passed to `Intl.DateTimeFormat`"
           }
         ],
         "events": [

--- a/src/components/calendar/package.json
+++ b/src/components/calendar/package.json
@@ -135,6 +135,10 @@
           {
             "prop": "labelHelp",
             "description": "Help text that appears at the bottom of the calendar grid"
+          },
+          {
+            "prop": "formatLong",
+            "description": "Format object for displayed text string"
           }
         ],
         "events": [

--- a/src/components/form-datepicker/README.md
+++ b/src/components/form-datepicker/README.md
@@ -301,6 +301,33 @@ and usage of these props.
 Want a fancy popup with a dark background instead of a light background? Set the `dark` prop to
 `true` to enable the dark background.
 
+### Date string format
+
+To change format options of the displayed date text inside the component, e.g. in the header or in the placeholder, adjust the `dateFormatOptions` prop according to the elements contained in the `Intl.DateTimeFormat` object (see also [Internationalization](#internationalization)).
+
+```html
+<template>
+  <div>
+    <label for="datepicker-dateformat1">Long date format</label>
+    <b-form-datepicker
+      id="datepicker-dateformat1"
+      :dateFormatOptions="{year: 'numeric', month: '2-digit', day: '2-digit', weekday: 'long'}"
+      locale="en"
+    ></b-form-datepicker>
+    <label for="datepicker-dateformat2">Short date format</label>
+    <b-form-datepicker
+      id="datepicker-dateformat2"
+      :dateFormatOptions="{year: 'numeric', month: 'numeric', day: 'numeric'}"
+      locale="en"
+    ></b-form-datepicker>
+  </div>
+</template>
+
+<!-- b-form-datepicker-dateformat.vue -->
+```
+
+Note that leaving out certain options may affect the shown text string, e.g. the `weekday`.
+
 ## Internationalization
 
 Internationalization of the date picker's calendar is provided via

--- a/src/components/form-datepicker/README.md
+++ b/src/components/form-datepicker/README.md
@@ -305,17 +305,18 @@ Want a fancy popup with a dark background instead of a light background? Set the
 
 <span class="badge badge-info small">v2.6.0+</span>
 
-To change format options of the displayed date text inside the component, e.g. in the header or in
-the placeholder, adjust the `dateFormatOptions` prop according to the elements contained in the
-`Intl.DateTimeFormat` object (see also [Internationalization](#internationalization)).
+To change format options of the displayed date text inside the component, e.g. in the header or
+placeholder, set the `date-format-options` prop to an object containing the requested format
+properties for the `Intl.DateTimeFormat` object (see also
+[Internationalization](#internationalization)).
 
 ```html
 <template>
   <div>
-    <label for="datepicker-dateformat1">Long date format</label>
+    <label for="datepicker-dateformat1">Custom date format</label>
     <b-form-datepicker
       id="datepicker-dateformat1"
-      :dateFormatOptions="{year: 'numeric', month: '2-digit', day: '2-digit', weekday: 'long'}"
+      :dateFormatOptions="{year: 'numeric', month: 'short', day: '2-digit', weekday: 'short'}"
       locale="en"
     ></b-form-datepicker>
     <label for="datepicker-dateformat2">Short date format</label>
@@ -330,7 +331,7 @@ the placeholder, adjust the `dateFormatOptions` prop according to the elements c
 <!-- b-form-datepicker-dateformat.vue -->
 ```
 
-The following table sumarizes the valid options for each format property:
+The following table summarizes the valid options for each format property:
 
 | Property  | Possible values                                              |
 | --------- | ------------------------------------------------------------ |

--- a/src/components/form-datepicker/README.md
+++ b/src/components/form-datepicker/README.md
@@ -343,7 +343,7 @@ The following table summarizes the valid options for each format property:
 Notes:
 
 - leaving out certain options may affect the formatted text string, e.g. the `weekday`.
-- the formatted value will vary acorrding to the resolved locale. Some locales may not support the
+- the formatted value will vary according to the resolved locale. Some locales may not support the
   `'narrow'` format and will fall back to `'short'` or `long'` (if `'short'` is not available)
 - `year`, `month` and `day` will always be shown. If you need to leave out a value, set the
   property to `undefined`, although this is highly discouraged for accessibility reasons

--- a/src/components/form-datepicker/README.md
+++ b/src/components/form-datepicker/README.md
@@ -316,13 +316,13 @@ properties for the `Intl.DateTimeFormat` object (see also
     <label for="datepicker-dateformat1">Custom date format</label>
     <b-form-datepicker
       id="datepicker-dateformat1"
-      :dateFormatOptions="{year: 'numeric', month: 'short', day: '2-digit', weekday: 'short'}"
+      :dateFormatOptions="{ year: 'numeric', month: 'short', day: '2-digit', weekday: 'short' }"
       locale="en"
     ></b-form-datepicker>
     <label for="datepicker-dateformat2">Short date format</label>
     <b-form-datepicker
       id="datepicker-dateformat2"
-      :dateFormatOptions="{year: 'numeric', month: 'numeric', day: 'numeric'}"
+      :dateFormatOptions="{ year: 'numeric', month: 'numeric', day: 'numeric' }"
       locale="en"
     ></b-form-datepicker>
   </div>
@@ -345,8 +345,8 @@ Notes:
 - leaving out certain options may affect the formatted text string, e.g. the `weekday`.
 - the formatted value will vary according to the resolved locale. Some locales may not support the
   `'narrow'` format and will fall back to `'short'` or `long'` (if `'short'` is not available)
-- `year`, `month` and `day` will always be shown. If you need to leave out a value, set the
-  property to `undefined`, although this is highly discouraged for accessibility reasons
+- `year`, `month` and `day` will always be shown. If you need to leave out a value, set the property
+  to `undefined`, although this is highly discouraged for accessibility reasons
 
 ## Internationalization
 

--- a/src/components/form-datepicker/README.md
+++ b/src/components/form-datepicker/README.md
@@ -342,8 +342,8 @@ The following table summarizes the valid options for each format property:
 
 Notes:
 
-- leaving out certain options may affect the formatted text string, e.g. the `weekday`.
-- the formatted value will vary according to the resolved locale. Some locales may not support the
+- Leaving out certain options may affect the formatted text string, e.g. the `weekday`
+- The formatted value will vary according to the resolved locale. Some locales may not support the
   `'narrow'` format and will fall back to `'short'` or `long'` (if `'short'` is not available)
 - `year`, `month` and `day` will always be shown. If you need to leave out a value, set the property
   to `undefined`, although this is highly discouraged for accessibility reasons

--- a/src/components/form-datepicker/README.md
+++ b/src/components/form-datepicker/README.md
@@ -303,7 +303,11 @@ Want a fancy popup with a dark background instead of a light background? Set the
 
 ### Date string format
 
-To change format options of the displayed date text inside the component, e.g. in the header or in the placeholder, adjust the `dateFormatOptions` prop according to the elements contained in the `Intl.DateTimeFormat` object (see also [Internationalization](#internationalization)).
+<span class="badge badge-info small">v2.6.0+</span>
+
+To change format options of the displayed date text inside the component, e.g. in the header or in
+the placeholder, adjust the `dateFormatOptions` prop according to the elements contained in the
+`Intl.DateTimeFormat` object (see also [Internationalization](#internationalization)).
 
 ```html
 <template>

--- a/src/components/form-datepicker/README.md
+++ b/src/components/form-datepicker/README.md
@@ -330,7 +330,20 @@ the placeholder, adjust the `dateFormatOptions` prop according to the elements c
 <!-- b-form-datepicker-dateformat.vue -->
 ```
 
-Note that leaving out certain options may affect the shown text string, e.g. the `weekday`.
+The following table sumarizes the valid options for each format property:
+
+| Property  | Possible values                                              |
+| --------- | ------------------------------------------------------------ |
+| `year`    | `'numeric'`, or `'2-digit'`                                  |
+| `month`   | `'numeric'`, `'2-digit'`, `'long'`, `'short'`, or `'narrow'` |
+| `day`     | `'numeric'`, or `'2-digit'`                                  |
+| `weekday` | `'long'`, `'short'`, or `'narrow'`                           |
+
+Notes:
+
+- leaving out certain options may affect the formatted text string, e.g. the `weekday`.
+- `year`, `month` and `day` will always be shown. If you need to leave out a value, set the
+  property to `undefined`
 
 ## Internationalization
 

--- a/src/components/form-datepicker/README.md
+++ b/src/components/form-datepicker/README.md
@@ -343,8 +343,10 @@ The following table summarizes the valid options for each format property:
 Notes:
 
 - leaving out certain options may affect the formatted text string, e.g. the `weekday`.
+- the formatted value will vary acorrding to the resolved locale. Some locales may not support the
+  `'narrow'` format and will fall back to `'short'` or `long'` (if `'short'` is not available)
 - `year`, `month` and `day` will always be shown. If you need to leave out a value, set the
-  property to `undefined`
+  property to `undefined`, although this is highly discouraged for accessibility reasons
 
 ## Internationalization
 

--- a/src/components/form-datepicker/form-datepicker.js
+++ b/src/components/form-datepicker/form-datepicker.js
@@ -210,16 +210,14 @@ const propsMixin = {
       default: false
     },
     dateFormatOptions: {
-      // Intl.DateTimeFormat object
+      // `Intl.DateTimeFormat` object
       type: Object,
-      default() {
-        return {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-          weekday: 'long'
-        }
-      }
+      default: () => ({
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long'
+      })
     }
   }
 }

--- a/src/components/form-datepicker/form-datepicker.js
+++ b/src/components/form-datepicker/form-datepicker.js
@@ -208,6 +208,17 @@ const propsMixin = {
     dark: {
       type: Boolean,
       default: false
+    },
+    formatLong: {
+      // Intl.DateTimeFormat object
+      type: Object,
+      default: {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long',
+        calendar: 'gregory'
+      }
     }
   }
 }
@@ -248,7 +259,7 @@ export const BFormDatepicker = /*#__PURE__*/ Vue.extend({
       return this.activeYMD.slice(0, -3)
     },
     calendarProps() {
-      // We alis `this` to `self` for better minification
+      // We alias `this` to `self` for better minification
       const self = this
       // TODO: Make the ID's computed props
       const idLabel = self.safeId('_value_')
@@ -280,7 +291,8 @@ export const BFormDatepicker = /*#__PURE__*/ Vue.extend({
         labelNoDateSelected: self.labelNoDateSelected,
         labelCalendar: self.labelCalendar,
         labelNav: self.labelNav,
-        labelHelp: self.labelHelp
+        labelHelp: self.labelHelp,
+        formatLong: self.formatLong
       }
     },
     computedResetValue() {

--- a/src/components/form-datepicker/form-datepicker.js
+++ b/src/components/form-datepicker/form-datepicker.js
@@ -217,8 +217,7 @@ const propsMixin = {
           year: 'numeric',
           month: 'long',
           day: 'numeric',
-          weekday: 'long',
-          calendar: 'gregory'
+          weekday: 'long'
         }
       }
     }

--- a/src/components/form-datepicker/form-datepicker.js
+++ b/src/components/form-datepicker/form-datepicker.js
@@ -212,12 +212,14 @@ const propsMixin = {
     formatLong: {
       // Intl.DateTimeFormat object
       type: Object,
-      default: {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        weekday: 'long',
-        calendar: 'gregory'
+      default() {
+        return {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          calendar: 'gregory'
+        }
       }
     }
   }

--- a/src/components/form-datepicker/form-datepicker.js
+++ b/src/components/form-datepicker/form-datepicker.js
@@ -209,7 +209,7 @@ const propsMixin = {
       type: Boolean,
       default: false
     },
-    formatLong: {
+    dateFormatOptions: {
       // Intl.DateTimeFormat object
       type: Object,
       default() {
@@ -294,7 +294,7 @@ export const BFormDatepicker = /*#__PURE__*/ Vue.extend({
         labelCalendar: self.labelCalendar,
         labelNav: self.labelNav,
         labelHelp: self.labelHelp,
-        formatLong: self.formatLong
+        dateFormatOptions: self.dateFormatOptions
       }
     },
     computedResetValue() {

--- a/src/components/form-datepicker/package.json
+++ b/src/components/form-datepicker/package.json
@@ -208,6 +208,10 @@
           {
             "prop": "labelCloseButton",
             "description": "Content for the optional `Close` button"
+          },
+          {
+            "prop": "formatLong",
+            "description": "Format object for displayed text string"
           }
         ],
         "events": [

--- a/src/components/form-datepicker/package.json
+++ b/src/components/form-datepicker/package.json
@@ -210,8 +210,8 @@
             "description": "Content for the optional `Close` button"
           },
           {
-            "prop": "formatLong",
-            "description": "Format object for displayed text string"
+            "prop": "dateFormatOptions",
+            "description": "Format object for displayed text string that is passed to `Intl.DateTimeFormat`"
           }
         ],
         "events": [

--- a/src/components/form-datepicker/package.json
+++ b/src/components/form-datepicker/package.json
@@ -211,6 +211,7 @@
           },
           {
             "prop": "dateFormatOptions",
+            "version": "2.6.0",
             "description": "Format object for displayed text string that is passed to `Intl.DateTimeFormat`"
           }
         ],


### PR DESCRIPTION
### Describe the PR

Added prop to allow formatting of in-component displayed date string to allow better control of size (and a better integration with other components defining these format, e.g. vue-i18n). This is especially helpful for space-constrained usage in forms.

Closes #4797

### PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [x] Existing test suites are passing
- [x] CodeCov for patch has met target
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
