### PR TITLE
fix(b-table): only set `tabindex="0"` for sortable fields (closes #6097)

### DIFF
--- a/src/components/table/helpers/mixin-thead.js
+++ b/src/components/table/helpers/mixin-thead.js
@@ -115,8 +115,9 @@ export default {
           props: { variant, stickyColumn },
           style: field.thStyle || {},
           attrs: {
-            // We only add a tabindex of 0 if there is a head-clicked listener
-            tabindex: hasHeadClickListener ? '0' : null,
+            // We only add a `tabindex` of `0` if there is a head-clicked listener
+            // and the current field is sortable
+            tabindex: hasHeadClickListener && field.sortable ? '0' : null,
             abbr: field.headerAbbr || null,
             title: field.headerTitle || null,
             'aria-colindex': colIndex + 1,

--- a/src/components/table/table-sorting.spec.js
+++ b/src/components/table/table-sorting.spec.js
@@ -18,10 +18,13 @@ describe('table > sorting', () => {
         items: testItems
       }
     })
+
+    await waitNT(wrapper.vm)
+
     expect(wrapper).toBeDefined()
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(3)
-    await waitNT(wrapper.vm)
+
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input').length).toBe(1)
     expect(wrapper.emitted('input')[0][0]).toEqual(testItems)
@@ -69,19 +72,19 @@ describe('table > sorting', () => {
         sortDesc: false
       }
     })
+
+    await waitNT(wrapper.vm)
+
     expect(wrapper).toBeDefined()
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(3)
-    let $rows
-    let columnA
 
-    await waitNT(wrapper.vm)
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input').length).toBe(1)
-    $rows = wrapper.findAll('tbody > tr').wrappers
+    let $rows = wrapper.findAll('tbody > tr').wrappers
     expect($rows.length).toBe(3)
     // Map the rows to the first column text value
-    columnA = $rows.map(row => {
+    let columnA = $rows.map(row => {
       return row
         .findAll('td')
         .at(0)
@@ -95,6 +98,7 @@ describe('table > sorting', () => {
 
     // Currently sorted as ascending
     expect($ths.at(0).attributes('aria-sort')).toBe('ascending')
+    expect($ths.at(0).attributes('tabindex')).toBe('0')
     // For switching to descending
     expect(
       $ths
@@ -105,6 +109,7 @@ describe('table > sorting', () => {
 
     // Not sorted by this column
     expect($ths.at(1).attributes('aria-sort')).toBe('none')
+    expect($ths.at(1).attributes('tabindex')).toBe('0')
     // For sorting by ascending
     expect(
       $ths
@@ -115,6 +120,7 @@ describe('table > sorting', () => {
 
     // Not a sortable column
     expect($ths.at(2).attributes('aria-sort')).not.toBeDefined()
+    expect($ths.at(2).attributes('tabindex')).not.toBeDefined()
     // For clearing sorting
     expect(
       $ths
@@ -238,11 +244,13 @@ describe('table > sorting', () => {
         }
       }
     })
+
+    await waitNT(wrapper.vm)
+
     expect(wrapper).toBeDefined()
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(3)
 
-    await waitNT(wrapper.vm)
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input').length).toBe(1)
     const $rows = wrapper.findAll('tbody > tr').wrappers
@@ -268,20 +276,20 @@ describe('table > sorting', () => {
         items: testItems
       }
     })
+
+    await waitNT(wrapper.vm)
+
     expect(wrapper).toBeDefined()
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(3)
-    let $rows
-    let columnA
 
     // Should not be sorted
-    await waitNT(wrapper.vm)
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('sort-changed')).not.toBeDefined()
-    $rows = wrapper.findAll('tbody > tr').wrappers
+    let $rows = wrapper.findAll('tbody > tr').wrappers
     expect($rows.length).toBe(3)
     // Map the rows to the first column text value
-    columnA = $rows.map(row => {
+    let columnA = $rows.map(row => {
       return row
         .findAll('td')
         .at(0)
@@ -383,20 +391,20 @@ describe('table > sorting', () => {
         footClone: true
       }
     })
+
+    await waitNT(wrapper.vm)
+
     expect(wrapper).toBeDefined()
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(3)
-    let $rows
-    let columnA
 
     // Should not be sorted
-    await waitNT(wrapper.vm)
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('sort-changed')).not.toBeDefined()
-    $rows = wrapper.findAll('tbody > tr').wrappers
+    let $rows = wrapper.findAll('tbody > tr').wrappers
     expect($rows.length).toBe(3)
     // Map the rows to the first column text value
-    columnA = $rows.map(row => {
+    let columnA = $rows.map(row => {
       return row
         .findAll('td')
         .at(0)
@@ -511,20 +519,20 @@ describe('table > sorting', () => {
         noFooterSorting: true
       }
     })
+
+    await waitNT(wrapper.vm)
+
     expect(wrapper).toBeDefined()
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(3)
-    let $rows
-    let columnA
 
     // Should not be sorted
-    await waitNT(wrapper.vm)
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('sort-changed')).not.toBeDefined()
-    $rows = wrapper.findAll('tbody > tr').wrappers
+    let $rows = wrapper.findAll('tbody > tr').wrappers
     expect($rows.length).toBe(3)
     // Map the rows to the first column text value
-    columnA = $rows.map(row => {
+    let columnA = $rows.map(row => {
       return row
         .findAll('td')
         .at(0)
@@ -593,17 +601,17 @@ describe('table > sorting', () => {
         sortDirection: 'desc'
       }
     })
+
+    await waitNT(wrapper.vm)
+
     expect(wrapper).toBeDefined()
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(3)
-    let $rows
-    let columnA
 
-    await waitNT(wrapper.vm)
-    $rows = wrapper.findAll('tbody > tr').wrappers
+    let $rows = wrapper.findAll('tbody > tr').wrappers
     expect($rows.length).toBe(3)
     // Map the rows to the first column text value
-    columnA = $rows.map(row => {
+    let columnA = $rows.map(row => {
       return row
         .findAll('td')
         .at(0)
@@ -707,20 +715,20 @@ describe('table > sorting', () => {
         noSortReset: true
       }
     })
+
+    await waitNT(wrapper.vm)
+
     expect(wrapper).toBeDefined()
     expect(wrapper.findAll('tbody > tr').exists()).toBe(true)
     expect(wrapper.findAll('tbody > tr').length).toBe(3)
-    let $rows
-    let columnA
 
     // Should not be sorted
-    await waitNT(wrapper.vm)
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('sort-changed')).not.toBeDefined()
-    $rows = wrapper.findAll('tbody > tr').wrappers
+    let $rows = wrapper.findAll('tbody > tr').wrappers
     expect($rows.length).toBe(3)
     // Map the rows to the first column text value
-    columnA = $rows.map(row => {
+    let columnA = $rows.map(row => {
       return row
         .findAll('td')
         .at(0)
@@ -794,6 +802,7 @@ describe('table > sorting', () => {
     })
 
     expect(wrapper).toBeDefined()
+
     let $trs = wrapper.findAll('tbody > tr')
     expect($trs.length).toBe(2)
 


### PR DESCRIPTION
### Describe the PR

This PR ensures that only sortable fields have a `tabindex="0"`.

Closes #6097.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [ ] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc.). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates
- [ ] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (required for new features and enhancements)
- [ ] Existing test suites are passing
- [ ] CodeCov for patch has met target (all changes/updates have been tested)
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
