### PR TITLE
chore: remove old `es/` dir from gitignore on master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ coverage/
 dist/
 docs-dist/
 esm/
-es/
 node_modules/
 sw.js
 workbox*.js*


### PR DESCRIPTION
To trigger a zeit redeploy on master branch, to ensure auto-deploy is working