### PR TITLE
chore: don't let renovate update hightlight.js past 9.x.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
       "allowedVersions": "<3.0.0"
     },
     {
+      "packageNames": ["highlight.js"],
+      "allowedVersions": "<10.0.0"
+    },
+    {
       "packageNames": ["prettier"],
       "allowedVersions": "<=1.14.3"
     },


### PR DESCRIPTION
As v10.x.x of highlight.js does not support IE11 browser (https://github.com/highlightjs/highlight.js/issues/2501)

Closes #5212 