### PR TITLE
fix(b-form-checkbox-group): only emit `input` when value loosely changes

### DIFF
--- a/src/components/form-checkbox/form-checkbox-group.spec.js
+++ b/src/components/form-checkbox/form-checkbox-group.spec.js
@@ -363,6 +363,54 @@ describe('form-checkbox-group', () => {
     wrapper.destroy()
   })
 
+  it('does not emit "input" event when value loosely changes', async () => {
+    const value = ['one', 'two', 'three']
+    const wrapper = mount(BFormCheckboxGroup, {
+      attachTo: createContainer(),
+      propsData: {
+        options: value.slice(),
+        checked: value.slice()
+      }
+    })
+    expect(wrapper.classes()).toBeDefined()
+    const checks = wrapper.findAll('input')
+    expect(checks.length).toBe(3)
+    expect(wrapper.vm.localChecked).toEqual(value)
+    expect(checks.wrappers.every(c => c.find('input[type=checkbox]').exists())).toBe(true)
+    expect(checks.at(0).element.checked).toBe(true)
+    expect(checks.at(1).element.checked).toBe(true)
+    expect(checks.at(2).element.checked).toBe(true)
+
+    expect(wrapper.emitted('input')).not.toBeDefined()
+
+    // Set internal value to new array reference
+    wrapper.vm.localChecked = value.slice()
+    await waitNT(wrapper.vm)
+
+    expect(wrapper.vm.localChecked).toEqual(value)
+    expect(checks.wrappers.every(c => c.find('input[type=checkbox]').exists())).toBe(true)
+    expect(checks.at(0).element.checked).toBe(true)
+    expect(checks.at(1).element.checked).toBe(true)
+    expect(checks.at(2).element.checked).toBe(true)
+
+    expect(wrapper.emitted('input')).not.toBeDefined()
+
+    // Set internal value to new array (reversed order)
+    wrapper.vm.localChecked = value.slice().reverse()
+    await waitNT(wrapper.vm)
+
+    expect(wrapper.vm.localChecked).toEqual(value.slice().reverse())
+    expect(checks.wrappers.every(c => c.find('input[type=checkbox]').exists())).toBe(true)
+    expect(checks.at(0).element.checked).toBe(true)
+    expect(checks.at(1).element.checked).toBe(true)
+    expect(checks.at(2).element.checked).toBe(true)
+    expect(wrapper.emitted('input')).toBeDefined()
+    expect(wrapper.emitted('input').length).toBe(1)
+    expect(wrapper.emitted('input')[0][0]).toEqual(value.slice().reverse())
+
+    wrapper.destroy()
+  })
+
   it('checkboxes reflect group checked v-model', async () => {
     const wrapper = mount(BFormCheckboxGroup, {
       attachTo: createContainer(),

--- a/src/mixins/form-radio-check-group.js
+++ b/src/mixins/form-radio-check-group.js
@@ -1,4 +1,5 @@
 import { htmlOrText } from '../utils/html'
+import looseEqual from '../utils/loose-equal'
 import normalizeSlotMixin from './normalize-slot'
 import { BFormCheckbox } from '../components/form-checkbox/form-checkbox'
 import { BFormRadio } from '../components/form-radio/form-radio'
@@ -70,8 +71,10 @@ export default {
     checked(newVal) {
       this.localChecked = newVal
     },
-    localChecked(newVal) {
-      this.$emit('input', newVal)
+    localChecked(newVal, oldVal) {
+      if (!looseEqual(newVal, oldVal)) {
+        this.$emit('input', newVal)
+      }
     }
   },
   render(h) {

--- a/src/utils/loose-equal.js
+++ b/src/utils/loose-equal.js
@@ -1,4 +1,4 @@
-import { keys } from './object'
+import { hasOwnProperty, keys } from './object'
 import { isArray, isDate, isObject } from './inspect'
 
 // Assumes both a and b are arrays!
@@ -46,10 +46,8 @@ const looseEqual = (a, b) => {
       return false
     }
     for (const key in a) {
-      // eslint-disable-next-line no-prototype-builtins
-      const aHasKey = a.hasOwnProperty(key)
-      // eslint-disable-next-line no-prototype-builtins
-      const bHasKey = b.hasOwnProperty(key)
+      const aHasKey = hasOwnProperty(a, key)
+      const bHasKey = hasOwnProperty(b, key)
       if ((aHasKey && !bHasKey) || (!aHasKey && bHasKey) || !looseEqual(a[key], b[key])) {
         return false
       }


### PR DESCRIPTION
### Describe the PR

Uses `looseEqual` to determine if the `input` event should be emitted.

This will prevent input event loops when the array reference changes, but the contents are the same.

StackOverlow issue: https://stackoverflow.com/questions/62002613/computed-property-setter-creates-maximus-stack-exceeded

To Do:

- [x] unit tests for array reference change (but same contents)

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [ ] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates
- [ ] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [x] New/updated tests are included and passing (required for new features and enhancements)
- [x] Existing test suites are passing
- [x] CodeCov for patch has met target (all changes/updates have been tested)
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
