### PR TITLE
feat(b-sidebar): disable header close button when not open for A11Y reasons

### DIFF
--- a/src/components/sidebar/package.json
+++ b/src/components/sidebar/package.json
@@ -119,9 +119,21 @@
                 "description": "When called, will close the sidebar"
               },
               {
+                "prop": "isOpen",
+                "version": "2.11.0",
+                "type": "Boolean",
+                "description": "`true` when the sidebar is transitioning and when fully opened. Useful for disabling interactive elements when the sidebar is hidden"
+              },
+              {
+                "prop": "isClosed",
+                "version": "2.11.0",
+                "type": "Boolean",
+                "description": "The opposite of `isOpen`, for convenience"
+              },
+              {
                 "prop": "visible",
                 "type": "Boolean",
-                "description": "`true` if the sidebar is open"
+                "description": "`true` if the sidebar is open. Note: will be `false` when the close transition happens. This value mimics the internal `v-model` value"
               },
               {
                 "prop": "right",
@@ -144,9 +156,21 @@
                 "description": "When called, will close the sidebar"
               },
               {
+                "prop": "isOpen",
+                "version": "2.11.0",
+                "type": "Boolean",
+                "description": "`true` when the sidebar is transitioning and when fully opened. Useful for disabling interactive elements when the sidebar is hidden"
+              },
+              {
+                "prop": "isClosed",
+                "version": "2.11.0",
+                "type": "Boolean",
+                "description": "The opposite of `isOpen`, for convenience"
+              },
+              {
                 "prop": "visible",
                 "type": "Boolean",
-                "description": "`true` if the sidebar is open"
+                "description": "`true` if the sidebar is open. Note: will be `false` when the close transition happens. This value mimics the internal `v-model` value"
               },
               {
                 "prop": "right",
@@ -165,9 +189,21 @@
                 "description": "When called, will close the sidebar"
               },
               {
+                "prop": "isOpen",
+                "version": "2.11.0",
+                "type": "Boolean",
+                "description": "`true` when the sidebar is transitioning and when fully opened. Useful for disabling interactive elements when the sidebar is hidden"
+              },
+              {
+                "prop": "isClosed",
+                "version": "2.11.0",
+                "type": "Boolean",
+                "description": "The opposite of `isOpen`, for convenience"
+              },
+              {
                 "prop": "visible",
                 "type": "Boolean",
-                "description": "`true` if the sidebar is open"
+                "description": "`true` if the sidebar is open. Note: will be `false` when the close transition happens. This value mimics the internal `v-model` value"
               },
               {
                 "prop": "right",

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -230,6 +230,7 @@ export const BSidebar = /*#__PURE__*/ Vue.extend({
     slotScope() {
       return {
         isOpen: this.isOpen,
+        isClosed: !this.isOpen,
         visible: this.localShow,
         right: this.right,
         hide: this.hide

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -37,13 +37,13 @@ const renderHeaderClose = (h, ctx) => {
     return h()
   }
 
-  const { closeLabel, textVariant, hide } = ctx
+  const { closeLabel, textVariant, hide, isOpen } = ctx
 
   return h(
     BButtonClose,
     {
       ref: 'close-button',
-      props: { ariaLabel: closeLabel, textVariant },
+      props: { disabled: !isOpen, ariaLabel: closeLabel, textVariant },
       on: { click: hide }
     },
     [ctx.normalizeSlot('header-close') || h(BIconX)]
@@ -229,6 +229,7 @@ export const BSidebar = /*#__PURE__*/ Vue.extend({
     },
     slotScope() {
       return {
+        isOpen: this.isOpen,
         visible: this.localShow,
         right: this.right,
         hide: this.hide


### PR DESCRIPTION
### Describe the PR

When the sidebar is closed, the interactive elements inside should be disabled, to prevent them from being in the document tab sequence.  If they are in the tab sequence it can be confusing for Screen Reader and keyboard only users.

Also adds a new `isOpen` property to the slots' scope which will be `true` when the sidebar is beginning the open transition, and all the way through to when the close transition completes, at which point it will be `false` (completely obscured).  It is similar to the `visible` property, which reflects the v-model, although visible will be `false` when the close transition starts.

For convenience, an `isClosed` scope property is provided, which is equal to `!isOpen`

To Do:

- [x] update package.json meta to include new scope property
- [ ] update documentation examples to disable interactive elements when `isOpen` is `false`
- [ ] update accessibility section to mention disabling interactive elements when closed
- [ ] unit tests

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement
- [x] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages.**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates (including updating the component's `package.json` for slot and event changes)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (if required)
- [ ] Existing test suites are passing
- [x] CodeCov for patch has met target
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
