### PR TITLE
fix(b-form-datepicker/b-form-timepicker): label styles when in `button-only` mode (closes #6172)

### DIFF
--- a/src/components/form-btn-label-control/bv-form-btn-label-control.js
+++ b/src/components/form-btn-label-control/bv-form-btn-label-control.js
@@ -215,6 +215,7 @@ export const BVFormBtnLabelControl = /*#__PURE__*/ Vue.extend({
               'text-break',
               'text-wrap',
               'bg-transparent',
+              // Mute the text if showing the placeholder
               { 'text-muted': !value },
               this.stateClass,
               this.sizeFormClass

--- a/src/components/form-btn-label-control/bv-form-btn-label-control.js
+++ b/src/components/form-btn-label-control/bv-form-btn-label-control.js
@@ -209,7 +209,7 @@ export const BVFormBtnLabelControl = /*#__PURE__*/ Vue.extend({
       'label',
       {
         class: buttonOnly
-          ? 'sr-only'
+          ? 'sr-only' // Hidden in button only mode
           : [
               'form-control',
               'text-break',

--- a/src/components/form-btn-label-control/bv-form-btn-label-control.js
+++ b/src/components/form-btn-label-control/bv-form-btn-label-control.js
@@ -208,17 +208,17 @@ export const BVFormBtnLabelControl = /*#__PURE__*/ Vue.extend({
     const $label = h(
       'label',
       {
-        staticClass: 'form-control text-break text-wrap bg-transparent h-auto',
-        class: [
-          {
-            // Hidden in button only mode
-            'sr-only': buttonOnly,
-            // Mute the text if showing the placeholder
-            'text-muted': !value
-          },
-          this.stateClass,
-          this.sizeFormClass
-        ],
+        class: buttonOnly
+          ? 'sr-only'
+          : [
+              'form-control',
+              'text-break',
+              'text-wrap',
+              'bg-transparent',
+              { 'text-muted': !value },
+              this.stateClass,
+              this.sizeFormClass
+            ],
         attrs: {
           id: idLabel,
           for: idButton,

--- a/src/components/form-datepicker/form-datepicker.js
+++ b/src/components/form-datepicker/form-datepicker.js
@@ -53,9 +53,6 @@ export const props = makePropsConfigurable(
     ...modelProps,
     ...calendarProps,
     ...formBtnLabelControlProps,
-    buttonOnly: makeProp(PROP_TYPE_BOOLEAN, false),
-    // Applicable in button only mode
-    buttonVariant: makeProp(PROP_TYPE_STRING, 'secondary'),
     // Width of the calendar dropdown
     calendarWidth: makeProp(PROP_TYPE_STRING, '270px'),
     closeButton: makeProp(PROP_TYPE_BOOLEAN, false),

--- a/src/components/form-datepicker/form-datepicker.spec.js
+++ b/src/components/form-datepicker/form-datepicker.spec.js
@@ -1,7 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { createContainer, waitNT, waitRAF } from '../../../tests/utils'
 import { BFormDatepicker } from './form-datepicker'
-// import { formatYMD } from '../../utils/date'
 
 // Note that JSDOM only supports `en-US` (`en`) locale for `Intl`
 
@@ -37,10 +36,10 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
     expect(wrapper.classes()).toContain('b-form-datepicker')
     expect(wrapper.classes()).toContain('b-form-btn-label-control')
     expect(wrapper.classes()).toContain('form-control')
@@ -49,22 +48,24 @@ describe('form-date', () => {
     expect(wrapper.classes()).not.toContain('btn-group')
     expect(wrapper.attributes('role')).toEqual('group')
 
-    expect(wrapper.find('.dropdown-menu').exists()).toBe(true)
-    expect(wrapper.find('.dropdown-menu').classes()).not.toContain('show')
-    expect(wrapper.find('.dropdown-menu').attributes('role')).toEqual('dialog')
-    expect(wrapper.find('.dropdown-menu').attributes('aria-modal')).toEqual('false')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
+    expect($dropdownMenu.attributes('role')).toEqual('dialog')
+    expect($dropdownMenu.attributes('aria-modal')).toEqual('false')
 
-    expect(wrapper.find('label.form-control').exists()).toBe(true)
-    expect(wrapper.find('label.form-control').attributes('for')).toEqual('test-base')
-    expect(wrapper.find('label.form-control').classes()).not.toContain('sr-only')
+    const $label = wrapper.find('label.form-control')
+    expect($label.exists()).toBe(true)
+    expect($label.attributes('for')).toEqual('test-base')
+    expect($label.classes()).not.toContain('sr-only')
 
     expect(wrapper.find('input[type="hidden"]').exists()).toBe(false)
 
-    const $btn = wrapper.find('button#test-base')
-    expect($btn.exists()).toBe(true)
-    expect($btn.attributes('aria-haspopup')).toEqual('dialog')
-    expect($btn.attributes('aria-expanded')).toEqual('false')
-    expect($btn.find('svg.bi-calendar').exists()).toBe(true)
+    const $button = wrapper.find('button#test-base')
+    expect($button.exists()).toBe(true)
+    expect($button.attributes('aria-haspopup')).toEqual('dialog')
+    expect($button.attributes('aria-expanded')).toEqual('false')
+    expect($button.find('svg.bi-calendar').exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -79,10 +80,10 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
     expect(wrapper.classes()).toContain('b-form-datepicker')
     expect(wrapper.classes()).toContain('b-form-btn-label-control')
     expect(wrapper.classes()).not.toContain('form-control')
@@ -91,22 +92,25 @@ describe('form-date', () => {
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.attributes('role')).not.toEqual('group')
 
-    expect(wrapper.find('.dropdown-menu').exists()).toBe(true)
-    expect(wrapper.find('.dropdown-menu').classes()).not.toContain('show')
-    expect(wrapper.find('.dropdown-menu').attributes('role')).toEqual('dialog')
-    expect(wrapper.find('.dropdown-menu').attributes('aria-modal')).toEqual('false')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
+    expect($dropdownMenu.attributes('role')).toEqual('dialog')
+    expect($dropdownMenu.attributes('aria-modal')).toEqual('false')
 
-    expect(wrapper.find('label.form-control').exists()).toBe(true)
-    expect(wrapper.find('label.form-control').attributes('for')).toEqual('test-button-only')
-    expect(wrapper.find('label.form-control').classes()).toContain('sr-only')
+    const $label = wrapper.find('label')
+    expect($label.exists()).toBe(true)
+    expect($label.attributes('for')).toEqual('test-button-only')
+    expect($label.classes().length).toBe(1)
+    expect($label.classes()).toContain('sr-only')
 
     expect(wrapper.find('input[type="hidden"]').exists()).toBe(false)
 
-    const $btn = wrapper.find('button#test-button-only')
-    expect($btn.exists()).toBe(true)
-    expect($btn.attributes('aria-haspopup')).toEqual('dialog')
-    expect($btn.attributes('aria-expanded')).toEqual('false')
-    expect($btn.find('svg.bi-calendar').exists()).toBe(true)
+    const $button = wrapper.find('button#test-button-only')
+    expect($button.exists()).toBe(true)
+    expect($button.attributes('aria-haspopup')).toEqual('dialog')
+    expect($button.attributes('aria-expanded')).toEqual('false')
+    expect($button.find('svg.bi-calendar').exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -121,12 +125,14 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    expect(wrapper.find('label.form-control').exists()).toBe(true)
-    expect(wrapper.find('label.form-control').text()).toContain('FOOBAR')
+    expect(wrapper.element.tagName).toBe('DIV')
+
+    const $label = wrapper.find('label.form-control')
+    expect($label.exists()).toBe(true)
+    expect($label.text()).toContain('FOOBAR')
 
     wrapper.destroy()
   })
@@ -141,46 +147,24 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+
     expect(wrapper.element.tagName).toBe('DIV')
+
+    let $input = wrapper.find('input[type="hidden"]')
+    expect($input.exists()).toBe(true)
+    expect($input.attributes('name')).toBe('foobar')
+    expect($input.attributes('value')).toBe('')
+
+    await wrapper.setProps({ value: '2020-01-20' })
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    expect(wrapper.find('input[type="hidden"]').exists()).toBe(true)
-    expect(wrapper.find('input[type="hidden"]').attributes('name')).toBe('foobar')
-    expect(wrapper.find('input[type="hidden"]').attributes('value')).toBe('')
-
-    await wrapper.setProps({
-      value: '2020-01-20'
-    })
-    await waitNT(wrapper.vm)
-    await waitRAF()
-
-    expect(wrapper.find('input[type="hidden"]').exists()).toBe(true)
-    expect(wrapper.find('input[type="hidden"]').attributes('name')).toBe('foobar')
-    expect(wrapper.find('input[type="hidden"]').attributes('value')).toBe('2020-01-20')
-
-    wrapper.destroy()
-  })
-
-  it('reacts to changes in value', async () => {
-    const wrapper = mount(BFormDatepicker, {
-      attachTo: createContainer(),
-      propsData: {
-        value: ''
-      }
-    })
-
-    expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
-    await waitNT(wrapper.vm)
-    await waitRAF()
-
-    await wrapper.setProps({
-      value: '2020-01-20'
-    })
-
-    await waitNT(wrapper.vm)
-    await waitRAF()
+    $input = wrapper.find('input[type="hidden"]')
+    expect($input.exists()).toBe(true)
+    expect($input.attributes('name')).toBe('foobar')
+    expect($input.attributes('value')).toBe('2020-01-20')
 
     wrapper.destroy()
   })
@@ -195,15 +179,14 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    const $toggle = wrapper.find('button#test-focus-blur')
+    expect(wrapper.element.tagName).toBe('DIV')
 
+    const $toggle = wrapper.find('button#test-focus-blur')
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
-
     expect(document.activeElement).not.toBe($toggle.element)
 
     wrapper.vm.focus()
@@ -231,9 +214,10 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
+
+    expect(wrapper.element.tagName).toBe('DIV')
 
     const $toggle = wrapper.find('button#test-hover')
     const $label = wrapper.find('button#test-hover ~ label')
@@ -272,29 +256,28 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    const $toggle = wrapper.find('button#test-open')
+    expect(wrapper.element.tagName).toBe('DIV')
 
+    const $toggle = wrapper.find('button#test-open')
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
 
-    const $menu = wrapper.find('.dropdown-menu')
-
-    expect($menu.exists()).toBe(true)
-    expect($menu.classes()).not.toContain('show')
-
-    await $toggle.trigger('click')
-    await waitRAF()
-    await waitRAF()
-    expect($menu.classes()).toContain('show')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
 
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
+
+    await $toggle.trigger('click')
+    await waitRAF()
+    await waitRAF()
+    expect($dropdownMenu.classes()).not.toContain('show')
 
     wrapper.destroy()
   })
@@ -309,25 +292,25 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
     expect(wrapper.emitted('input')).toBeUndefined()
 
     const $toggle = wrapper.find('button#test-emit-input')
-    const $menu = wrapper.find('.dropdown-menu')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
 
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
-    expect($menu.exists()).toBe(true)
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect(wrapper.find('.b-calendar').exists()).toBe(false)
 
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
     expect(wrapper.find('.b-calendar').exists()).toBe(true)
 
     expect(wrapper.emitted('context')).toBeDefined()
@@ -347,7 +330,7 @@ describe('form-date', () => {
     await $grid.trigger('keydown.enter')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input').length).toBe(1)
     expect(wrapper.emitted('input')[0][0]).toBe(activeYMD)
@@ -366,23 +349,24 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
+
     const $toggle = wrapper.find('button#test-no-close')
-    const $menu = wrapper.find('.dropdown-menu')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
 
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
-    expect($menu.exists()).toBe(true)
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect(wrapper.find('.b-calendar').exists()).toBe(false)
 
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
     expect(wrapper.find('.b-calendar').exists()).toBe(true)
 
     expect(wrapper.emitted('context')).toBeDefined()
@@ -404,7 +388,7 @@ describe('form-date', () => {
     await waitRAF()
 
     // Calendar should remain open
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
 
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input').length).toBe(1)
@@ -428,25 +412,26 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
+
     const $toggle = wrapper.find('button#test-footer')
-    const $menu = wrapper.find('.dropdown-menu')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
 
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
-    expect($menu.exists()).toBe(true)
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect(wrapper.find('.b-calendar').exists()).toBe(false)
 
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
 
     const $value = wrapper.find('input[type="hidden"]')
     expect($value.exists()).toBe(true)
@@ -456,19 +441,18 @@ describe('form-date', () => {
     const $footer = wrapper.find('.b-form-date-controls')
     expect($footer.exists()).toBe(true)
 
-    const $btns = $footer.findAll('button')
+    const $buttons = $footer.findAll('button')
+    expect($buttons.length).toBe(3)
 
-    expect($btns.length).toBe(3)
-
-    const $today = $btns.at(0)
-    const $reset = $btns.at(1)
-    const $close = $btns.at(2)
+    const $today = $buttons.at(0)
+    const $reset = $buttons.at(1)
+    const $close = $buttons.at(2)
 
     await $today.trigger('click')
     await waitRAF()
     await waitRAF()
 
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
     expect($value.attributes('value')).not.toBe('1900-01-01')
     expect($value.attributes('value')).not.toBe('')
     expect(/^\d+-\d\d-\d\d$/.test($value.attributes('value'))).toBe(true)
@@ -477,14 +461,14 @@ describe('form-date', () => {
     await waitRAF()
     await waitRAF()
 
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
     expect($value.attributes('value')).toBe('')
 
     await $close.trigger('click')
     await waitRAF()
     await waitRAF()
 
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect($value.attributes('value')).toBe('')
 
     wrapper.destroy()
@@ -503,26 +487,27 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
+
     const $toggle = wrapper.find('button#test-reset')
-    const $menu = wrapper.find('.dropdown-menu')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
 
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
-    expect($menu.exists()).toBe(true)
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect(wrapper.find('.b-calendar').exists()).toBe(false)
 
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
 
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
 
     const $value = wrapper.find('input[type="hidden"]')
     expect($value.exists()).toBe(true)
@@ -532,17 +517,16 @@ describe('form-date', () => {
     const $footer = wrapper.find('.b-form-date-controls')
     expect($footer.exists()).toBe(true)
 
-    const $btns = $footer.findAll('button')
+    const $buttons = $footer.findAll('button')
+    expect($buttons.length).toBe(1)
 
-    expect($btns.length).toBe(1)
-
-    const $reset = $btns.at(0)
+    const $reset = $buttons.at(0)
 
     await $reset.trigger('click')
     await waitRAF()
     await waitRAF()
 
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect($value.attributes('value')).toBe('1900-01-01')
 
     wrapper.destroy()
@@ -561,11 +545,12 @@ describe('form-date', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+
     expect(wrapper.element.tagName).toBe('DIV')
-    await waitNT(wrapper.vm)
-    await waitRAF()
-    await waitNT(wrapper.vm)
-    await waitRAF()
 
     const $toggle = wrapper.find('button#test-button-slot')
 

--- a/src/components/form-timepicker/form-timepicker.js
+++ b/src/components/form-timepicker/form-timepicker.js
@@ -47,9 +47,6 @@ export const props = makePropsConfigurable(
     ...modelProps,
     ...timeProps,
     ...formBtnLabelControlProps,
-    buttonOnly: makeProp(PROP_TYPE_BOOLEAN, false),
-    // Applicable in button only mode
-    buttonVariant: makeProp(PROP_TYPE_STRING, 'secondary'),
     closeButtonVariant: makeProp(PROP_TYPE_STRING, 'outline-secondary'),
     labelCloseButton: makeProp(PROP_TYPE_STRING, 'Close'),
     labelNowButton: makeProp(PROP_TYPE_STRING, 'Select now'),

--- a/src/components/form-timepicker/form-timepicker.spec.js
+++ b/src/components/form-timepicker/form-timepicker.spec.js
@@ -36,10 +36,10 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
     expect(wrapper.classes()).toContain('b-form-timepicker')
     expect(wrapper.classes()).toContain('b-form-btn-label-control')
     expect(wrapper.classes()).toContain('form-control')
@@ -48,22 +48,24 @@ describe('form-timepicker', () => {
     expect(wrapper.classes()).not.toContain('btn-group')
     expect(wrapper.attributes('role')).toEqual('group')
 
-    expect(wrapper.find('.dropdown-menu').exists()).toBe(true)
-    expect(wrapper.find('.dropdown-menu').classes()).not.toContain('show')
-    expect(wrapper.find('.dropdown-menu').attributes('role')).toEqual('dialog')
-    expect(wrapper.find('.dropdown-menu').attributes('aria-modal')).toEqual('false')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
+    expect($dropdownMenu.attributes('role')).toEqual('dialog')
+    expect($dropdownMenu.attributes('aria-modal')).toEqual('false')
 
-    expect(wrapper.find('label.form-control').exists()).toBe(true)
-    expect(wrapper.find('label.form-control').attributes('for')).toEqual('test-base')
-    expect(wrapper.find('label.form-control').text()).toContain('No time selected')
+    const $label = wrapper.find('label.form-control')
+    expect($label.exists()).toBe(true)
+    expect($label.attributes('for')).toEqual('test-base')
+    expect($label.text()).toContain('No time selected')
 
     expect(wrapper.find('input[type="hidden"]').exists()).toBe(false)
 
-    const $btn = wrapper.find('button#test-base')
-    expect($btn.exists()).toBe(true)
-    expect($btn.attributes('aria-haspopup')).toEqual('dialog')
-    expect($btn.attributes('aria-expanded')).toEqual('false')
-    expect($btn.find('svg.bi-clock').exists()).toBe(true)
+    const $button = wrapper.find('button#test-base')
+    expect($button.exists()).toBe(true)
+    expect($button.attributes('aria-haspopup')).toEqual('dialog')
+    expect($button.attributes('aria-expanded')).toEqual('false')
+    expect($button.find('svg.bi-clock').exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -78,10 +80,10 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
     expect(wrapper.classes()).toContain('b-form-timepicker')
     expect(wrapper.classes()).toContain('b-form-btn-label-control')
     expect(wrapper.classes()).not.toContain('form-control')
@@ -90,23 +92,26 @@ describe('form-timepicker', () => {
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.attributes('role')).not.toEqual('group')
 
-    expect(wrapper.find('.dropdown-menu').exists()).toBe(true)
-    expect(wrapper.find('.dropdown-menu').classes()).not.toContain('show')
-    expect(wrapper.find('.dropdown-menu').attributes('role')).toEqual('dialog')
-    expect(wrapper.find('.dropdown-menu').attributes('aria-modal')).toEqual('false')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
+    expect($dropdownMenu.attributes('role')).toEqual('dialog')
+    expect($dropdownMenu.attributes('aria-modal')).toEqual('false')
 
-    expect(wrapper.find('label.form-control').exists()).toBe(true)
-    expect(wrapper.find('label.form-control').attributes('for')).toEqual('test-button-only')
-    expect(wrapper.find('label.form-control').text()).toContain('No time selected')
-    expect(wrapper.find('label.form-control').classes()).toContain('sr-only')
+    const $label = wrapper.find('label')
+    expect($label.exists()).toBe(true)
+    expect($label.attributes('for')).toEqual('test-button-only')
+    expect($label.text()).toContain('No time selected')
+    expect($label.classes().length).toBe(1)
+    expect($label.classes()).toContain('sr-only')
 
     expect(wrapper.find('input[type="hidden"]').exists()).toBe(false)
 
-    const $btn = wrapper.find('button#test-button-only')
-    expect($btn.exists()).toBe(true)
-    expect($btn.attributes('aria-haspopup')).toEqual('dialog')
-    expect($btn.attributes('aria-expanded')).toEqual('false')
-    expect($btn.find('svg.bi-clock').exists()).toBe(true)
+    const $button = wrapper.find('button#test-button-only')
+    expect($button.exists()).toBe(true)
+    expect($button.attributes('aria-haspopup')).toEqual('dialog')
+    expect($button.attributes('aria-expanded')).toEqual('false')
+    expect($button.find('svg.bi-clock').exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -122,23 +127,24 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+
     expect(wrapper.element.tagName).toBe('DIV')
+
+    let $input = wrapper.find('input[type="hidden"]')
+    expect($input.exists()).toBe(true)
+    expect($input.attributes('name')).toBe('foobar')
+    expect($input.attributes('value')).toBe('')
+
+    await wrapper.setProps({ value: '01:02:03' })
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    expect(wrapper.find('input[type="hidden"]').exists()).toBe(true)
-    expect(wrapper.find('input[type="hidden"]').attributes('name')).toBe('foobar')
-    expect(wrapper.find('input[type="hidden"]').attributes('value')).toBe('')
-
-    await wrapper.setProps({
-      value: '01:02:03'
-    })
-    await waitNT(wrapper.vm)
-    await waitRAF()
-
-    expect(wrapper.find('input[type="hidden"]').exists()).toBe(true)
-    expect(wrapper.find('input[type="hidden"]').attributes('name')).toBe('foobar')
-    expect(wrapper.find('input[type="hidden"]').attributes('value')).toBe('01:02:00')
+    $input = wrapper.find('input[type="hidden"]')
+    expect($input.exists()).toBe(true)
+    expect($input.attributes('name')).toBe('foobar')
+    expect($input.attributes('value')).toBe('01:02:00')
 
     await wrapper.setProps({
       showSeconds: true,
@@ -147,9 +153,10 @@ describe('form-timepicker', () => {
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    expect(wrapper.find('input[type="hidden"]').exists()).toBe(true)
-    expect(wrapper.find('input[type="hidden"]').attributes('name')).toBe('foobar')
-    expect(wrapper.find('input[type="hidden"]').attributes('value')).toBe('01:02:33')
+    $input = wrapper.find('input[type="hidden"]')
+    expect($input.exists()).toBe(true)
+    expect($input.attributes('name')).toBe('foobar')
+    expect($input.attributes('value')).toBe('01:02:33')
 
     wrapper.destroy()
   })
@@ -164,33 +171,32 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+
     expect(wrapper.element.tagName).toBe('DIV')
+
+    let $label = wrapper.find('label.form-control')
+    expect($label.exists()).toBe(true)
+    expect($label.text()).toContain('No time selected')
+
+    await wrapper.setProps({ placeholder: 'foobar' })
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    expect(wrapper.find('label.form-control').exists()).toBe(true)
-    expect(wrapper.find('label.form-control').text()).toContain('No time selected')
+    $label = wrapper.find('label.form-control')
+    expect($label.exists()).toBe(true)
+    expect($label.text()).not.toContain('No time selected')
+    expect($label.text()).toContain('foobar')
 
-    await wrapper.setProps({
-      placeholder: 'foobar'
-    })
+    await wrapper.setProps({ value: '01:02:03' })
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    expect(wrapper.find('label.form-control').exists()).toBe(true)
-    expect(wrapper.find('label.form-control').text()).not.toContain('No time selected')
-    expect(wrapper.find('label.form-control').text()).toContain('foobar')
-
-    await wrapper.setProps({
-      value: '01:02:03'
-    })
-
-    await waitNT(wrapper.vm)
-    await waitRAF()
-
-    expect(wrapper.find('label.form-control').exists()).toBe(true)
-    expect(wrapper.find('label.form-control').text()).not.toContain('No time selected')
-    expect(wrapper.find('label.form-control').text()).not.toContain('foobar')
+    $label = wrapper.find('label.form-control')
+    expect($label.exists()).toBe(true)
+    expect($label.text()).not.toContain('No time selected')
+    expect($label.text()).not.toContain('foobar')
 
     wrapper.destroy()
   })
@@ -205,15 +211,14 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    const $toggle = wrapper.find('button#test-focus-blur')
+    expect(wrapper.element.tagName).toBe('DIV')
 
+    const $toggle = wrapper.find('button#test-focus-blur')
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
-
     expect(document.activeElement).not.toBe($toggle.element)
 
     wrapper.vm.focus()
@@ -241,9 +246,10 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
+
+    expect(wrapper.element.tagName).toBe('DIV')
 
     const $toggle = wrapper.find('button#test-hover')
     const $label = wrapper.find('button#test-hover ~ label')
@@ -282,29 +288,28 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
 
-    const $toggle = wrapper.find('button#test-open')
+    expect(wrapper.element.tagName).toBe('DIV')
 
+    const $toggle = wrapper.find('button#test-open')
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
 
-    const $menu = wrapper.find('.dropdown-menu')
-
-    expect($menu.exists()).toBe(true)
-    expect($menu.classes()).not.toContain('show')
-
-    await $toggle.trigger('click')
-    await waitRAF()
-    await waitRAF()
-    expect($menu.classes()).toContain('show')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
 
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
+
+    await $toggle.trigger('click')
+    await waitRAF()
+    await waitRAF()
+    expect($dropdownMenu.classes()).not.toContain('show')
 
     wrapper.destroy()
   })
@@ -325,25 +330,26 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.element.tagName).toBe('DIV')
     await waitNT(wrapper.vm)
     await waitRAF()
     await waitNT(wrapper.vm)
     await waitRAF()
 
+    expect(wrapper.element.tagName).toBe('DIV')
+
     const $toggle = wrapper.find('button#test-footer')
-    const $menu = wrapper.find('.dropdown-menu')
+    const $dropdownMenu = wrapper.find('.dropdown-menu')
 
     expect($toggle.exists()).toBe(true)
     expect($toggle.element.tagName).toBe('BUTTON')
-    expect($menu.exists()).toBe(true)
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.exists()).toBe(true)
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect(wrapper.find('.b-calendar').exists()).toBe(false)
 
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
 
     const $value = wrapper.find('input[type="hidden"]')
     expect($value.exists()).toBe(true)
@@ -353,16 +359,16 @@ describe('form-timepicker', () => {
     const $footer = wrapper.find('.b-time > footer')
     expect($footer.exists()).toBe(true)
 
-    let $btns = $footer.findAll('button')
+    let $buttons = $footer.findAll('button')
 
-    expect($btns.length).toBe(3)
+    expect($buttons.length).toBe(3)
 
-    const $now = $btns.at(0)
+    const $now = $buttons.at(0)
 
     await $now.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect($value.attributes('value')).not.toBe('')
     expect(/^\d\d:\d\d:\d\d$/.test($value.attributes('value'))).toBe(true)
 
@@ -370,34 +376,34 @@ describe('form-timepicker', () => {
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
     expect($value.attributes('value')).not.toBe('')
 
-    $btns = wrapper.findAll('.b-time > footer button')
-    expect($btns.length).toBe(3)
-    const $reset = $btns.at(1)
+    $buttons = wrapper.findAll('.b-time > footer button')
+    expect($buttons.length).toBe(3)
+    const $reset = $buttons.at(1)
 
     await $reset.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect($value.attributes('value')).toBe('')
 
     // Open the popup again
     await $toggle.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).toContain('show')
+    expect($dropdownMenu.classes()).toContain('show')
     expect($value.attributes('value')).toBe('')
 
-    $btns = wrapper.findAll('.b-time > footer button')
-    expect($btns.length).toBe(3)
-    const $close = $btns.at(2)
+    $buttons = wrapper.findAll('.b-time > footer button')
+    expect($buttons.length).toBe(3)
+    const $close = $buttons.at(2)
 
     await $close.trigger('click')
     await waitRAF()
     await waitRAF()
-    expect($menu.classes()).not.toContain('show')
+    expect($dropdownMenu.classes()).not.toContain('show')
     expect($value.attributes('value')).toBe('')
 
     wrapper.destroy()
@@ -417,11 +423,12 @@ describe('form-timepicker', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+    await waitNT(wrapper.vm)
+    await waitRAF()
+
     expect(wrapper.element.tagName).toBe('DIV')
-    await waitNT(wrapper.vm)
-    await waitRAF()
-    await waitNT(wrapper.vm)
-    await waitRAF()
 
     const $toggle = wrapper.find('button#test-button-slot')
 


### PR DESCRIPTION
### Describe the PR

This PR ensures only the `sr-only` class is applied to the `label` when `<b-form-datepicker>` / `<b-form-timepicker>` are in `button-only` mode.

Closes #6172.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [ ] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc.). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates
- [ ] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (required for new features and enhancements)
- [ ] Existing test suites are passing
- [ ] CodeCov for patch has met target (all changes/updates have been tested)
- [ ] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
