### PR TITLE
fix(v-b-toggle): handle component updates on click listeners (closes #5475)

### DIFF
--- a/src/components/navbar/navbar-toggle.spec.js
+++ b/src/components/navbar/navbar-toggle.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { waitNT } from '../../../tests/utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 import { BNavbarToggle } from './navbar-toggle'
 
 describe('navbar-toggle', () => {
@@ -106,6 +106,10 @@ describe('navbar-toggle', () => {
         target: 'target-7'
       }
     })
+
+    await waitRAF()
+    await waitNT(wrapper.vm)
+
     let rootClicked = false
     const onRootClick = () => {
       rootClicked = true

--- a/src/directives/toggle/toggle.js
+++ b/src/directives/toggle/toggle.js
@@ -9,10 +9,11 @@ import {
   isTag,
   removeAttr,
   removeClass,
+  requestAF,
   setAttr
 } from '../../utils/dom'
 import { isBrowser } from '../../utils/env'
-import { eventOn, eventOff } from '../../utils/events'
+import { EVENT_OPTIONS_PASSIVE, eventOn, eventOff } from '../../utils/events'
 import { isString } from '../../utils/inspect'
 import { keys } from '../../utils/object'
 
@@ -95,8 +96,8 @@ const getTargets = ({ modifiers, arg, value }, el) => {
 const removeClickListener = el => {
   const handler = el[BV_TOGGLE_CLICK_HANDLER]
   if (handler) {
-    eventOff(el, 'click', handler)
-    eventOff(el, 'keydown', handler)
+    eventOff(el, 'click', handler, EVENT_OPTIONS_PASSIVE)
+    eventOff(el, 'keydown', handler, EVENT_OPTIONS_PASSIVE)
   }
   el[BV_TOGGLE_CLICK_HANDLER] = null
 }
@@ -116,9 +117,9 @@ const addClickListener = (el, vnode) => {
       }
     }
     el[BV_TOGGLE_CLICK_HANDLER] = handler
-    eventOn(el, 'click', handler)
+    eventOn(el, 'click', handler, EVENT_OPTIONS_PASSIVE)
     if (isNonStandardTag(el)) {
-      eventOn(el, 'keydown', handler)
+      eventOn(el, 'keydown', handler, EVENT_OPTIONS_PASSIVE)
     }
   }
 }
@@ -203,7 +204,11 @@ const handleUpdate = (el, binding, vnode) => {
   }
 
   // Add/Update our click listener(s)
-  addClickListener(el, vnode)
+  // Wrap in a `requestAF()` to allow any previous
+  // click handling to occur first
+  requestAF(() => {
+    addClickListener(el, vnode)
+  })
 
   // If targets array has changed, update
   if (!looseEqual(targets, el[BV_TOGGLE_TARGETS])) {

--- a/src/directives/toggle/toggle.spec.js
+++ b/src/directives/toggle/toggle.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { waitNT } from '../../../tests/utils'
+import { waitNT, waitRAF } from '../../../tests/utils'
 import { VBToggle } from './toggle'
 
 // Emitted control event for collapse (emitted to collapse)
@@ -28,6 +28,9 @@ describe('v-b-toggle directive', () => {
     }
 
     const wrapper = mount(App)
+
+    await waitRAF()
+    await waitNT(wrapper.vm)
 
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.element.tagName).toBe('BUTTON')
@@ -72,6 +75,9 @@ describe('v-b-toggle directive', () => {
 
     const wrapper = mount(App)
 
+    await waitRAF()
+    await waitNT(wrapper.vm)
+
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.element.tagName).toBe('BUTTON')
     expect(spy).not.toHaveBeenCalled()
@@ -113,6 +119,9 @@ describe('v-b-toggle directive', () => {
 
     const wrapper = mount(App)
 
+    await waitRAF()
+    await waitNT(wrapper.vm)
+
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.element.tagName).toBe('BUTTON')
     expect(spy).not.toHaveBeenCalled()
@@ -153,6 +162,9 @@ describe('v-b-toggle directive', () => {
     }
 
     const wrapper = mount(App)
+
+    await waitRAF()
+    await waitNT(wrapper.vm)
 
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.element.tagName).toBe('A')
@@ -206,6 +218,9 @@ describe('v-b-toggle directive', () => {
         target: 'test1'
       }
     })
+
+    await waitRAF()
+    await waitNT(wrapper.vm)
 
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.element.tagName).toBe('BUTTON')
@@ -278,6 +293,9 @@ describe('v-b-toggle directive', () => {
     }
 
     const wrapper = mount(App)
+
+    await waitRAF()
+    await waitNT(wrapper.vm)
 
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.element.tagName).toBe('SPAN')


### PR DESCRIPTION
### Describe the PR

When the element with the `v-b-toggle` directive assigned had other click handlers assigned that triggered a re-render of the element, the toggle click handler was not fired since we re-assign it to pick up any target changes.

This PR adds a `requestAnimationFrame()` call before re-assigning the click listeners in order to allow any previous click handling to occur first.

Closes #5475.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [ ] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates
- [ ] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (required for new features and enhancements)
- [ ] Existing test suites are passing
- [ ] CodeCov for patch has met target (all changes/updates have been tested)
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
