### PR TITLE
docs / intro: use bootstrap 4 for browser include

### DIFF
--- a/docs/markdown/intro/README.md
+++ b/docs/markdown/intro/README.md
@@ -712,7 +712,7 @@ JavaScript files.
 <!-- Add this to <head> -->
 
 <!-- Load required Bootstrap and BootstrapVue CSS -->
-<link type="text/css" rel="stylesheet" href="https://unpkg.com/bootstrap/dist/css/bootstrap.min.css" />
+<link type="text/css" rel="stylesheet" href="https://unpkg.com/bootstrap@4/dist/css/bootstrap.min.css" />
 <link type="text/css" rel="stylesheet" href="https://unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.css" />
 
 <!-- Load polyfills to support older browsers -->


### PR DESCRIPTION
`//unpkg.com/bootstrap/dist/css/bootstrap.min.css` is B5, some things breaks
