### PR TITLE
fix(b-table): set `aria-sort` when using `sortKey` and `no-local-sorting` (closes #6602)

### DIFF
--- a/src/components/table/helpers/mixin-sorting.js
+++ b/src/components/table/helpers/mixin-sorting.js
@@ -235,15 +235,18 @@ export const sortingMixin = Vue.extend({
       }
     },
     sortTheadThAttrs(key, field, isFoot) {
-      if (!this.isSortable || (isFoot && this.noFooterSorting)) {
+      const { isSortable, noFooterSorting, localSortDesc, localSortBy } = this
+      if (!isSortable || (isFoot && noFooterSorting)) {
         // No attributes if not a sortable table
         return {}
       }
       const sortable = field.sortable
+      const sortKey = field.sortKey ?? key
+
       // Assemble the aria-sort attribute value
       const ariaSort =
-        sortable && this.localSortBy === key
-          ? this.localSortDesc
+        sortable && localSortBy === sortKey
+          ? localSortDesc
             ? 'descending'
             : 'ascending'
           : sortable

--- a/src/components/table/helpers/mixin-sorting.js
+++ b/src/components/table/helpers/mixin-sorting.js
@@ -235,13 +235,14 @@ export const sortingMixin = Vue.extend({
       }
     },
     sortTheadThAttrs(key, field, isFoot) {
-      const { isSortable, noFooterSorting, localSortDesc, localSortBy } = this
+      const { isSortable, noFooterSorting, localSortDesc, localSortBy, localSorting } = this
       if (!isSortable || (isFoot && noFooterSorting)) {
         // No attributes if not a sortable table
         return {}
       }
+
       const sortable = field.sortable
-      const sortKey = field.sortKey ?? key
+      const sortKey = !localSorting ? field.sortKey ?? key : key
 
       // Assemble the aria-sort attribute value
       const ariaSort =

--- a/src/components/table/table-sorting.spec.js
+++ b/src/components/table/table-sorting.spec.js
@@ -63,6 +63,25 @@ describe('table > sorting', () => {
     expect(wrapper.emitted('sort-changed')[0][0].sortBy).toEqual('non-local')
   })
 
+  it('should set `aria-sort` when `field.sortKey` and `no-local-sorting` is used', async () => {
+    const wrapper = mount(BTable, {
+      propsData: {
+        fields: [...testFields, { key: 'd', label: 'D', sortable: true, sortKey: 'non-local' }],
+        items: testItems,
+        noLocalSorting: true
+      }
+    })
+
+    expect(wrapper).toBeDefined()
+    const $header = wrapper.findAll('thead > tr > th').at(3)
+
+    await $header.trigger('keydown.enter')
+    expect(wrapper.emitted('sort-changed').length).toBe(1)
+    expect(wrapper.emitted('sort-changed')[0][0].sortBy).toEqual('non-local')
+
+    expect($header.attributes('aria-sort')).toBe('ascending')
+  })
+
   it('should sort column descending when sortBy set and sortDesc changed, with proper attributes', async () => {
     const wrapper = mount(BTable, {
       propsData: {


### PR DESCRIPTION
### Describe the PR

Fixes an issue where `aria-sort` wasn't being correctly set on fields that used a `sortKey` and `no-local-sorting` was set on `<b-table>`.
It should now correctly set them when sorting that column.

Closes #6602.

Working example: https://codesandbox.io/s/bootstrapvue-starter-project-forked-3b7pt?file=/App.vue

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [ ] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [x] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc.). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates
- [ ] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [x] New/updated tests are included and passing (required for new features and enhancements)
- [x] Existing test suites are passing
- [ ] CodeCov for patch has met target (all changes/updates have been tested)
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)
