### PR TITLE
feat(b-link): add support 3rd party router links such as Gridsome's `<g-link>` (closes #2627)

### DIFF
--- a/docs/common-props.json
+++ b/docs/common-props.json
@@ -238,7 +238,7 @@
     "description": "nuxt-link prop: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting 'no-prefetch' will disabled this feature for the specific link"
   },
   "routerComponentName": {
-    "description": "BootstrapVue auto detects between `<router-link>` and `<nuxt-link>`. In cases where you want to use a 3rd party link component based on `<router-link>`, set this prop to the component name. e.g. set it to 'g-link' if you are using Gridsome (note only `<router-link>` specific props are passed to the component)",
+    "description": "b-link prop: BootstrapVue auto detects between `<router-link>` and `<nuxt-link>`. In cases where you want to use a 3rd party link component based on `<router-link>`, set this prop to the component name. e.g. set it to 'g-link' if you are using Gridsome (note only `<router-link>` specific props are passed to the component)",
     "version": "2.15.0"
   }
 }

--- a/docs/common-props.json
+++ b/docs/common-props.json
@@ -239,6 +239,7 @@
   },
   "routerComponentName": {
     "description": "<b-link> prop: BootstrapVue auto detects between `<router-link>` and `<nuxt-link>`. In cases where you want to use a 3rd party link component based on `<router-link>`, set this prop to the component name. e.g. set it to 'g-link' if you are using Gridsome (note only `<router-link>` specific props are passed to the component)",
-    "version": "2.15.0"
+    "version": "2.15.0",
+    "settings": true
   }
 }

--- a/docs/common-props.json
+++ b/docs/common-props.json
@@ -236,5 +236,9 @@
   },
   "noPrefetch": {
     "description": "nuxt-link prop: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting 'no-prefetch' will disabled this feature for the specific link"
+  },
+  "routerComponentName": {
+    "description": "BootstrapVue auto detects between `<router-link>` and `<nuxt-link>`. In cases where you want to use a 3rd party link component based on `<router-link>`, set this prop to the component name. e.g. set it to 'g-link' if you are using Gridsome",
+    "version": "2.15.0"
   }
 }

--- a/docs/common-props.json
+++ b/docs/common-props.json
@@ -238,7 +238,7 @@
     "description": "nuxt-link prop: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting 'no-prefetch' will disabled this feature for the specific link"
   },
   "routerComponentName": {
-    "description": "BootstrapVue auto detects between `<router-link>` and `<nuxt-link>`. In cases where you want to use a 3rd party link component based on `<router-link>`, set this prop to the component name. e.g. set it to 'g-link' if you are using Gridsome",
+    "description": "BootstrapVue auto detects between `<router-link>` and `<nuxt-link>`. In cases where you want to use a 3rd party link component based on `<router-link>`, set this prop to the component name. e.g. set it to 'g-link' if you are using Gridsome (note only `<router-link>` specific props are passed to the component)",
     "version": "2.15.0"
   }
 }

--- a/docs/common-props.json
+++ b/docs/common-props.json
@@ -197,14 +197,14 @@
   "active": {
     "description": "When set to 'true', places the component in the active state with active styling"
   },
+  "href": {
+    "description": "b-link prop: Denotes the target URL of the link for standard a links"
+  },
   "rel": {
-    "description": "Sets the 'rel' attribute on the rendered link"
+    "description": "b-link prop: Sets the 'rel' attribute on the rendered link"
   },
   "target": {
-    "description": "Sets the 'target' attribute on the rendered link"
-  },
-  "href": {
-    "description": "Denotes the target URL of the link for standard a links"
+    "description": "b-link prop: Sets the 'target' attribute on the rendered link"
   },
   "to": {
     "description": "router-link prop: Denotes the target route of the link. When clicked, the value of the to prop will be passed to router.push() internally, so the value can be either a string or a Location descriptor object"

--- a/docs/common-props.json
+++ b/docs/common-props.json
@@ -198,47 +198,47 @@
     "description": "When set to 'true', places the component in the active state with active styling"
   },
   "href": {
-    "description": "b-link prop: Denotes the target URL of the link for standard a links"
+    "description": "<b-link> prop: Denotes the target URL of the link for standard a links"
   },
   "rel": {
-    "description": "b-link prop: Sets the 'rel' attribute on the rendered link"
+    "description": "<b-link> prop: Sets the 'rel' attribute on the rendered link"
   },
   "target": {
-    "description": "b-link prop: Sets the 'target' attribute on the rendered link"
+    "description": "<b-link> prop: Sets the 'target' attribute on the rendered link"
   },
   "to": {
-    "description": "router-link prop: Denotes the target route of the link. When clicked, the value of the to prop will be passed to router.push() internally, so the value can be either a string or a Location descriptor object"
+    "description": "<router-link> prop: Denotes the target route of the link. When clicked, the value of the to prop will be passed to router.push() internally, so the value can be either a string or a Location descriptor object"
   },
   "replace": {
-    "description": "router-link prop: Setting the replace prop will call 'router.replace()' instead of 'router.push()' when clicked, so the navigation will not leave a history record"
+    "description": "<router-link> prop: Setting the replace prop will call 'router.replace()' instead of 'router.push()' when clicked, so the navigation will not leave a history record"
   },
   "append": {
-    "description": "router-link prop: Setting append prop always appends the relative path to the current path"
+    "description": "<router-link> prop: Setting append prop always appends the relative path to the current path"
   },
   "exact": {
-    "description": "router-link prop: The default active class matching behavior is inclusive match. Setting this prop forces the mode to exactly match the route"
+    "description": "<router-link> prop: The default active class matching behavior is inclusive match. Setting this prop forces the mode to exactly match the route"
   },
   "activeClass": {
-    "description": "router-link prop: Configure the active CSS class applied when the link is active. Typically you will want to set this to class name 'active'"
+    "description": "<router-link> prop: Configure the active CSS class applied when the link is active. Typically you will want to set this to class name 'active'"
   },
   "exactActiveClass": {
-    "description": "router-link prop: Configure the active CSS class applied when the link is active with exact match. Typically you will want to set this to class name 'active'"
+    "description": "<router-link> prop: Configure the active CSS class applied when the link is active with exact match. Typically you will want to set this to class name 'active'"
   },
   "routerTag": {
-    "description": "router-link prop: Specify which tag to render, and it will still listen to click events for navigation. 'router-tag' translates to the tag prop on the final rendered router-link. Typically you should use the default value"
+    "description": "<router-link> prop: Specify which tag to render, and it will still listen to click events for navigation. 'router-tag' translates to the tag prop on the final rendered router-link. Typically you should use the default value"
   },
   "event": {
-    "description": "router-link prop: Specify the event that triggers the link. In most cases you should leave this as the default"
+    "description": "<router-link> prop: Specify the event that triggers the link. In most cases you should leave this as the default"
   },
   "prefetch": {
-    "description": "nuxt-link prop: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting 'prefetch' to 'true' or 'false' will overwrite the default value of 'router.prefetchLinks'",
+    "description": "<nuxt-link> prop: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting 'prefetch' to 'true' or 'false' will overwrite the default value of 'router.prefetchLinks'",
     "version": "2.15.0"
   },
   "noPrefetch": {
-    "description": "nuxt-link prop: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting 'no-prefetch' will disabled this feature for the specific link"
+    "description": "<nuxt-link> prop: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting 'no-prefetch' will disabled this feature for the specific link"
   },
   "routerComponentName": {
-    "description": "b-link prop: BootstrapVue auto detects between `<router-link>` and `<nuxt-link>`. In cases where you want to use a 3rd party link component based on `<router-link>`, set this prop to the component name. e.g. set it to 'g-link' if you are using Gridsome (note only `<router-link>` specific props are passed to the component)",
+    "description": "<b-link> prop: BootstrapVue auto detects between `<router-link>` and `<nuxt-link>`. In cases where you want to use a 3rd party link component based on `<router-link>`, set this prop to the component name. e.g. set it to 'g-link' if you are using Gridsome (note only `<router-link>` specific props are passed to the component)",
     "version": "2.15.0"
   }
 }

--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -216,7 +216,7 @@ these third party `<router-link>` compatible components via the use of the `rout
 prop. All `vue-router` props (excluding `<nuxt-link>` specific props) will be passed to the
 specified router link component.
 
-Note that the 3rd arty component will only be used when the `to` prop is set.
+Note that the 3rd party component will only be used when the `to` prop is set.
 
 ### `router-component-name`
 

--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -216,7 +216,12 @@ these third party `<router-link>` compatible components via the use of the `rout
 prop. All `vue-router` props (excluding `<nuxt-link>` specific props) will be passed to the
 specified router link component.
 
-Note that the 3rd party component will only be used when the `to` prop is set.
+**Notes:**
+
+- The 3rd party component will only be used when the `to` prop is set.
+- Not all 3rd party components support all props supported by `<router-link>`, nor do not support
+  fully qualified domain name URLs, nor hash only URLs. Refer to the 3rd party component
+  documentation for details.
 
 ### `router-component-name`
 

--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -233,4 +233,3 @@ Set this prop to the name of the `<router-link>` compatible component, e.g. `'g-
 [Gridsome](https://gridsome.org/).
 
 If left at the default, BootstrapVue will automatically select `<router-link>` or `<nuxt-link>`.
-

--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -10,7 +10,8 @@
 In the following sections, we are using the `<b-link>` component to render router links. `<b-link>`
 is the building block of most of BootstrapVue's _actionable_ components. You could use any other
 component that supports link generation such as [`<b-link>`](/docs/components/link),
-[`<b-button>`](/docs/components/button), [`<b-breadcrumb-item>`](/docs/components/breadcrumb),
+[`<b-button>`](/docs/components/button), [`<b-avatar>`](/docs/components/avatar),
+[`<b-breadcrumb-item>`](/docs/components/breadcrumb),
 [`<b-list-group-item>`](/docs/components/list-group), [`<b-nav-item>`](/docs/components/nav),
 [`<b-dropdown-item>`](/docs/components/dropdown), and
 [`<b-pagination-nav>`](/docs/components/pagination-nav). Note that not all props are available on
@@ -203,3 +204,28 @@ disabled this feature for the specific link.
 **Note:** If you have prefetching disabled in your `nuxt.config.js` configuration
 (`router: { prefetchLinks: false }`), or are using a version of Nuxt.js `< 2.4.0`, then this prop
 will have no effect.
+
+## Third-party router link support
+
+<span class="badge badge-info small">v2.15.0+</span>
+
+BootstrapVue auto detects using `<router-link>` and `<nuxt-link>` link components. Some 3rd party
+frameworks also provide customized versions of `<router-link>`, such as
+[Gridsome's `<g-link>` component](https://gridsome.org/docs/linking/). BootstrapVue can support
+these third party `<router-link>` compatible components via the use of the `router-component-name`
+prop. All `vue-router` props (excluding `<nuxt-link>` specific props) will be passed to the
+specified router link component.
+
+Note that the 3rd arty component will only be used when the `to` prop is set.
+
+### `router-component-name`
+
+- type: `string`
+- default: `undefined`
+- availability: BootstrapVue 2.15.0+
+
+Set this prop to the name of the `<router-link>` compatible component, e.g. `'g-link''` for
+[Gridsome](https://gridsome.org/).
+
+If left at the default, BootstrapVue will automatically select `<router-link>` or `<nuxt-link>`.
+

--- a/docs/markdown/reference/router-links/README.md
+++ b/docs/markdown/reference/router-links/README.md
@@ -224,7 +224,7 @@ Note that the 3rd arty component will only be used when the `to` prop is set.
 - default: `undefined`
 - availability: BootstrapVue 2.15.0+
 
-Set this prop to the name of the `<router-link>` compatible component, e.g. `'g-link''` for
+Set this prop to the name of the `<router-link>` compatible component, e.g. `'g-link'` for
 [Gridsome](https://gridsome.org/).
 
 If left at the default, BootstrapVue will automatically select `<router-link>` or `<nuxt-link>`.

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -3,6 +3,7 @@ import pluckProps from '../../utils/pluck-props'
 import { getComponentConfig } from '../../utils/config'
 import { isNumber, isString, isUndefinedOrNull } from '../../utils/inspect'
 import { toFloat } from '../../utils/number'
+import { omit } from '../../utils/object'
 import { BButton } from '../button/button'
 import { BLink, props as BLinkProps } from '../link/link'
 import { BIcon } from '../../icons/icon'
@@ -25,24 +26,7 @@ const DEFAULT_SIZES = {
 }
 
 // --- Props ---
-const linkProps = pluckProps(
-  [
-    'href',
-    'rel',
-    'target',
-    'disabled',
-    'to',
-    'append',
-    'replace',
-    'activeClass',
-    'exact',
-    'exactActiveClass',
-    'prefetch',
-    'noPrefetch',
-    'routerComponentName'
-  ],
-  BLinkProps
-)
+const linkProps = omit(BLinkProps, ['active', 'event', 'routerTag'])
 
 const props = {
   src: {

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -38,7 +38,8 @@ const linkProps = pluckProps(
     'exact',
     'exactActiveClass',
     'prefetch',
-    'noPrefetch'
+    'noPrefetch',
+    'routerComponentName'
   ],
   BLinkProps
 )

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -4,6 +4,7 @@ import { getComponentConfig } from '../../utils/config'
 import { isNumber, isString, isUndefinedOrNull } from '../../utils/inspect'
 import { toFloat } from '../../utils/number'
 import { omit } from '../../utils/object'
+import { isLink } from '../../utils/router'
 import { BButton } from '../button/button'
 import { BLink, props as BLinkProps } from '../link/link'
 import { BIcon } from '../../icons/icon'
@@ -193,14 +194,14 @@ export const BAvatar = /*#__PURE__*/ Vue.extend({
       fontStyle,
       marginStyle,
       computedSize: size,
-      button: isButton,
+      button,
       buttonType: type,
       badge,
       badgeVariant,
       badgeStyle
     } = this
-    const isBLink = !isButton && (this.href || this.to)
-    const tag = isButton ? BButton : isBLink ? BLink : 'span'
+    const link = !button && isLink(this)
+    const tag = button ? BButton : link ? BLink : 'span'
     const alt = this.alt || null
     const ariaLabel = this.ariaLabel || null
 
@@ -246,7 +247,7 @@ export const BAvatar = /*#__PURE__*/ Vue.extend({
       staticClass: CLASS_NAME,
       class: {
         // We use badge styles for theme variants when not rendering `BButton`
-        [`badge-${variant}`]: !isButton && variant,
+        [`badge-${variant}`]: !button && variant,
         // Rounding/Square
         rounded: rounded === true,
         [`rounded-${rounded}`]: rounded && rounded !== true,
@@ -255,8 +256,8 @@ export const BAvatar = /*#__PURE__*/ Vue.extend({
       },
       style: { width: size, height: size, ...marginStyle },
       attrs: { 'aria-label': ariaLabel || null },
-      props: isButton ? { variant, disabled, type } : isBLink ? pluckProps(linkProps, this) : {},
-      on: isBLink || isButton ? { click: this.onClick } : {}
+      props: button ? { variant, disabled, type } : link ? pluckProps(linkProps, this) : {},
+      on: button || link ? { click: this.onClick } : {}
     }
 
     return h(tag, componentData, [$content, $badge])

--- a/src/components/badge/badge.js
+++ b/src/components/badge/badge.js
@@ -3,11 +3,16 @@ import pluckProps from '../../utils/pluck-props'
 import { mergeData } from 'vue-functional-data-merge'
 import { getComponentConfig } from '../../utils/config'
 import { omit } from '../../utils/object'
+import { isLink } from '../../utils/router'
 import { BLink, props as BLinkProps } from '../link/link'
+
+// --- Constants ---
 
 const NAME = 'BBadge'
 
-const linkProps = omit(BLinkProps, ['event'])
+// --- Props ---
+
+const linkProps = omit(BLinkProps, ['event', 'routerTag'])
 delete linkProps.href.default
 delete linkProps.to.default
 
@@ -27,14 +32,15 @@ export const props = {
   ...linkProps
 }
 
+// --- Main component ---
 // @vue/component
 export const BBadge = /*#__PURE__*/ Vue.extend({
   name: NAME,
   functional: true,
   props,
   render(h, { props, data, children }) {
-    const isBLink = props.href || props.to
-    const tag = isBLink ? BLink : props.tag
+    const link = isLink(props)
+    const tag = link ? BLink : props.tag
 
     const componentData = {
       staticClass: 'badge',
@@ -46,7 +52,7 @@ export const BBadge = /*#__PURE__*/ Vue.extend({
           disabled: props.disabled
         }
       ],
-      props: isBLink ? pluckProps(linkProps, props) : {}
+      props: link ? pluckProps(linkProps, props) : {}
     }
 
     return h(tag, mergeData(data, componentData), children)

--- a/src/components/badge/badge.js
+++ b/src/components/badge/badge.js
@@ -2,12 +2,12 @@ import Vue from '../../utils/vue'
 import pluckProps from '../../utils/pluck-props'
 import { mergeData } from 'vue-functional-data-merge'
 import { getComponentConfig } from '../../utils/config'
-import { clone } from '../../utils/object'
+import { omit } from '../../utils/object'
 import { BLink, props as BLinkProps } from '../link/link'
 
 const NAME = 'BBadge'
 
-const linkProps = clone(BLinkProps)
+const linkProps = omit(BLinkProps, ['event'])
 delete linkProps.href.default
 delete linkProps.to.default
 

--- a/src/components/breadcrumb/breadcrumb-link.js
+++ b/src/components/breadcrumb/breadcrumb-link.js
@@ -18,7 +18,7 @@ export const props = {
     type: String,
     default: 'location'
   },
-  ...omit(BLinkProps, ['event'])
+  ...omit(BLinkProps, ['event', 'routerTag'])
 }
 
 // @vue/component

--- a/src/components/breadcrumb/breadcrumb-link.js
+++ b/src/components/breadcrumb/breadcrumb-link.js
@@ -1,7 +1,8 @@
-import Vue from '../../utils/vue'
 import { mergeData } from 'vue-functional-data-merge'
+import Vue from '../../utils/vue'
 import pluckProps from '../../utils/pluck-props'
 import { htmlOrText } from '../../utils/html'
+import { omit } from '../../utils/object'
 import { BLink, props as BLinkProps } from '../link/link'
 
 export const props = {
@@ -17,7 +18,7 @@ export const props = {
     type: String,
     default: 'location'
   },
-  ...BLinkProps
+  ...omit(BLinkProps, ['event'])
 }
 
 // @vue/component

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -16,7 +16,7 @@ const NAME = 'BButton'
 
 // --- Props ---
 
-const linkProps = omit(BLinkProps, ['event'])
+const linkProps = omit(BLinkProps, ['event', 'routerTag'])
 delete linkProps.href.default
 delete linkProps.to.default
 

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -6,7 +6,7 @@ import { concat } from '../../utils/array'
 import { getComponentConfig } from '../../utils/config'
 import { addClass, removeClass } from '../../utils/dom'
 import { isBoolean, isEvent, isFunction } from '../../utils/inspect'
-import { clone } from '../../utils/object'
+import { omit } from '../../utils/object'
 import { toString } from '../../utils/string'
 import { BLink, props as BLinkProps } from '../link/link'
 
@@ -16,7 +16,7 @@ const NAME = 'BButton'
 
 // --- Props ---
 
-const linkProps = clone(BLinkProps)
+const linkProps = omit(BLinkProps, ['event'])
 delete linkProps.href.default
 delete linkProps.to.default
 

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -4,10 +4,10 @@ import KeyCodes from '../../utils/key-codes'
 import pluckProps from '../../utils/pluck-props'
 import { concat } from '../../utils/array'
 import { getComponentConfig } from '../../utils/config'
-import { addClass, removeClass } from '../../utils/dom'
+import { addClass, isTag, removeClass } from '../../utils/dom'
 import { isBoolean, isEvent, isFunction } from '../../utils/inspect'
 import { omit } from '../../utils/object'
-import { toString } from '../../utils/string'
+import { isLink as isLinkStrict } from '../../utils/router'
 import { BLink, props as BLinkProps } from '../link/link'
 
 // --- Constants ---
@@ -65,9 +65,6 @@ export const props = { ...btnProps, ...linkProps }
 
 // --- Helper methods ---
 
-// Returns `true` if a tag's name equals `name`
-const tagIs = (tag, name) => toString(tag).toLowerCase() === toString(name).toLowerCase()
-
 // Focus handler for toggle buttons
 // Needs class of 'focus' when focused
 const handleFocus = evt => {
@@ -80,13 +77,13 @@ const handleFocus = evt => {
 
 // Is the requested button a link?
 // If tag prop is set to `a`, we use a <b-link> to get proper disabled handling
-const isLink = props => props.href || props.to || tagIs(props.tag, 'a')
+const isLink = props => isLinkStrict(props) || isTag(props.tag, 'a')
 
 // Is the button to be a toggle button?
 const isToggle = props => isBoolean(props.pressed)
 
 // Is the button "really" a button?
-const isButton = props => !(isLink(props) || (props.tag && !tagIs(props.tag, 'button')))
+const isButton = props => !(isLink(props) || (props.tag && !isTag(props.tag, 'button')))
 
 // Is the requested tag not a button or link?
 const isNonStandardTag = props => !isLink(props) && !isButton(props)
@@ -105,7 +102,7 @@ const computeClass = props => [
 ]
 
 // Compute the link props to pass to b-link (if required)
-const computeLinkProps = props => (isLink(props) ? pluckProps(linkProps, props) : null)
+const computeLinkProps = props => (isLink(props) ? pluckProps(linkProps, props) : {})
 
 // Compute the attributes for a button
 const computeAttrs = (props, data) => {

--- a/src/components/dropdown/dropdown-item.js
+++ b/src/components/dropdown/dropdown-item.js
@@ -1,11 +1,11 @@
 import Vue from '../../utils/vue'
 import { requestAF } from '../../utils/dom'
-import { clone } from '../../utils/object'
+import { omit } from '../../utils/object'
 import attrsMixin from '../../mixins/attrs'
 import normalizeSlotMixin from '../../mixins/normalize-slot'
 import { BLink, props as BLinkProps } from '../link/link'
 
-export const props = clone(BLinkProps)
+export const props = omit(BLinkProps, ['event'])
 
 // @vue/component
 export const BDropdownItem = /*#__PURE__*/ Vue.extend({

--- a/src/components/dropdown/dropdown-item.js
+++ b/src/components/dropdown/dropdown-item.js
@@ -5,7 +5,7 @@ import attrsMixin from '../../mixins/attrs'
 import normalizeSlotMixin from '../../mixins/normalize-slot'
 import { BLink, props as BLinkProps } from '../link/link'
 
-export const props = omit(BLinkProps, ['event'])
+export const props = omit(BLinkProps, ['event', 'routerTag'])
 
 // @vue/component
 export const BDropdownItem = /*#__PURE__*/ Vue.extend({

--- a/src/components/dropdown/package.json
+++ b/src/components/dropdown/package.json
@@ -97,7 +97,7 @@
           },
           {
             "prop": "splitTo",
-            "description": "router-link prop: Denotes the target route of the split button. When clicked, the value of the to prop will be passed to router.push() internally, so the value can be either a string or a Location descriptor object"
+            "description": "<router-link> prop: Denotes the target route of the split button. When clicked, the value of the to prop will be passed to router.push() internally, so the value can be either a string or a Location descriptor object"
           },
           {
             "prop": "splitVariant",

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -32,8 +32,8 @@ BootstrapVue auto detects using `<router-link>` and `<nuxt-link>` link component
 frameworks also provide customized versions of `<router-link>`, such as
 [Gridsome's `<g-link>` component](https://gridsome.org/docs/linking/). `<b-link>` can support these
 third party `<router-link>` compatible components via the use of the `router-component-name` prop.
-All vue-router props (excluding `<nuxt-link>` specific props) will be passed to the specified router
-link component.
+All `vue-router` props (excluding `<nuxt-link>` specific props) will be passed to the specified
+router link component.
 
 Note that the 3rd party component will only be used when the `to` prop is set.
 

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -26,6 +26,17 @@ If your app is running under [Nuxt.js](https://nuxtjs.org), the
 `<router-link>`. The `<nuxt-link>` component supports all the same features as `<router-link>` (as
 it is a wrapper component for `<router-link>`) and more.
 
+### Third party rounter links
+
+BootstrapVue auto detects using `<router-link>` and `<nuxt-link>` link components. Some 3rd party
+frameworks also provide customized versions of `<router-link>`, such as
+[Gridsome's `<g-link>` component](https://gridsome.org/docs/linking/). `<b-link>` can support these
+third party `<router-link>` compatible components via the use of the `router-component-name` prop.
+All vue-router props (excluding `<nuxt-link>` specific props) will be passed to the specified router
+link component.
+
+Note that the 3rd party component will only be used when the `to` prop is set.
+
 ## Links with `href="#"`
 
 Typically `<a href="#">` will cause the document to scroll to the top of page when clicked.

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -43,14 +43,6 @@ export const routerLinkProps = {
   routerTag: {
     type: String,
     default: 'a'
-  },
-  // To support 3rd party router links based on `<router-link>` (i.e. `g-link` for Gridsome)
-  // Default is to auto choose between `<router-link>` and `<nuxt-link>`
-  // Gridsome doesn't provide a mechanism to auto detect and has caveats
-  // such as not supporting FQDN URLs or hash only URLs
-  routerComponentName: {
-    type: String
-    // default: undefined
   }
 }
 
@@ -95,7 +87,15 @@ export const props = {
     default: false
   },
   ...routerLinkProps,
-  ...nuxtLinkProps
+  ...nuxtLinkProps,
+  // To support 3rd party router links based on `<router-link>` (i.e. `g-link` for Gridsome)
+  // Default is to auto choose between `<router-link>` and `<nuxt-link>`
+  // Gridsome doesn't provide a mechanism to auto detect and has caveats
+  // such as not supporting FQDN URLs or hash only URLs
+  routerComponentName: {
+    type: String
+    // default: undefined
+  }
 }
 
 // --- Main component ---

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -106,7 +106,11 @@ export const BLink = /*#__PURE__*/ Vue.extend({
   computed: {
     computedTag() {
       // We don't pass `this` as the first arg as we need reactivity of the props
-      return computeTag({ to: this.to, disabled: this.disabled }, this)
+      return computeTag({
+        to: this.to,
+        disabled: this.disabled,
+        routerComponentName: this.routerComponentName
+      }, this)
     },
     isRouterLink() {
       return isRouterLink(this.computedTag)

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -83,11 +83,10 @@ export const propsFactory = () => ({
     type: Boolean,
     default: false
   },
-  // To support 3rd party router links based on `<router-link>`
-  // i.e. set to `g-link` for Gridsome
-  // Default is to auto choose betwen `<router-link>` and `<nuxt-link>`
-  // As Grdisome doesn't provide a mechanism to auto detect
-  // And has caveats such as not supporting FQDN URLs or hash only URLs
+  // To support 3rd party router links based on `<router-link>` (i.e. `g-link` for Gridsome)
+  // Default is to auto choose between `<router-link>` and `<nuxt-link>`
+  // Gridsome doesn't provide a mechanism to auto detect and has caveats
+  // such as not supporting FQDN URLs or hash only URLs
   routerComponentName: {
     type: String
     // default: undefined
@@ -106,11 +105,8 @@ export const BLink = /*#__PURE__*/ Vue.extend({
   computed: {
     computedTag() {
       // We don't pass `this` as the first arg as we need reactivity of the props
-      return computeTag({
-        to: this.to,
-        disabled: this.disabled,
-        routerComponentName: this.routerComponentName
-      }, this)
+      const { to, disabled, routerComponentName } = this
+      return computeTag({ to, disabled, routerComponentName }, this)
     },
     isRouterLink() {
       return isRouterLink(this.computedTag)

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -132,7 +132,7 @@ export const BLink = /*#__PURE__*/ Vue.extend({
       const prefetch = this.prefetch
       return this.isRouterLink
         ? {
-            ...pluckProps({ ...routerLinkProps, ...nuxtLinkProps }, this.$props),
+            ...pluckProps({ ...routerLinkProps, ...nuxtLinkProps }, this),
             // Coerce `prefetch` value `null` to be `undefined`
             prefetch: isBoolean(prefetch) ? prefetch : undefined,
             // Pass `router-tag` as `tag` prop

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -1,12 +1,17 @@
 import Vue from '../../utils/vue'
 import pluckProps from '../../utils/pluck-props'
 import { concat } from '../../utils/array'
+import { getComponentConfig } from '../../utils/config'
 import { attemptBlur, attemptFocus } from '../../utils/dom'
 import { isBoolean, isEvent, isFunction, isUndefined } from '../../utils/inspect'
 import { computeHref, computeRel, computeTag, isRouterLink } from '../../utils/router'
 import attrsMixin from '../../mixins/attrs'
 import listenersMixin from '../../mixins/listeners'
 import normalizeSlotMixin from '../../mixins/normalize-slot'
+
+// --- Constants ---
+
+const NAME = 'BLink'
 
 // --- Props ---
 
@@ -93,8 +98,8 @@ export const props = {
   // Gridsome doesn't provide a mechanism to auto detect and has caveats
   // such as not supporting FQDN URLs or hash only URLs
   routerComponentName: {
-    type: String
-    // default: undefined
+    type: String,
+    default: () => getComponentConfig(NAME, 'routerComponentName')
   }
 }
 

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -83,9 +83,9 @@ export const propsFactory = () => ({
     type: Boolean,
     default: false
   },
-  // To support 3rd party router links based on router link
+  // To support 3rd party router links based on `<router-link>`
   // i.e. set to `g-link` for Gridsome
-  // Default is to auto choose `<router-link>` vs `<nuxt-link>`
+  // Default is to auto choose betwen `<router-link>` and `<nuxt-link>`
   // As Grdisome doesn't provide a mechanism to auto detect
   // And has caveats such as not supporting FQDN URLs or hash only URLs
   routerComponentName: {

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -43,6 +43,14 @@ export const routerLinkProps = {
   routerTag: {
     type: String,
     default: 'a'
+  },
+  // To support 3rd party router links based on `<router-link>` (i.e. `g-link` for Gridsome)
+  // Default is to auto choose between `<router-link>` and `<nuxt-link>`
+  // Gridsome doesn't provide a mechanism to auto detect and has caveats
+  // such as not supporting FQDN URLs or hash only URLs
+  routerComponentName: {
+    type: String
+    // default: undefined
   }
 }
 
@@ -61,14 +69,6 @@ export const nuxtLinkProps = {
   noPrefetch: {
     type: Boolean,
     default: false
-  },
-  // To support 3rd party router links based on `<router-link>` (i.e. `g-link` for Gridsome)
-  // Default is to auto choose between `<router-link>` and `<nuxt-link>`
-  // Gridsome doesn't provide a mechanism to auto detect and has caveats
-  // such as not supporting FQDN URLs or hash only URLs
-  routerComponentName: {
-    type: String
-    // default: undefined
   }
 }
 

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -82,6 +82,15 @@ export const propsFactory = () => ({
   noPrefetch: {
     type: Boolean,
     default: false
+  },
+  // To support 3rd party router links based on router link
+  // i.e. set to `g-link` for Gridsome
+  // Default is to auto choose `<router-link>` vs `<nuxt-link>`
+  // As Grdisome doesn't provide a mechanism to auto detect
+  // And has caveats such as not supporting FQDN URLs or hash only URLs
+  routerComponentName: {
+    type: String
+    // default: undefined
   }
 })
 

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -342,7 +342,9 @@ describe('b-link', () => {
           }
         },
         render(h) {
-          return h('RouterLink', { props: this.$props }, [this.$slots.default])
+          // We just us a simple A tag to render teh fake g-link
+          // and assume `to` is a string
+          return h('a', { attrs: { href: this.to } }, [this.$slots.default])
         }
       }
 

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -348,9 +348,11 @@ describe('b-link', () => {
         }
       }
 
+      localVue.component('GLink', GLink)
+
       const App = localVue.extend({
         router,
-        components: { BLink, GLink },
+        components: { BLink },
         render(h) {
           return h('main', [
             // router-link

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -362,7 +362,7 @@ describe('b-link', () => {
             // regular link
             h('b-link', { props: { href: '/b' } }, ['href-a']),
             // g-link
-            h('b-link', { props: { routerComponentName: 'g-link', to: '/a' } }, ['glink-a']),
+            // h('b-link', { props: { routerComponentName: 'g-link', to: '/a' } }, ['glink-a']),
             h('router-view')
           ])
         }
@@ -376,7 +376,7 @@ describe('b-link', () => {
       expect(wrapper.vm).toBeDefined()
       expect(wrapper.element.tagName).toBe('MAIN')
 
-      expect(wrapper.findAll('a').length).toBe(5)
+      expect(wrapper.findAll('a').length).toBe(4)
 
       const $links = wrapper.findAll('a')
 
@@ -398,10 +398,10 @@ describe('b-link', () => {
       expect($links.at(3).vm.$options.name).toBe('BLink')
       expect($links.at(3).vm.$children.length).toBe(0)
 
-      expect($links.at(4).vm).toBeDefined()
-      expect($links.at(4).vm.$options.name).toBe('BLink')
-      expect($links.at(4).vm.$children.length).toBe(1)
-      expect($links.at(4).vm.$children[0].$options.name).toBe('GLink')
+      // expect($links.at(4).vm).toBeDefined()
+      // expect($links.at(4).vm.$options.name).toBe('BLink')
+      // expect($links.at(4).vm.$children.length).toBe(1)
+      // expect($links.at(4).vm.$children[0].$options.name).toBe('GLink')
 
       wrapper.destroy()
     })

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -1,5 +1,5 @@
 import VueRouter from 'vue-router'
-import { mount, createLocalVue as CreateLocalVue } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
 import { createContainer } from '../../../tests/utils'
 import { BLink } from './link'
 
@@ -200,7 +200,7 @@ describe('b-link', () => {
   })
 
   describe('click handling', () => {
-    const localVue = new CreateLocalVue()
+    const localVue = createLocalVue()
 
     it('should invoke click handler bound by Vue when clicked on', async () => {
       let called = 0
@@ -320,7 +320,7 @@ describe('b-link', () => {
 
   describe('router-link support', () => {
     it('works', async () => {
-      const localVue = new CreateLocalVue()
+      const localVue = createLocalVue()
       localVue.use(VueRouter)
 
       const router = new VueRouter({
@@ -342,7 +342,7 @@ describe('b-link', () => {
           }
         },
         render(h) {
-          return h('router-link', { props: this.$props }, [this.$slots.default])
+          return h('RouterLink', { props: this.$props }, [this.$slots.default])
         }
       }
 

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -332,9 +332,23 @@ describe('b-link', () => {
         ]
       })
 
+      // Fake Gridsome `<g-link>` component
+      const GLink = {
+        name: 'GLink',
+        props: {
+          to: {
+            type: [String, Object],
+            default: ''
+          }
+        },
+        render(h) {
+          return h('router-link', { props: this.$props }, [this.$slots.default])
+        }
+      }
+
       const App = localVue.extend({
         router,
-        components: { BLink },
+        components: { BLink, GLink },
         render(h) {
           return h('main', [
             // router-link
@@ -345,6 +359,8 @@ describe('b-link', () => {
             h('b-link', { props: { to: { path: '/b' } } }, ['to-path-b']),
             // regular link
             h('b-link', { props: { href: '/b' } }, ['href-a']),
+            // g-link
+            h('b-link', { props: { routerComponentName: 'g-link', to: '/a' } }, ['glink-a']),
             h('router-view')
           ])
         }
@@ -358,7 +374,7 @@ describe('b-link', () => {
       expect(wrapper.vm).toBeDefined()
       expect(wrapper.element.tagName).toBe('MAIN')
 
-      expect(wrapper.findAll('a').length).toBe(4)
+      expect(wrapper.findAll('a').length).toBe(5)
 
       const $links = wrapper.findAll('a')
 
@@ -379,6 +395,11 @@ describe('b-link', () => {
       expect($links.at(3).vm).toBeDefined()
       expect($links.at(3).vm.$options.name).toBe('BLink')
       expect($links.at(3).vm.$children.length).toBe(0)
+
+      expect($links.at(4).vm).toBeDefined()
+      expect($links.at(4).vm.$options.name).toBe('BLink')
+      expect($links.at(4).vm.$children.length).toBe(1)
+      expect($links.at(4).vm.$children[0].$options.name).toBe('GLink')
 
       wrapper.destroy()
     })

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -342,8 +342,8 @@ describe('b-link', () => {
           }
         },
         render(h) {
-          // We just us a simple A tag to render teh fake g-link
-          // and assume `to` is a string
+          // We just us a simple A tag to render the
+          // fake `<g-link>` and assume `to` is a string
           return h('a', { attrs: { href: this.to } }, [this.$slots.default])
         }
       }
@@ -362,7 +362,7 @@ describe('b-link', () => {
             // regular link
             h('b-link', { props: { href: '/b' } }, ['href-a']),
             // g-link
-            // h('b-link', { props: { routerComponentName: 'g-link', to: '/a' } }, ['glink-a']),
+            h('b-link', { props: { routerComponentName: 'g-link', to: '/a' } }, ['glink-a']),
             h('router-view')
           ])
         }
@@ -376,7 +376,7 @@ describe('b-link', () => {
       expect(wrapper.vm).toBeDefined()
       expect(wrapper.element.tagName).toBe('MAIN')
 
-      expect(wrapper.findAll('a').length).toBe(4)
+      expect(wrapper.findAll('a').length).toBe(5)
 
       const $links = wrapper.findAll('a')
 
@@ -398,10 +398,10 @@ describe('b-link', () => {
       expect($links.at(3).vm.$options.name).toBe('BLink')
       expect($links.at(3).vm.$children.length).toBe(0)
 
-      // expect($links.at(4).vm).toBeDefined()
-      // expect($links.at(4).vm.$options.name).toBe('BLink')
-      // expect($links.at(4).vm.$children.length).toBe(1)
-      // expect($links.at(4).vm.$children[0].$options.name).toBe('GLink')
+      expect($links.at(4).vm).toBeDefined()
+      expect($links.at(4).vm.$options.name).toBe('BLink')
+      expect($links.at(4).vm.$children.length).toBe(1)
+      expect($links.at(4).vm.$children[0].$options.name).toBe('GLink')
 
       wrapper.destroy()
     })

--- a/src/components/link/package.json
+++ b/src/components/link/package.json
@@ -7,7 +7,20 @@
     "components": [
       {
         "component": "BLink",
-        "props": [],
+        "props": [
+          {
+            "prop": "href",
+            "description": "Denotes the target URL of the link for standard a links"
+          },
+          {
+            "prop": "rel",
+            "description": "Sets the 'rel' attribute on the rendered link"
+          },
+          {
+            "prop": "target",
+            "description": "Sets the 'target' attribute on the rendered link"
+          }
+        ],
         "events": [
           {
             "event": "click",

--- a/src/components/list-group/list-group-item.js
+++ b/src/components/list-group/list-group-item.js
@@ -3,7 +3,7 @@ import Vue from '../../utils/vue'
 import pluckProps from '../../utils/pluck-props'
 import { arrayIncludes } from '../../utils/array'
 import { getComponentConfig } from '../../utils/config'
-import { clone } from '../../utils/object'
+import { omit } from '../../utils/object'
 import { BLink, props as BLinkProps } from '../link/link'
 
 // --- Constants ---
@@ -14,7 +14,7 @@ const actionTags = ['a', 'router-link', 'button', 'b-link']
 
 // --- Props ---
 
-const linkProps = clone(BLinkProps)
+const linkProps = omit(BLinkProps, ['event'])
 delete linkProps.href.default
 delete linkProps.to.default
 

--- a/src/components/nav/nav-item.js
+++ b/src/components/nav/nav-item.js
@@ -1,11 +1,11 @@
 import { mergeData } from 'vue-functional-data-merge'
 import Vue from '../../utils/vue'
-import { clone } from '../../utils/object'
+import { omit } from '../../utils/object'
 import { BLink, props as BLinkProps } from '../link/link'
 
 // --- Props ---
 
-export const props = clone(BLinkProps)
+export const props = omit(BLinkProps, ['event'])
 
 // --- Main component ---
 // @vue/component

--- a/src/components/nav/nav-item.js
+++ b/src/components/nav/nav-item.js
@@ -5,7 +5,7 @@ import { BLink, props as BLinkProps } from '../link/link'
 
 // --- Props ---
 
-export const props = omit(BLinkProps, ['event'])
+export const props = omit(BLinkProps, ['event', 'routerTag'])
 
 // --- Main component ---
 // @vue/component

--- a/src/components/navbar/navbar-brand.js
+++ b/src/components/navbar/navbar-brand.js
@@ -4,7 +4,7 @@ import pluckProps from '../../utils/pluck-props'
 import { omit } from '../../utils/object'
 import { BLink, props as BLinkProps } from '../link/link'
 
-const linkProps = omit(BLinkProps, ['event'])
+const linkProps = omit(BLinkProps, ['event', 'routerTag'])
 linkProps.href.default = undefined
 linkProps.to.default = undefined
 

--- a/src/components/navbar/navbar-brand.js
+++ b/src/components/navbar/navbar-brand.js
@@ -4,18 +4,21 @@ import pluckProps from '../../utils/pluck-props'
 import { omit } from '../../utils/object'
 import { BLink, props as BLinkProps } from '../link/link'
 
+// --- Props ---
+
 const linkProps = omit(BLinkProps, ['event', 'routerTag'])
 linkProps.href.default = undefined
 linkProps.to.default = undefined
 
 export const props = {
-  ...linkProps,
   tag: {
     type: String,
     default: 'div'
-  }
+  },
+  ...linkProps
 }
 
+// --- Main component ---
 // @vue/component
 export const BNavbarBrand = /*#__PURE__*/ Vue.extend({
   name: 'BNavbarBrand',

--- a/src/components/navbar/navbar-brand.js
+++ b/src/components/navbar/navbar-brand.js
@@ -1,10 +1,10 @@
 import { mergeData } from 'vue-functional-data-merge'
 import Vue from '../../utils/vue'
 import pluckProps from '../../utils/pluck-props'
-import { clone } from '../../utils/object'
+import { omit } from '../../utils/object'
 import { BLink, props as BLinkProps } from '../link/link'
 
-const linkProps = clone(BLinkProps)
+const linkProps = omit(BLinkProps, ['event'])
 linkProps.href.default = undefined
 linkProps.to.default = undefined
 

--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -1,9 +1,14 @@
 import Vue from '../../utils/vue'
 import { getComponentConfig, getBreakpoints } from '../../utils/config'
+import { isTag } from '../../utils/dom'
 import { isString } from '../../utils/inspect'
 import normalizeSlotMixin from '../../mixins/normalize-slot'
 
+// --- Constants ---
+
 const NAME = 'BNavbar'
+
+// --- Props ---
 
 export const props = {
   tag: {
@@ -35,6 +40,7 @@ export const props = {
   }
 }
 
+// --- Main component ---
 // @vue/component
 export const BNavbar = /*#__PURE__*/ Vue.extend({
   name: NAME,
@@ -73,7 +79,7 @@ export const BNavbar = /*#__PURE__*/ Vue.extend({
           this.breakpointClass
         ],
         attrs: {
-          role: this.tag === 'nav' ? null : 'navigation'
+          role: isTag(this.tag, 'nav') ? null : 'navigation'
         }
       },
       [this.normalizeSlot('default')]

--- a/src/components/pagination-nav/pagination-nav.js
+++ b/src/components/pagination-nav/pagination-nav.js
@@ -13,10 +13,16 @@ import { warn } from '../../utils/warn'
 import paginationMixin from '../../mixins/pagination'
 import { props as BLinkProps } from '../link/link'
 
+// --- Constants ---
+
 const NAME = 'BPaginationNav'
 
-// Sanitize the provided number of pages (converting to a number)
-export const sanitizeNumberOfPages = value => mathMax(toInteger(value, 0), 1)
+// --- Props ---
+
+const linkProps = pluckProps(
+  ['activeClass', 'exact', 'exactActiveClass', 'prefetch', 'noPrefetch', 'routerComponentName'],
+  BLinkProps
+)
 
 const props = {
   size: {
@@ -61,9 +67,15 @@ const props = {
     type: Boolean,
     default: false
   },
-  ...pluckProps(['activeClass', 'exact', 'exactActiveClass', 'prefetch', 'noPrefetch'], BLinkProps)
+  ...linkProps
 }
 
+// --- Utility methods ---
+
+// Sanitize the provided number of pages (converting to a number)
+export const sanitizeNumberOfPages = value => mathMax(toInteger(value, 0), 1)
+
+// --- Main component ---
 // The render function is brought in via the pagination mixin
 // @vue/component
 export const BPaginationNav = /*#__PURE__*/ Vue.extend({

--- a/src/components/pagination-nav/pagination-nav.js
+++ b/src/components/pagination-nav/pagination-nav.js
@@ -185,7 +185,7 @@ export const BPaginationNav = /*#__PURE__*/ Vue.extend({
       return info.link
     },
     linkProps(pageNum) {
-      const props = pluckProps(linkProps, this.$props)
+      const props = pluckProps(linkProps, this)
       const link = this.makeLink(pageNum)
       if (this.useRouter || isObject(link)) {
         props.to = link

--- a/src/components/pagination-nav/pagination-nav.js
+++ b/src/components/pagination-nav/pagination-nav.js
@@ -20,7 +20,7 @@ const NAME = 'BPaginationNav'
 
 // --- Props ---
 
-const linkProps = omit(BLinkProps, ['event'])
+const linkProps = omit(BLinkProps, ['event', 'routerTag'])
 
 const props = {
   size: {

--- a/src/components/pagination-nav/pagination-nav.js
+++ b/src/components/pagination-nav/pagination-nav.js
@@ -7,6 +7,7 @@ import { isBrowser } from '../../utils/env'
 import { isArray, isUndefined, isFunction, isObject } from '../../utils/inspect'
 import { mathMax } from '../../utils/math'
 import { toInteger } from '../../utils/number'
+import { omit } from '../../utils/object'
 import { computeHref, parseQuery } from '../../utils/router'
 import { toString } from '../../utils/string'
 import { warn } from '../../utils/warn'
@@ -19,10 +20,7 @@ const NAME = 'BPaginationNav'
 
 // --- Props ---
 
-const linkProps = pluckProps(
-  ['activeClass', 'exact', 'exactActiveClass', 'prefetch', 'noPrefetch', 'routerComponentName'],
-  BLinkProps
-)
+const linkProps = omit(BLinkProps, ['event'])
 
 const props = {
   size: {
@@ -187,38 +185,13 @@ export const BPaginationNav = /*#__PURE__*/ Vue.extend({
       return info.link
     },
     linkProps(pageNum) {
+      const props = pluckProps(linkProps, this.$props)
       const link = this.makeLink(pageNum)
-      const {
-        disabled,
-        exact,
-        activeClass,
-        exactActiveClass,
-        append,
-        replace,
-        prefetch,
-        noPrefetch
-      } = this
-
-      const props = {
-        target: this.target || null,
-        rel: this.rel || null,
-        disabled,
-        // The following props are only used if `BLink` detects router
-        exact,
-        activeClass,
-        exactActiveClass,
-        append,
-        replace,
-        // <nuxt-link> specific prop
-        prefetch,
-        noPrefetch
-      }
       if (this.useRouter || isObject(link)) {
         props.to = link
       } else {
         props.href = link
       }
-
       return props
     },
     resolveLink(to = '') {

--- a/src/components/table/td.js
+++ b/src/components/table/td.js
@@ -1,10 +1,13 @@
 import Vue from '../../utils/vue'
+import { isTag } from '../../utils/dom'
 import { isUndefinedOrNull } from '../../utils/inspect'
 import { toInteger } from '../../utils/number'
 import { toString } from '../../utils/string'
 import attrsMixin from '../../mixins/attrs'
 import listenersMixin from '../../mixins/listeners'
 import normalizeSlotMixin from '../../mixins/normalize-slot'
+
+// --- Utility methods ---
 
 // Parse a rowspan or colspan into a digit (or `null` if < `1` )
 const parseSpan = value => {
@@ -42,6 +45,7 @@ export const props = {
   }
 }
 
+// --- Main component ---
 // TODO:
 //   In Bootstrap v5, we won't need "sniffing" as table element variants properly inherit
 //   to the child elements, so this can be converted to a functional component
@@ -160,7 +164,7 @@ export const BTd = /*#__PURE__*/ Vue.extend({
         // Header or footer cells
         role = 'columnheader'
         scope = colspan > 0 ? 'colspan' : 'col'
-      } else if (this.tag === 'th') {
+      } else if (isTag(this.tag, 'th')) {
         // th's in tbody
         role = 'rowheader'
         scope = rowspan > 0 ? 'rowgroup' : 'row'

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -1,12 +1,15 @@
-import Vue from '../../utils/vue'
 import { Portal, Wormhole } from 'portal-vue'
 import BVTransition from '../../utils/bv-transition'
+import Vue from '../../utils/vue'
+import pluckProps from '../../utils/pluck-props'
 import { BvEvent } from '../../utils/bv-event.class'
 import { getComponentConfig } from '../../utils/config'
 import { requestAF } from '../../utils/dom'
 import { EVENT_OPTIONS_NO_CAPTURE, eventOnOff } from '../../utils/events'
 import { mathMax } from '../../utils/math'
 import { toInteger } from '../../utils/number'
+import { pick } from '../../utils/object'
+import { isLink } from '../../utils/router'
 import attrsMixin from '../../mixins/attrs'
 import idMixin from '../../mixins/id'
 import listenOnRootMixin from '../../mixins/listen-on-root'
@@ -14,7 +17,7 @@ import normalizeSlotMixin from '../../mixins/normalize-slot'
 import scopedStyleAttrsMixin from '../../mixins/scoped-style-attrs'
 import { BToaster } from './toaster'
 import { BButtonClose } from '../button/button-close'
-import { BLink } from '../link/link'
+import { BLink, props as BLinkProps } from '../link/link'
 
 // --- Constants ---
 
@@ -23,6 +26,8 @@ const NAME = 'BToast'
 const MIN_DURATION = 1000
 
 // --- Props ---
+
+const linkProps = pick(BLinkProps, ['href', 'to'])
 
 export const props = {
   id: {
@@ -92,19 +97,12 @@ export const props = {
     type: [String, Object, Array],
     default: () => getComponentConfig(NAME, 'bodyClass')
   },
-  href: {
-    type: String
-    // default: null
-  },
-  to: {
-    type: [String, Object]
-    // default: null
-  },
   static: {
     // Render the toast in place, rather than in a portal-target
     type: Boolean,
     default: false
-  }
+  },
+  ...linkProps
 }
 
 // @vue/component
@@ -385,14 +383,14 @@ export const BToast = /*#__PURE__*/ Vue.extend({
         )
       }
       // Toast body
-      const isLink = this.href || this.to
+      const link = isLink(this)
       const $body = h(
-        isLink ? BLink : 'div',
+        link ? BLink : 'div',
         {
           staticClass: 'toast-body',
           class: this.bodyClass,
-          props: isLink ? { to: this.to, href: this.href } : {},
-          on: isLink ? { click: this.onLinkClick } : {}
+          props: link ? pluckProps(linkProps, this) : {},
+          on: link ? { click: this.onLinkClick } : {}
         },
         [this.normalizeSlot('default', this.slotScope) || h()]
       )

--- a/src/utils/config-defaults.js
+++ b/src/utils/config-defaults.js
@@ -183,6 +183,9 @@ export default deepFreeze({
     borderVariant: undefined,
     textVariant: undefined
   },
+  BLink: {
+    routerComponentName: undefined
+  },
   BListGroupItem: {
     variant: undefined
   },

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -2,6 +2,7 @@ import { from as arrayFrom } from './array'
 import { hasWindowSupport, hasDocumentSupport } from './env'
 import { isFunction, isNull } from './inspect'
 import { toFloat } from './number'
+import { toString } from './string'
 
 // --- Constants ---
 
@@ -73,6 +74,9 @@ export const getActiveElement = (excludes = []) => {
   const activeElement = d.activeElement
   return activeElement && !excludes.some(el => el === activeElement) ? activeElement : null
 }
+
+// Returns `true` if a tag's name equals `name`
+export const isTag = (tag, name) => toString(tag).toLowerCase() === toString(name).toLowerCase()
 
 // Determine if an HTML element is the currently active element
 export const isActiveElement = el => isElement(el) && el === getActiveElement()

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -95,20 +95,15 @@ export const computeTag = ({ to, disabled, routerComponentName } = {}, thisOrPar
     return ANCHOR_TAG
   }
 
-  // Possible To Do:
-  //   Check registered components for existance of user supplied
-  //   router link component name. We would need to check PascalCase,
-  //   kebab-case, and camelCase versions of name:
+  // TODO:
+  //   Check registered components for existence of user supplied router link component name
+  //   We would need to check PascalCase, kebab-case, and camelCase versions of name:
   //   const name = routerComponentName
   //   const names = [name, PascalCase(name), KebabCase(name), CamelCase(name)]
   //   exists = names.some(name => !!thisOrParent.$options.components[name])
-  //   And may want to cache the result for performance
-  //   Or: we just let the render fail if the component is not registered
-  return routerComponentName
-    ? routerComponentName
-    : thisOrParent.$nuxt
-      ? 'nuxt-link'
-      : 'router-link'
+  //   And may want to cache the result for performance or we just let the render fail
+  //   if the component is not registered
+  return routerComponentName || thisOrParent.$nuxt ? 'nuxt-link' : 'router-link'
 }
 
 export const computeRel = ({ target, rel } = {}) => {

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -103,7 +103,7 @@ export const computeTag = ({ to, disabled, routerComponentName } = {}, thisOrPar
   //   exists = names.some(name => !!thisOrParent.$options.components[name])
   //   And may want to cache the result for performance or we just let the render fail
   //   if the component is not registered
-  return routerComponentName || thisOrParent.$nuxt ? 'nuxt-link' : 'router-link'
+  return routerComponentName || (thisOrParent.$nuxt ? 'nuxt-link' : 'router-link')
 }
 
 export const computeRel = ({ target, rel } = {}) => {

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,3 +1,4 @@
+import { isTag } from './dom'
 import { isArray, isNull, isPlainObject, isString, isUndefined } from './inspect'
 import { keys } from './object'
 import { toString } from './string'
@@ -87,7 +88,9 @@ export const parseQuery = query => {
   return parsed
 }
 
-export const isRouterLink = tag => toString(tag).toLowerCase() !== ANCHOR_TAG
+export const isLink = props => !!(props.href || props.to)
+
+export const isRouterLink = tag => !isTag(tag, ANCHOR_TAG)
 
 export const computeTag = ({ to, disabled, routerComponentName } = {}, thisOrParent) => {
   const hasRouter = thisOrParent.$router

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -91,7 +91,7 @@ export const isRouterLink = tag => toString(tag).toLowerCase() !== ANCHOR_TAG
 
 export const computeTag = ({ to, disabled, routerComponentName } = {}, thisOrParent) => {
   const hasRouter = thisOrParent.$router
-  if (!hasRouter || (hasRouter && disabled) || !to) {
+  if (!hasRouter || (hasRouter && disabled) || (hasRouter && !to)) {
     return ANCHOR_TAG
   }
 

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -89,12 +89,26 @@ export const parseQuery = query => {
 
 export const isRouterLink = tag => toString(tag).toLowerCase() !== ANCHOR_TAG
 
-export const computeTag = ({ to, disabled } = {}, thisOrParent) => {
-  return thisOrParent.$router && to && !disabled
-    ? thisOrParent.$nuxt
+export const computeTag = ({ to, disabled, routerComponentName } = {}, thisOrParent) => {
+  const hasRouter = thisOrParent.$router
+  if (!hasRouter || (hasRouter && disabled) || !to) {
+    return ANCHOR_TAG
+  }
+
+  // Possible To Do:
+  //   Check registered components for existance of user supplied
+  //   router link component name. We would need to check PascalCase,
+  //   kebab-case, and camelCase versions of name:
+  //   const name = routerComponentName
+  //   const names = [name, PascalCase(name), KebabCase(name), CamelCase(name)]
+  //   exists = names.some(name => !!thisOrParent.$options.components[name])
+  //   And may want to cache the result for performance
+  //   Or: we just let the render fail if the component is not registered
+  return routerComponentName
+    ? routerComponentName
+    : thisOrParent.$nuxt
       ? 'nuxt-link'
       : 'router-link'
-    : ANCHOR_TAG
 }
 
 export const computeRel = ({ target, rel } = {}) => {


### PR DESCRIPTION
### Describe the PR

Adds a new prop `router-component-name`, which defaults to `undefined`.

Default is to auto detect `<router-link>` or`<nuxt-link>`.

Gridsome does not provide a means for detecting that the app is running under Gridsome, so users who wish to use `<g-link>` can set this prop to `'g-link'`

Notes:

- if `vue-router` is not detected, then the user supplied router-link component will not be used.
- If vue-router is detected, and `g-link` is not a registered component, then the render or the link will fail
- Gridsome's `<g-link>` component does not support FQDN URLs nor hash only URLs (https://gridsome.org/docs/linking/)

To Do:

- [x] Unit tests
- [x] Router-Links reference section docs updates
- [x] b-link docs updates
- [x] common props meta json (and include version property)

Possible ToDo:

- Check to see if the user supplied component name is registered with Vue, and if not, fallback to `<router-link>`

Closes #2627

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [x] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [x] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates
- [x] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [x] New/updated tests are included and passing (required for new features and enhancements)
- [x] Existing test suites are passing
- [x] CodeCov for patch has met target (all changes/updates have been tested)
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
