### PR TITLE
feat(b-dropdown): add `toggle-attrs` prop (closes #3694)

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -3,6 +3,7 @@ import { NAME_DROPDOWN } from '../../constants/components'
 import {
   PROP_TYPE_ARRAY_OBJECT_STRING,
   PROP_TYPE_BOOLEAN,
+  PROP_TYPE_OBJECT,
   PROP_TYPE_OBJECT_STRING,
   PROP_TYPE_STRING
 } from '../../constants/props'
@@ -42,6 +43,7 @@ export const props = makePropsConfigurable(
     text: makeProp(PROP_TYPE_STRING),
     toggleClass: makeProp(PROP_TYPE_ARRAY_OBJECT_STRING),
     toggleTag: makeProp(PROP_TYPE_STRING, 'button'),
+    toggleAttrs: makeProp(PROP_TYPE_OBJECT, {}),
     // TODO: This really should be `toggleLabel`
     toggleText: makeProp(PROP_TYPE_STRING, 'Toggle dropdown'),
     variant: makeProp(PROP_TYPE_STRING, 'secondary')
@@ -145,6 +147,9 @@ export const BDropdown = /*#__PURE__*/ Vue.extend({
         staticClass: 'dropdown-toggle',
         class: this.toggleClasses,
         attrs: {
+          // Merge in user supplied attributes
+          ...this.toggleAttrs,
+          // Must have attributes
           id: this.safeId('_BV_toggle_'),
           'aria-haspopup': 'true',
           'aria-expanded': toString(visible)

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -41,9 +41,9 @@ export const props = makePropsConfigurable(
     splitTo: makeProp(PROP_TYPE_OBJECT_STRING),
     splitVariant: makeProp(PROP_TYPE_STRING),
     text: makeProp(PROP_TYPE_STRING),
+    toggleAttrs: makeProp(PROP_TYPE_OBJECT, {}),
     toggleClass: makeProp(PROP_TYPE_ARRAY_OBJECT_STRING),
     toggleTag: makeProp(PROP_TYPE_STRING, 'button'),
-    toggleAttrs: makeProp(PROP_TYPE_OBJECT, {}),
     // TODO: This really should be `toggleLabel`
     toggleText: makeProp(PROP_TYPE_STRING, 'Toggle dropdown'),
     variant: makeProp(PROP_TYPE_STRING, 'secondary')

--- a/src/components/dropdown/dropdown.spec.js
+++ b/src/components/dropdown/dropdown.spec.js
@@ -300,7 +300,9 @@ describe('dropdown', () => {
         block: true
       }
     })
+
     expect(wrapper.classes()).not.toContain('btn-group')
+
     wrapper.destroy()
   })
 
@@ -312,8 +314,10 @@ describe('dropdown', () => {
         split: true
       }
     })
+
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('d-flex')
+
     wrapper.destroy()
   })
 
@@ -324,7 +328,9 @@ describe('dropdown', () => {
         noCaret: true
       }
     })
+
     expect(wrapper.find('.dropdown-toggle').classes()).toContain('dropdown-toggle-no-caret')
+
     wrapper.destroy()
   })
 
@@ -336,7 +342,9 @@ describe('dropdown', () => {
         split: true
       }
     })
+
     expect(wrapper.find('.dropdown-toggle').classes()).not.toContain('dropdown-toggle-no-caret')
+
     wrapper.destroy()
   })
 
@@ -347,18 +355,22 @@ describe('dropdown', () => {
         toggleTag: 'div'
       }
     })
+
     expect(wrapper.find('.dropdown-toggle').element.tagName).toBe('DIV')
+
     wrapper.destroy()
   })
 
-  it('should have attrs on toggle when toggle-attrs is set', async () => {
+  it('should have attributes on toggle when "toggle-attrs" prop is set', async () => {
     const wrapper = mount(BDropdown, {
       attachTo: createContainer(),
       propsData: {
         toggleAttrs: { 'data-foo-bar': 'foo-bar' }
       }
     })
+
     expect(wrapper.find('.dropdown-toggle').attributes('data-foo-bar')).toBe('foo-bar')
+
     wrapper.destroy()
   })
 
@@ -369,17 +381,21 @@ describe('dropdown', () => {
         dropup: true
       }
     })
+
     expect(wrapper.classes()).toContain('dropdown')
     expect(wrapper.classes()).toContain('dropup')
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.find('.dropdown-menu').classes()).not.toContain('show')
+
     wrapper.vm.show()
     await waitNT(wrapper.vm)
     await waitRAF()
+
     expect(wrapper.classes()).toContain('dropdown')
     expect(wrapper.classes()).toContain('dropup')
     expect(wrapper.classes()).toContain('show')
     expect(wrapper.find('.dropdown-menu').classes()).toContain('show')
+
     wrapper.destroy()
   })
 
@@ -390,17 +406,21 @@ describe('dropdown', () => {
         dropright: true
       }
     })
+
     expect(wrapper.classes()).toContain('dropdown')
     expect(wrapper.classes()).toContain('dropright')
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.find('.dropdown-menu').classes()).not.toContain('show')
+
     wrapper.vm.show()
     await waitNT(wrapper.vm)
     await waitRAF()
+
     expect(wrapper.classes()).toContain('dropdown')
     expect(wrapper.classes()).toContain('dropright')
     expect(wrapper.classes()).toContain('show')
     expect(wrapper.find('.dropdown-menu').classes()).toContain('show')
+
     wrapper.destroy()
   })
 
@@ -411,17 +431,21 @@ describe('dropdown', () => {
         dropleft: true
       }
     })
+
     expect(wrapper.classes()).toContain('dropdown')
     expect(wrapper.classes()).toContain('dropleft')
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.find('.dropdown-menu').classes()).not.toContain('show')
+
     wrapper.vm.show()
     await waitNT(wrapper.vm)
     await waitRAF()
+
     expect(wrapper.classes()).toContain('dropdown')
     expect(wrapper.classes()).toContain('dropleft')
     expect(wrapper.classes()).toContain('show')
     expect(wrapper.find('.dropdown-menu').classes()).toContain('show')
+
     wrapper.destroy()
   })
 
@@ -434,10 +458,12 @@ describe('dropdown', () => {
         split: true
       }
     })
+
     const $buttons = wrapper.findAll('button')
     const $split = $buttons.at(0)
-
     expect($split.classes()).toContain(splitClass)
+
+    wrapper.destroy()
   })
 
   it('menu should have class dropdown-menu-right when prop right set', async () => {
@@ -447,17 +473,21 @@ describe('dropdown', () => {
         right: true
       }
     })
+
     expect(wrapper.classes()).toContain('dropdown')
     expect(wrapper.classes()).not.toContain('show')
     expect(wrapper.find('.dropdown-menu').classes()).toContain('dropdown-menu-right')
     expect(wrapper.find('.dropdown-menu').classes()).not.toContain('show')
+
     wrapper.vm.show()
     await waitNT(wrapper.vm)
     await waitRAF()
+
     expect(wrapper.classes()).toContain('dropdown')
     expect(wrapper.classes()).toContain('show')
     expect(wrapper.find('.dropdown-menu').classes()).toContain('dropdown-menu-right')
     expect(wrapper.find('.dropdown-menu').classes()).toContain('show')
+
     wrapper.destroy()
   })
 

--- a/src/components/dropdown/dropdown.spec.js
+++ b/src/components/dropdown/dropdown.spec.js
@@ -351,6 +351,17 @@ describe('dropdown', () => {
     wrapper.destroy()
   })
 
+  it('should have attrs on toggle when toggle-attrs is set', async () => {
+    const wrapper = mount(BDropdown, {
+      attachTo: createContainer(),
+      propsData: {
+        toggleAttrs: { 'data-foo-bar': 'foo-bar' }
+      }
+    })
+    expect(wrapper.find('.dropdown-toggle').attributes('data-foo-bar')).toBe('foo-bar')
+    wrapper.destroy()
+  })
+
   it('should have class dropup when prop dropup set', async () => {
     const wrapper = mount(BDropdown, {
       attachTo: createContainer(),

--- a/src/components/dropdown/package.json
+++ b/src/components/dropdown/package.json
@@ -99,6 +99,11 @@
             "description": "Text to place in the toggle button, or in the split button is split mode"
           },
           {
+            "prop": "toggleAttrs",
+            "version": "2.22.0",
+            "description": "Additional attributes to apply to the toggle button"
+          },
+          {
             "prop": "toggleClass",
             "description": "CSS class (or classes) to add to the toggle button"
           },


### PR DESCRIPTION
### Describe the PR

Add `toggle-attrs` prop to allow adding HTML attributes to the dropdown toggle. This feature has been talked about here: https://github.com/bootstrap-vue/bootstrap-vue/issues/3694

At GitLab we have a [component library](https://gitlab-org.gitlab.io/gitlab-ui/?path=/story/base-dropdown--default) built on top of Bootstrap Vue and would like this feature so that we can add the `data-qa-selector` attribute to the dropdown toggle. We use this attribute exclusively for QA E2E specs. I could also see it being helpful for adding the `data-testid` attribute which is supported by [Vue Testing Library](https://testing-library.com/docs/vue-testing-library/api#queries). This prop could also be used for other user-facing attributes such as `aria-*` attributes.

Closes #3694.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [x] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc.). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [x] Includes documentation updates
- [x] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [x] Includes any needed TypeScript declaration file updates
- [x] New/updated tests are included and passing (required for new features and enhancements)
- [x] Existing test suites are passing
- [x] CodeCov for patch has met target (all changes/updates have been tested)
- [x] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
  - I think it's convincing 🙂. This wasn't a hugely time consuming change so not a big deal if this feature doesn't get approved 