### PR TITLE
feat(compat): add Vue 3 support via @vue/compat (fixes #5196)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,20 @@
+const useVue2 = 'USE_VUE2' in process.env
+
+const moduleNameMapper = useVue2
+  ? {}
+  : {
+      '^vue$': '@vue/compat',
+      '^@vue/test-utils$': '@vue/test-utils-vue3'
+    }
+
 module.exports = {
   testRegex: 'spec.js$',
   moduleFileExtensions: ['js', 'vue'],
+  moduleNameMapper,
   transform: {
-    '^.+\\.js$': 'babel-jest',
-    '.*\\.(vue)$': 'vue-jest'
+    '^.+\\.js$': 'babel-jest'
   },
+  transformIgnorePatterns: ['/node_modules(?![\\\\/]vue-test-utils-compat[\\\\/])'],
   coverageDirectory: './coverage/',
   testEnvironmentOptions: {
     pretendToBeVisual: true

--- a/package.json
+++ b/package.json
@@ -99,7 +99,10 @@
     "@nuxtjs/robots": "^2.5.0",
     "@nuxtjs/sitemap": "^2.4.0",
     "@testing-library/jest-dom": "^5.12.0",
+    "@vue/compat": "^3.2.24",
+    "@vue/compiler-dom": "^3.2.24",
     "@vue/test-utils": "^1.3.0",
+    "@vue/test-utils-vue3": "npm:@vue/test-utils@^2.0.0",
     "autoprefixer": "^10.2.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
@@ -148,10 +151,10 @@
     "standard-version": "^9.3.0",
     "terser": "^5.7.0",
     "vue": "^2.6.12",
-    "vue-jest": "^3.0.7",
     "vue-router": "^3.5.1",
     "vue-server-renderer": "^2.6.12",
-    "vue-template-compiler": "^2.6.12"
+    "vue-template-compiler": "^2.6.12",
+    "vue-test-utils-compat": "0.0.3"
   },
   "keywords": [
     "Bootstrap",

--- a/src/components/alert/alert.js
+++ b/src/components/alert/alert.js
@@ -1,4 +1,4 @@
-import { COMPONENT_UID_KEY, Vue } from '../../vue'
+import { COMPONENT_UID_KEY, defineComponent } from '../../vue'
 import { NAME_ALERT } from '../../constants/components'
 import { EVENT_NAME_DISMISSED, EVENT_NAME_DISMISS_COUNT_DOWN } from '../../constants/events'
 import {
@@ -68,7 +68,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BAlert = /*#__PURE__*/ Vue.extend({
+export const BAlert = /*#__PURE__*/ defineComponent({
   name: NAME_ALERT,
   compatConfig: {
     MODE: 3,

--- a/src/components/alert/alert.js
+++ b/src/components/alert/alert.js
@@ -70,6 +70,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BAlert = /*#__PURE__*/ Vue.extend({
   name: NAME_ALERT,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [modelMixin, normalizeSlotMixin],
   props,
   data() {

--- a/src/components/aspect/aspect.js
+++ b/src/components/aspect/aspect.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_ASPECT } from '../../constants/components'
 import { PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { RX_ASPECT, RX_ASPECT_SEPARATOR } from '../../constants/regex'
@@ -26,7 +26,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BAspect = /*#__PURE__*/ Vue.extend({
+export const BAspect = /*#__PURE__*/ defineComponent({
   name: NAME_ASPECT,
   mixins: [normalizeSlotMixin],
   props,

--- a/src/components/avatar/avatar-group.js
+++ b/src/components/avatar/avatar-group.js
@@ -37,7 +37,7 @@ export const BAvatarGroup = /*#__PURE__*/ Vue.extend({
   name: NAME_AVATAR_GROUP,
   mixins: [normalizeSlotMixin],
   provide() {
-    return { bvAvatarGroup: this }
+    return { getBvAvatarGroup: () => this }
   },
   props,
   computed: {

--- a/src/components/avatar/avatar-group.js
+++ b/src/components/avatar/avatar-group.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_AVATAR_GROUP } from '../../constants/components'
 import {
   PROP_TYPE_BOOLEAN,
@@ -33,7 +33,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BAvatarGroup = /*#__PURE__*/ Vue.extend({
+export const BAvatarGroup = /*#__PURE__*/ defineComponent({
   name: NAME_AVATAR_GROUP,
   mixins: [normalizeSlotMixin],
   provide() {

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -71,7 +71,7 @@ export const BAvatar = /*#__PURE__*/ Vue.extend({
   name: NAME_AVATAR,
   mixins: [normalizeSlotMixin],
   inject: {
-    bvAvatarGroup: { default: null }
+    getBvAvatarGroup: { default: () => () => null }
   },
   props,
   data() {
@@ -80,6 +80,9 @@ export const BAvatar = /*#__PURE__*/ Vue.extend({
     }
   },
   computed: {
+    bvAvatarGroup() {
+      return this.getBvAvatarGroup()
+    },
     computedSize() {
       // Always use the avatar group size
       const { bvAvatarGroup } = this

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_AVATAR } from '../../constants/components'
 import { EVENT_NAME_CLICK, EVENT_NAME_IMG_ERROR } from '../../constants/events'
 import {
@@ -67,7 +67,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BAvatar = /*#__PURE__*/ Vue.extend({
+export const BAvatar = /*#__PURE__*/ defineComponent({
   name: NAME_AVATAR,
   mixins: [normalizeSlotMixin],
   inject: {

--- a/src/components/avatar/avatar.spec.js
+++ b/src/components/avatar/avatar.spec.js
@@ -250,7 +250,7 @@ describe('avatar', () => {
     const wrapper1 = mount(BAvatar, {
       provide: {
         // Emulate `undefined`/`null` props
-        bvAvatarGroup: {}
+        getBvAvatarGroup: () => ({})
       }
     })
 
@@ -265,9 +265,9 @@ describe('avatar', () => {
 
     const wrapper2 = mount(BAvatar, {
       provide: {
-        bvAvatarGroup: {
+        getBvAvatarGroup: () => ({
           variant: 'danger'
-        }
+        })
       }
     })
 
@@ -289,7 +289,7 @@ describe('avatar', () => {
       },
       provide: {
         // Emulate `undefined`/`null` props
-        bvAvatarGroup: {}
+        getBvAvatarGroup: () => ({})
       }
     })
 
@@ -307,9 +307,9 @@ describe('avatar', () => {
         size: '2em'
       },
       provide: {
-        bvAvatarGroup: {
+        getBvAvatarGroup: () => ({
           size: '5em'
-        }
+        })
       }
     })
 

--- a/src/components/badge/badge.js
+++ b/src/components/badge/badge.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_BADGE } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { omit, sortKeys } from '../../utils/object'
@@ -25,7 +25,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BBadge = /*#__PURE__*/ Vue.extend({
+export const BBadge = /*#__PURE__*/ defineComponent({
   name: NAME_BADGE,
   functional: true,
   props,

--- a/src/components/breadcrumb/breadcrumb-item.js
+++ b/src/components/breadcrumb/breadcrumb-item.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_BREADCRUMB_ITEM } from '../../constants/components'
 import { makePropsConfigurable } from '../../utils/props'
 import { BBreadcrumbLink, props as BBreadcrumbLinkProps } from './breadcrumb-link'
@@ -10,7 +10,7 @@ export const props = makePropsConfigurable(BBreadcrumbLinkProps, NAME_BREADCRUMB
 // --- Main component ---
 
 // @vue/component
-export const BBreadcrumbItem = /*#__PURE__*/ Vue.extend({
+export const BBreadcrumbItem = /*#__PURE__*/ defineComponent({
   name: NAME_BREADCRUMB_ITEM,
   functional: true,
   props,

--- a/src/components/breadcrumb/breadcrumb-link.js
+++ b/src/components/breadcrumb/breadcrumb-link.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_BREADCRUMB_LINK } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { htmlOrText } from '../../utils/html'
@@ -21,7 +21,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BBreadcrumbLink = /*#__PURE__*/ Vue.extend({
+export const BBreadcrumbLink = /*#__PURE__*/ defineComponent({
   name: NAME_BREADCRUMB_LINK,
   functional: true,
   props,

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_BREADCRUMB } from '../../constants/components'
 import { PROP_TYPE_ARRAY } from '../../constants/props'
 import { isArray, isObject } from '../../utils/inspect'
@@ -18,7 +18,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BBreadcrumb = /*#__PURE__*/ Vue.extend({
+export const BBreadcrumb = /*#__PURE__*/ defineComponent({
   name: NAME_BREADCRUMB,
   functional: true,
   props,

--- a/src/components/button-group/button-group.js
+++ b/src/components/button-group/button-group.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_BUTTON_GROUP } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { pick, sortKeys } from '../../utils/object'
@@ -21,7 +21,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BButtonGroup = /*#__PURE__*/ Vue.extend({
+export const BButtonGroup = /*#__PURE__*/ defineComponent({
   name: NAME_BUTTON_GROUP,
   functional: true,
   props,

--- a/src/components/button-toolbar/button-toolbar.js
+++ b/src/components/button-toolbar/button-toolbar.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_BUTTON_TOOLBAR } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN } from '../../constants/props'
 import { CODE_DOWN, CODE_LEFT, CODE_RIGHT, CODE_UP } from '../../constants/key-codes'
@@ -30,7 +30,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BButtonToolbar = /*#__PURE__*/ Vue.extend({
+export const BButtonToolbar = /*#__PURE__*/ defineComponent({
   name: NAME_BUTTON_TOOLBAR,
   mixins: [normalizeSlotMixin],
   props,

--- a/src/components/button-toolbar/button-toolbar.spec.js
+++ b/src/components/button-toolbar/button-toolbar.spec.js
@@ -82,6 +82,11 @@ describe('button-toolbar', () => {
 
     // Test App for keynav
     const App = {
+      compatConfig: {
+        MODE: 3,
+        RENDER_FUNCTION: 'suppress-warning',
+        COMPONENT_FUNCTIONAL: 'suppress-warning'
+      },
       render(h) {
         return h(BButtonToolbar, { props: { keyNav: true } }, [
           h(BButtonGroup, [h(BButton, 'a'), h(BButton, 'b')]),

--- a/src/components/button/button-close.js
+++ b/src/components/button/button-close.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_BUTTON_CLOSE } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { SLOT_NAME_DEFAULT } from '../../constants/slots'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BButtonClose = /*#__PURE__*/ Vue.extend({
+export const BButtonClose = /*#__PURE__*/ defineComponent({
   name: NAME_BUTTON_CLOSE,
   compatConfig: {
     MODE: 3,

--- a/src/components/button/button-close.js
+++ b/src/components/button/button-close.js
@@ -24,6 +24,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BButtonClose = /*#__PURE__*/ Vue.extend({
   name: NAME_BUTTON_CLOSE,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { props, data, slots, scopedSlots }) {

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_BUTTON } from '../../constants/components'
 import { CODE_ENTER, CODE_SPACE } from '../../constants/key-codes'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
@@ -115,7 +115,7 @@ const computeAttrs = (props, data) => {
 // --- Main component ---
 
 // @vue/component
-export const BButton = /*#__PURE__*/ Vue.extend({
+export const BButton = /*#__PURE__*/ defineComponent({
   name: NAME_BUTTON,
   functional: true,
   props,

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -811,7 +811,7 @@ export const BCalendar = Vue.extend({
       {
         staticClass: 'b-calendar-header',
         class: { 'sr-only': this.hideHeader },
-        attrs: { title: this.selectedDate ? this.labelSelectedDate || null : null }
+        attrs: { title: this.selectedDate ? this.labelSelected || null : null }
       },
       [$header]
     )

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_CALENDAR } from '../../constants/components'
 import {
   CALENDAR_GREGORY,
@@ -180,7 +180,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCalendar = Vue.extend({
+export const BCalendar = defineComponent({
   name: NAME_CALENDAR,
   compatConfig: {
     MODE: 3,

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -182,6 +182,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BCalendar = Vue.extend({
   name: NAME_CALENDAR,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   // Mixin order is important!
   mixins: [attrsMixin, idMixin, modelMixin, normalizeSlotMixin],
   props,

--- a/src/components/card/card-body.js
+++ b/src/components/card/card-body.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_BODY } from '../../constants/components'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_BOOLEAN } from '../../constants/props'
 import { sortKeys } from '../../utils/object'
@@ -29,7 +29,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardBody = /*#__PURE__*/ Vue.extend({
+export const BCardBody = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_BODY,
   functional: true,
   props,

--- a/src/components/card/card-footer.js
+++ b/src/components/card/card-footer.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_FOOTER } from '../../constants/components'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { htmlOrText } from '../../utils/html'
@@ -21,7 +21,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardFooter = /*#__PURE__*/ Vue.extend({
+export const BCardFooter = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_FOOTER,
   functional: true,
   props,

--- a/src/components/card/card-group.js
+++ b/src/components/card/card-group.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_GROUP } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -17,7 +17,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardGroup = /*#__PURE__*/ Vue.extend({
+export const BCardGroup = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_GROUP,
   functional: true,
   props,

--- a/src/components/card/card-header.js
+++ b/src/components/card/card-header.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_HEADER } from '../../constants/components'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { htmlOrText } from '../../utils/html'
@@ -21,7 +21,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardHeader = /*#__PURE__*/ Vue.extend({
+export const BCardHeader = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_HEADER,
   functional: true,
   props,

--- a/src/components/card/card-img-lazy.js
+++ b/src/components/card/card-img-lazy.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_IMG_LAZY } from '../../constants/components'
 import { keys, omit, sortKeys } from '../../utils/object'
 import { makePropsConfigurable } from '../../utils/props'
@@ -19,7 +19,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardImgLazy = /*#__PURE__*/ Vue.extend({
+export const BCardImgLazy = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_IMG_LAZY,
   functional: true,
   props,

--- a/src/components/card/card-img.js
+++ b/src/components/card/card-img.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_IMG } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN } from '../../constants/props'
 import { pick, sortKeys } from '../../utils/object'
@@ -21,7 +21,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardImg = /*#__PURE__*/ Vue.extend({
+export const BCardImg = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_IMG,
   functional: true,
   props,

--- a/src/components/card/card-sub-title.js
+++ b/src/components/card/card-sub-title.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_SUB_TITLE } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -18,7 +18,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardSubTitle = /*#__PURE__*/ Vue.extend({
+export const BCardSubTitle = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_SUB_TITLE,
   functional: true,
   props,

--- a/src/components/card/card-text.js
+++ b/src/components/card/card-text.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_TEXT } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -15,7 +15,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardText = /*#__PURE__*/ Vue.extend({
+export const BCardText = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_TEXT,
   functional: true,
   props,

--- a/src/components/card/card-title.js
+++ b/src/components/card/card-title.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD_TITLE } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -17,7 +17,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCardTitle = /*#__PURE__*/ Vue.extend({
+export const BCardTitle = /*#__PURE__*/ defineComponent({
   name: NAME_CARD_TITLE,
   functional: true,
   props,

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CARD } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { SLOT_NAME_DEFAULT, SLOT_NAME_FOOTER, SLOT_NAME_HEADER } from '../../constants/slots'
@@ -40,7 +40,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCard = /*#__PURE__*/ Vue.extend({
+export const BCard = /*#__PURE__*/ defineComponent({
   name: NAME_CARD,
   compatConfig: {
     MODE: 3,

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -42,6 +42,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BCard = /*#__PURE__*/ Vue.extend({
   name: NAME_CARD,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { props, data, slots, scopedSlots }) {

--- a/src/components/carousel/carousel-slide.js
+++ b/src/components/carousel/carousel-slide.js
@@ -47,13 +47,16 @@ export const BCarouselSlide = /*#__PURE__*/ Vue.extend({
   name: NAME_CAROUSEL_SLIDE,
   mixins: [idMixin, normalizeSlotMixin],
   inject: {
-    bvCarousel: {
+    getBvCarousel: {
       // Explicitly disable touch if not a child of carousel
-      default: () => ({ noTouch: true })
+      default: () => () => ({ noTouch: true })
     }
   },
   props,
   computed: {
+    bvCarousel() {
+      return this.getBvCarousel()
+    },
     contentClasses() {
       return [
         this.contentVisibleUp ? 'd-none' : '',

--- a/src/components/carousel/carousel-slide.js
+++ b/src/components/carousel/carousel-slide.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_CAROUSEL_SLIDE } from '../../constants/components'
 import { HAS_TOUCH_SUPPORT } from '../../constants/env'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
@@ -43,7 +43,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCarouselSlide = /*#__PURE__*/ Vue.extend({
+export const BCarouselSlide = /*#__PURE__*/ defineComponent({
   name: NAME_CAROUSEL_SLIDE,
   mixins: [idMixin, normalizeSlotMixin],
   inject: {

--- a/src/components/carousel/carousel-slide.spec.js
+++ b/src/components/carousel/carousel-slide.spec.js
@@ -144,9 +144,9 @@ describe('carousel-slide', () => {
   it('has style background inherited from carousel parent', async () => {
     const wrapper = mount(BCarouselSlide, {
       provide: {
-        bvCarousel: {
+        getBvCarousel: () => ({
           background: 'rgb(1, 2, 3)'
-        }
+        })
       }
     })
 
@@ -254,10 +254,10 @@ describe('carousel-slide', () => {
     const wrapper = mount(BCarouselSlide, {
       provide: {
         // Mock carousel injection
-        bvCarousel: {
+        getBvCarousel: () => ({
           imgWidth: '1024',
           imgHeight: '480'
-        }
+        })
       },
       propsData: {
         imgSrc: 'https://picsum.photos/1024/480/?image=52'

--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -136,7 +136,7 @@ export const BCarousel = /*#__PURE__*/ Vue.extend({
   name: NAME_CAROUSEL,
   mixins: [idMixin, modelMixin, normalizeSlotMixin],
   provide() {
-    return { bvCarousel: this }
+    return { getBvCarousel: () => this }
   },
   props,
   data() {

--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -134,6 +134,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BCarousel = /*#__PURE__*/ Vue.extend({
   name: NAME_CAROUSEL,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [idMixin, modelMixin, normalizeSlotMixin],
   provide() {
     return { getBvCarousel: () => this }

--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_CAROUSEL } from '../../constants/components'
 import { IS_BROWSER, HAS_POINTER_EVENT_SUPPORT, HAS_TOUCH_SUPPORT } from '../../constants/env'
 import {
@@ -132,7 +132,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCarousel = /*#__PURE__*/ Vue.extend({
+export const BCarousel = /*#__PURE__*/ defineComponent({
   name: NAME_CAROUSEL,
   compatConfig: {
     MODE: 3,

--- a/src/components/carousel/carousel.spec.js
+++ b/src/components/carousel/carousel.spec.js
@@ -6,6 +6,7 @@ import { BCarouselSlide } from './carousel-slide'
 jest.useFakeTimers()
 
 const App = {
+  compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
   props: [
     // BCarousel props
     'interval',

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_COLLAPSE } from '../../constants/components'
 import { CLASS_NAME_SHOW } from '../../constants/classes'
 import { IS_BROWSER } from '../../constants/env'
@@ -55,7 +55,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BCollapse = /*#__PURE__*/ Vue.extend({
+export const BCollapse = /*#__PURE__*/ defineComponent({
   name: NAME_COLLAPSE,
   compatConfig: {
     MODE: 3,

--- a/src/components/collapse/collapse.js
+++ b/src/components/collapse/collapse.js
@@ -57,6 +57,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BCollapse = /*#__PURE__*/ Vue.extend({
   name: NAME_COLLAPSE,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [idMixin, modelMixin, normalizeSlotMixin, listenOnRootMixin],
   props,
   data() {

--- a/src/components/collapse/collapse.spec.js
+++ b/src/components/collapse/collapse.spec.js
@@ -371,6 +371,7 @@ describe('collapse', () => {
 
   it('should close when clicking on contained nav-link prop is-nav is set', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('div', [
           // JSDOM supports `getComputedStyle()` when using stylesheets (non responsive)
@@ -421,6 +422,7 @@ describe('collapse', () => {
 
   it('should not close when clicking on nav-link prop is-nav is set & collapse is display block important', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('div', [
           // JSDOM supports `getComputedStyle()` when using stylesheets (non responsive)

--- a/src/components/collapse/helpers/bv-collapse.js
+++ b/src/components/collapse/helpers/bv-collapse.js
@@ -5,7 +5,7 @@
 //   during the enter/leave transition phases only
 //   Although it appears that Vue may be leaving the classes
 //   in-place after the transition completes
-import { Vue, mergeData } from '../../../vue'
+import { defineComponent, mergeData } from '../../../vue'
 import { NAME_COLLAPSE_HELPER } from '../../../constants/components'
 import { PROP_TYPE_BOOLEAN } from '../../../constants/props'
 import { getBCR, reflow, removeStyle, requestAF, setStyle } from '../../../utils/dom'
@@ -72,7 +72,7 @@ export const props = {
 // --- Main component ---
 
 // @vue/component
-export const BVCollapse = /*#__PURE__*/ Vue.extend({
+export const BVCollapse = /*#__PURE__*/ defineComponent({
   name: NAME_COLLAPSE_HELPER,
   functional: true,
   props,

--- a/src/components/dropdown/dropdown-divider.js
+++ b/src/components/dropdown/dropdown-divider.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_DROPDOWN_DIVIDER } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -16,7 +16,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BDropdownDivider = /*#__PURE__*/ Vue.extend({
+export const BDropdownDivider = /*#__PURE__*/ defineComponent({
   name: NAME_DROPDOWN_DIVIDER,
   functional: true,
   props,

--- a/src/components/dropdown/dropdown-form.js
+++ b/src/components/dropdown/dropdown-form.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_DROPDOWN_FORM } from '../../constants/components'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_BOOLEAN } from '../../constants/props'
 import { omit, sortKeys } from '../../utils/object'
@@ -19,7 +19,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BDropdownForm = /*#__PURE__*/ Vue.extend({
+export const BDropdownForm = /*#__PURE__*/ defineComponent({
   name: NAME_DROPDOWN_FORM,
   functional: true,
   props,

--- a/src/components/dropdown/dropdown-group.js
+++ b/src/components/dropdown/dropdown-group.js
@@ -27,6 +27,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BDropdownGroup = /*#__PURE__*/ Vue.extend({
   name: NAME_DROPDOWN_GROUP,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { props, data, slots, scopedSlots }) {

--- a/src/components/dropdown/dropdown-group.js
+++ b/src/components/dropdown/dropdown-group.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_DROPDOWN_GROUP } from '../../constants/components'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { SLOT_NAME_DEFAULT, SLOT_NAME_HEADER } from '../../constants/slots'
@@ -25,7 +25,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BDropdownGroup = /*#__PURE__*/ Vue.extend({
+export const BDropdownGroup = /*#__PURE__*/ defineComponent({
   name: NAME_DROPDOWN_GROUP,
   compatConfig: {
     MODE: 3,

--- a/src/components/dropdown/dropdown-header.js
+++ b/src/components/dropdown/dropdown-header.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_DROPDOWN_HEADER } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { isTag } from '../../utils/dom'
@@ -19,7 +19,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BDropdownHeader = /*#__PURE__*/ Vue.extend({
+export const BDropdownHeader = /*#__PURE__*/ defineComponent({
   name: NAME_DROPDOWN_HEADER,
   functional: true,
   props,

--- a/src/components/dropdown/dropdown-item-button.js
+++ b/src/components/dropdown/dropdown-item-button.js
@@ -30,11 +30,15 @@ export const BDropdownItemButton = /*#__PURE__*/ Vue.extend({
   name: NAME_DROPDOWN_ITEM_BUTTON,
   mixins: [attrsMixin, normalizeSlotMixin],
   inject: {
-    bvDropdown: { default: null }
+    getBvDropdown: { default: () => () => null }
   },
   inheritAttrs: false,
   props,
   computed: {
+    bvDropdown() {
+      return this.getBvDropdown()
+    },
+
     computedAttrs() {
       return {
         ...this.bvAttrs,

--- a/src/components/dropdown/dropdown-item-button.js
+++ b/src/components/dropdown/dropdown-item-button.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_DROPDOWN_ITEM_BUTTON } from '../../constants/components'
 import { EVENT_NAME_CLICK } from '../../constants/events'
 import {
@@ -26,7 +26,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BDropdownItemButton = /*#__PURE__*/ Vue.extend({
+export const BDropdownItemButton = /*#__PURE__*/ defineComponent({
   name: NAME_DROPDOWN_ITEM_BUTTON,
   mixins: [attrsMixin, normalizeSlotMixin],
   inject: {

--- a/src/components/dropdown/dropdown-item-button.spec.js
+++ b/src/components/dropdown/dropdown-item-button.spec.js
@@ -54,12 +54,12 @@ describe('dropdown-item-button', () => {
     let refocus = null
     const wrapper = mount(BDropdownItemButton, {
       provide: {
-        bvDropdown: {
+        getBvDropdown: () => ({
           hide(arg) {
             called = true
             refocus = arg
           }
-        }
+        })
       }
     })
     expect(wrapper.element.tagName).toBe('LI')
@@ -81,12 +81,12 @@ describe('dropdown-item-button', () => {
         disabled: true
       },
       provide: {
-        bvDropdown: {
+        getBvDropdown: () => ({
           hide(arg) {
             called = true
             refocus = arg
           }
-        }
+        })
       }
     })
     expect(wrapper.element.tagName).toBe('LI')

--- a/src/components/dropdown/dropdown-item.js
+++ b/src/components/dropdown/dropdown-item.js
@@ -29,11 +29,14 @@ export const BDropdownItem = /*#__PURE__*/ Vue.extend({
   name: NAME_DROPDOWN_ITEM,
   mixins: [attrsMixin, normalizeSlotMixin],
   inject: {
-    bvDropdown: { default: null }
+    getBvDropdown: { default: () => () => null }
   },
   inheritAttrs: false,
   props,
   computed: {
+    bvDropdown() {
+      return this.getBvDropdown()
+    },
     computedAttrs() {
       return {
         ...this.bvAttrs,

--- a/src/components/dropdown/dropdown-item.js
+++ b/src/components/dropdown/dropdown-item.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_DROPDOWN_ITEM } from '../../constants/components'
 import { EVENT_NAME_CLICK } from '../../constants/events'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_STRING } from '../../constants/props'
@@ -25,7 +25,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BDropdownItem = /*#__PURE__*/ Vue.extend({
+export const BDropdownItem = /*#__PURE__*/ defineComponent({
   name: NAME_DROPDOWN_ITEM,
   mixins: [attrsMixin, normalizeSlotMixin],
   inject: {

--- a/src/components/dropdown/dropdown-item.spec.js
+++ b/src/components/dropdown/dropdown-item.spec.js
@@ -34,12 +34,12 @@ describe('dropdown-item', () => {
     let refocus = null
     const wrapper = mount(BDropdownItem, {
       provide: {
-        bvDropdown: {
+        getBvDropdown: () => ({
           hide(arg) {
             called = true
             refocus = arg
           }
-        }
+        })
       }
     })
     expect(wrapper.element.tagName).toBe('LI')
@@ -60,12 +60,12 @@ describe('dropdown-item', () => {
     const wrapper = mount(BDropdownItem, {
       propsData: { disabled: true },
       provide: {
-        bvDropdown: {
+        getBvDropdown: () => ({
           hide(arg) {
             called = true
             refocus = arg
           }
-        }
+        })
       }
     })
     expect(wrapper.element.tagName).toBe('LI')

--- a/src/components/dropdown/dropdown-item.spec.js
+++ b/src/components/dropdown/dropdown-item.spec.js
@@ -107,6 +107,11 @@ describe('dropdown-item', () => {
       })
 
       const App = {
+        compatConfig: {
+          MODE: 3,
+          RENDER_FUNCTION: 'suppress-warning',
+          COMPONENT_FUNCTIONAL: 'suppress-warning'
+        },
         router,
         render(h) {
           return h('ul', [

--- a/src/components/dropdown/dropdown-text.js
+++ b/src/components/dropdown/dropdown-text.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_DROPDOWN_TEXT } from '../../constants/components'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { omit } from '../../utils/object'
@@ -18,7 +18,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BDropdownText = /*#__PURE__*/ Vue.extend({
+export const BDropdownText = /*#__PURE__*/ defineComponent({
   name: NAME_DROPDOWN_TEXT,
   functional: true,
   props,

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_DROPDOWN } from '../../constants/components'
 import {
   PROP_TYPE_ARRAY_OBJECT_STRING,
@@ -54,7 +54,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BDropdown = /*#__PURE__*/ Vue.extend({
+export const BDropdown = /*#__PURE__*/ defineComponent({
   name: NAME_DROPDOWN,
   mixins: [idMixin, dropdownMixin, normalizeSlotMixin],
   props,

--- a/src/components/dropdown/dropdown.spec.js
+++ b/src/components/dropdown/dropdown.spec.js
@@ -517,6 +517,7 @@ describe('dropdown', () => {
 
   it('dropdown opens and closes', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         disabled: { type: Boolean, default: false }
       },
@@ -787,6 +788,7 @@ describe('dropdown', () => {
 
   it('Keyboard navigation works when open', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('div', [
           h(BDropdown, { props: { id: 'test' } }, [

--- a/src/components/embed/embed.js
+++ b/src/components/embed/embed.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_EMBED } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { arrayIncludes } from '../../utils/array'
@@ -25,7 +25,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BEmbed = /*#__PURE__*/ Vue.extend({
+export const BEmbed = /*#__PURE__*/ defineComponent({
   name: NAME_EMBED,
   functional: true,
   props,

--- a/src/components/form-btn-label-control/bv-form-btn-label-control.js
+++ b/src/components/form-btn-label-control/bv-form-btn-label-control.js
@@ -55,6 +55,10 @@ export const props = sortKeys({
 
 // @vue/component
 export const BVFormBtnLabelControl = /*#__PURE__*/ Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    CUSTOM_DIR: 'suppress-warning'
+  },
   name: NAME_FORM_BUTTON_LABEL_CONTROL,
   directives: {
     'b-hover': VBHover

--- a/src/components/form-btn-label-control/bv-form-btn-label-control.js
+++ b/src/components/form-btn-label-control/bv-form-btn-label-control.js
@@ -1,7 +1,7 @@
 //
 // Private component used by `b-form-datepicker` and `b-form-timepicker`
 //
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_BUTTON_LABEL_CONTROL } from '../../constants/components'
 import {
   PROP_TYPE_ARRAY_OBJECT_STRING,
@@ -54,7 +54,7 @@ export const props = sortKeys({
 // --- Main component ---
 
 // @vue/component
-export const BVFormBtnLabelControl = /*#__PURE__*/ Vue.extend({
+export const BVFormBtnLabelControl = /*#__PURE__*/ defineComponent({
   compatConfig: {
     MODE: 3,
     CUSTOM_DIR: 'suppress-warning'

--- a/src/components/form-checkbox/form-checkbox-group.js
+++ b/src/components/form-checkbox/form-checkbox-group.js
@@ -30,7 +30,7 @@ export const BFormCheckboxGroup = /*#__PURE__*/ Vue.extend({
   mixins: [formRadioCheckGroupMixin],
   provide() {
     return {
-      bvCheckGroup: this
+      getBvCheckGroup: () => this
     }
   },
   props,

--- a/src/components/form-checkbox/form-checkbox-group.js
+++ b/src/components/form-checkbox/form-checkbox-group.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_CHECKBOX_GROUP } from '../../constants/components'
 import { PROP_TYPE_ARRAY, PROP_TYPE_BOOLEAN } from '../../constants/props'
 import { sortKeys } from '../../utils/object'
@@ -24,7 +24,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormCheckboxGroup = /*#__PURE__*/ Vue.extend({
+export const BFormCheckboxGroup = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_CHECKBOX_GROUP,
   // Includes render function
   mixins: [formRadioCheckGroupMixin],

--- a/src/components/form-checkbox/form-checkbox-group.spec.js
+++ b/src/components/form-checkbox/form-checkbox-group.spec.js
@@ -316,6 +316,7 @@ describe('form-checkbox-group', () => {
 
   it('button mode button variant works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(
           BFormCheckboxGroup,

--- a/src/components/form-checkbox/form-checkbox.js
+++ b/src/components/form-checkbox/form-checkbox.js
@@ -41,13 +41,16 @@ export const BFormCheckbox = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_CHECKBOX,
   mixins: [formRadioCheckMixin],
   inject: {
-    bvGroup: {
-      from: 'bvCheckGroup',
-      default: null
+    getBvGroup: {
+      from: 'getBvCheckGroup',
+      default: () => () => null
     }
   },
   props,
   computed: {
+    bvGroup() {
+      return this.getBvGroup()
+    },
     isChecked() {
       const { value, computedLocalChecked: checked } = this
       return isArray(checked) ? looseIndexOf(checked, value) > -1 : looseEqual(checked, value)

--- a/src/components/form-checkbox/form-checkbox.js
+++ b/src/components/form-checkbox/form-checkbox.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_CHECKBOX } from '../../constants/components'
 import { EVENT_NAME_CHANGE, MODEL_EVENT_NAME_PREFIX } from '../../constants/events'
 import { PROP_TYPE_ANY, PROP_TYPE_BOOLEAN } from '../../constants/props'
@@ -37,7 +37,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormCheckbox = /*#__PURE__*/ Vue.extend({
+export const BFormCheckbox = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_CHECKBOX,
   mixins: [formRadioCheckMixin],
   inject: {

--- a/src/components/form-datepicker/form-datepicker.js
+++ b/src/components/form-datepicker/form-datepicker.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_DATEPICKER } from '../../constants/components'
 import { EVENT_NAME_CONTEXT, EVENT_NAME_HIDDEN, EVENT_NAME_SHOWN } from '../../constants/events'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_DATE_STRING, PROP_TYPE_STRING } from '../../constants/props'
@@ -75,7 +75,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormDatepicker = /*#__PURE__*/ Vue.extend({
+export const BFormDatepicker = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_DATEPICKER,
   compatConfig: {
     MODE: 3,

--- a/src/components/form-datepicker/form-datepicker.js
+++ b/src/components/form-datepicker/form-datepicker.js
@@ -77,6 +77,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BFormDatepicker = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_DATEPICKER,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   mixins: [idMixin, modelMixin],
   props,
   data() {

--- a/src/components/form-file/form-file.js
+++ b/src/components/form-file/form-file.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_FILE } from '../../constants/components'
 import { HAS_PROMISE_SUPPORT } from '../../constants/env'
 import { EVENT_NAME_CHANGE, EVENT_OPTIONS_PASSIVE } from '../../constants/events'
@@ -176,7 +176,7 @@ const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormFile = /*#__PURE__*/ Vue.extend({
+export const BFormFile = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_FILE,
   compatConfig: {
     MODE: 3,

--- a/src/components/form-file/form-file.js
+++ b/src/components/form-file/form-file.js
@@ -178,6 +178,10 @@ const props = makePropsConfigurable(
 // @vue/component
 export const BFormFile = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_FILE,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [
     attrsMixin,
     idMixin,

--- a/src/components/form-file/form-file.spec.js
+++ b/src/components/form-file/form-file.spec.js
@@ -540,6 +540,7 @@ describe('form-file', () => {
 
   it('form native reset event triggers BFormFile reset', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('form', {}, [h(BFormFile, { id: 'foo' })])
       }

--- a/src/components/form-group/form-group.js
+++ b/src/components/form-group/form-group.js
@@ -89,6 +89,12 @@ export const generateProps = () =>
 // immediately, which we do not want to happen
 // @vue/component
 export const BFormGroup = {
+  compatConfig: {
+    MODE: 3,
+    RENDER_FUNCTION: 'suppress-warning',
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning',
+    COMPONENT_FUNCTIONAL: 'suppress-warning'
+  },
   name: NAME_FORM_GROUP,
   mixins: [idMixin, formStateMixin, normalizeSlotMixin],
   get props() {

--- a/src/components/form-group/form-group.js
+++ b/src/components/form-group/form-group.js
@@ -85,7 +85,7 @@ export const generateProps = () =>
 
 // --- Main component ---
 
-// We do not use `Vue.extend()` here as that would evaluate the props
+// We do not use `defineComponent()` here as that would evaluate the props
 // immediately, which we do not want to happen
 // @vue/component
 export const BFormGroup = {

--- a/src/components/form-input/form-input.js
+++ b/src/components/form-input/form-input.js
@@ -63,6 +63,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BFormInput = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_INPUT,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   // Mixin order is important!
   mixins: [
     listenersMixin,

--- a/src/components/form-input/form-input.js
+++ b/src/components/form-input/form-input.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_INPUT } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { arrayIncludes } from '../../utils/array'
@@ -61,7 +61,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormInput = /*#__PURE__*/ Vue.extend({
+export const BFormInput = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_INPUT,
   compatConfig: {
     MODE: 3,

--- a/src/components/form-radio/form-radio-group.js
+++ b/src/components/form-radio/form-radio-group.js
@@ -18,7 +18,7 @@ export const BFormRadioGroup = /*#__PURE__*/ Vue.extend({
   mixins: [formRadioCheckGroupMixin],
   provide() {
     return {
-      bvRadioGroup: this
+      getBvRadioGroup: () => this
     }
   },
   props,

--- a/src/components/form-radio/form-radio-group.js
+++ b/src/components/form-radio/form-radio-group.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_RADIO_GROUP } from '../../constants/components'
 import { makePropsConfigurable } from '../../utils/props'
 import {
@@ -13,7 +13,7 @@ export const props = makePropsConfigurable(formRadioCheckGroupProps, NAME_FORM_R
 // --- Main component ---
 
 // @vue/component
-export const BFormRadioGroup = /*#__PURE__*/ Vue.extend({
+export const BFormRadioGroup = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_RADIO_GROUP,
   mixins: [formRadioCheckGroupMixin],
   provide() {

--- a/src/components/form-radio/form-radio-group.spec.js
+++ b/src/components/form-radio/form-radio-group.spec.js
@@ -295,6 +295,7 @@ describe('form-radio-group', () => {
 
   it('button mode button-variant works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(
           BFormRadioGroup,

--- a/src/components/form-radio/form-radio.js
+++ b/src/components/form-radio/form-radio.js
@@ -19,12 +19,17 @@ export const BFormRadio = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_RADIO,
   mixins: [formRadioCheckMixin],
   inject: {
-    bvGroup: {
-      from: 'bvRadioGroup',
-      default: false
+    getBvGroup: {
+      from: 'getBvRadioGroup',
+      default: () => () => null
     }
   },
   props,
+  computed: {
+    bvGroup() {
+      return this.getBvGroup()
+    }
+  },
   watch: {
     computedLocalChecked(newValue, oldValue) {
       if (!looseEqual(newValue, oldValue)) {

--- a/src/components/form-radio/form-radio.js
+++ b/src/components/form-radio/form-radio.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_RADIO } from '../../constants/components'
 import { looseEqual } from '../../utils/loose-equal'
 import { makePropsConfigurable } from '../../utils/props'
@@ -15,7 +15,7 @@ export const props = makePropsConfigurable(formRadioCheckProps, NAME_FORM_RADIO)
 // --- Main component ---
 
 // @vue/component
-export const BFormRadio = /*#__PURE__*/ Vue.extend({
+export const BFormRadio = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_RADIO,
   mixins: [formRadioCheckMixin],
   inject: {

--- a/src/components/form-rating/form-rating.js
+++ b/src/components/form-rating/form-rating.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_RATING, NAME_FORM_RATING_STAR } from '../../constants/components'
 import { EVENT_NAME_CHANGE, EVENT_NAME_SELECTED } from '../../constants/events'
 import {
@@ -58,7 +58,7 @@ const clampValue = (value, min, max) => mathMax(mathMin(value, max), min)
 // --- Helper components ---
 
 // @vue/component
-const BVFormRatingStar = Vue.extend({
+const BVFormRatingStar = defineComponent({
   name: NAME_FORM_RATING_STAR,
   mixins: [normalizeSlotMixin],
   props: {
@@ -140,7 +140,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormRating = /*#__PURE__*/ Vue.extend({
+export const BFormRating = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_RATING,
   compatConfig: {
     MODE: 3,

--- a/src/components/form-rating/form-rating.js
+++ b/src/components/form-rating/form-rating.js
@@ -142,6 +142,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BFormRating = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_RATING,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   components: { BIconStar, BIconStarHalf, BIconStarFill, BIconX },
   mixins: [idMixin, modelMixin, formSizeMixin],
   props,

--- a/src/components/form-select/form-select-option-group.js
+++ b/src/components/form-select/form-select-option-group.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_SELECT_OPTION_GROUP } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { SLOT_NAME_FIRST } from '../../constants/slots'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormSelectOptionGroup = /*#__PURE__*/ Vue.extend({
+export const BFormSelectOptionGroup = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_SELECT_OPTION_GROUP,
   mixins: [normalizeSlotMixin, formOptionsMixin],
   props,

--- a/src/components/form-select/form-select-option.js
+++ b/src/components/form-select/form-select-option.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_FORM_SELECT_OPTION } from '../../constants/components'
 import { PROP_TYPE_ANY, PROP_TYPE_BOOLEAN } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -16,7 +16,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormSelectOption = /*#__PURE__*/ Vue.extend({
+export const BFormSelectOption = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_SELECT_OPTION,
   functional: true,
   props,

--- a/src/components/form-select/form-select.js
+++ b/src/components/form-select/form-select.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_SELECT } from '../../constants/components'
 import { EVENT_NAME_CHANGE } from '../../constants/events'
 import {
@@ -51,7 +51,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormSelect = /*#__PURE__*/ Vue.extend({
+export const BFormSelect = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_SELECT,
   mixins: [
     idMixin,

--- a/src/components/form-select/helpers/mixin-options.js
+++ b/src/components/form-select/helpers/mixin-options.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { PROP_TYPE_STRING } from '../../../constants/props'
 import { get } from '../../../utils/get'
 import { isNull, isPlainObject, isUndefined } from '../../../utils/inspect'
@@ -20,7 +20,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const optionsMixin = Vue.extend({
+export const optionsMixin = defineComponent({
   mixins: [formOptionsMixin],
   props,
   methods: {

--- a/src/components/form-spinbutton/form-spinbutton.js
+++ b/src/components/form-spinbutton/form-spinbutton.js
@@ -101,6 +101,10 @@ export const props = makePropsConfigurable(
 
 // @vue/component
 export const BFormSpinbutton = /*#__PURE__*/ Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   name: NAME_FORM_SPINBUTTON,
   // Mixin order is important!
   mixins: [attrsMixin, idMixin, modelMixin, formSizeMixin, formStateMixin, normalizeSlotMixin],
@@ -114,7 +118,7 @@ export const BFormSpinbutton = /*#__PURE__*/ Vue.extend({
   },
   computed: {
     required() {
-      false
+      return false
     },
     spinId() {
       return this.safeId()

--- a/src/components/form-spinbutton/form-spinbutton.js
+++ b/src/components/form-spinbutton/form-spinbutton.js
@@ -113,6 +113,9 @@ export const BFormSpinbutton = /*#__PURE__*/ Vue.extend({
     }
   },
   computed: {
+    required() {
+      false
+    },
     spinId() {
       return this.safeId()
     },

--- a/src/components/form-spinbutton/form-spinbutton.js
+++ b/src/components/form-spinbutton/form-spinbutton.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_SPINBUTTON } from '../../constants/components'
 import { EVENT_NAME_CHANGE } from '../../constants/events'
 import {
@@ -100,7 +100,7 @@ export const props = makePropsConfigurable(
 // --- Main Component ---
 
 // @vue/component
-export const BFormSpinbutton = /*#__PURE__*/ Vue.extend({
+export const BFormSpinbutton = /*#__PURE__*/ defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/components/form-tags/form-tag.js
+++ b/src/components/form-tags/form-tag.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_TAG } from '../../constants/components'
 import { EVENT_NAME_REMOVE } from '../../constants/events'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
@@ -29,7 +29,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormTag = /*#__PURE__*/ Vue.extend({
+export const BFormTag = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_TAG,
   mixins: [idMixin, normalizeSlotMixin],
   props,

--- a/src/components/form-tags/form-tags.js
+++ b/src/components/form-tags/form-tags.js
@@ -1,6 +1,6 @@
 // Tagged input form control
 // Based loosely on https://adamwathan.me/renderless-components-in-vuejs/
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_TAGS } from '../../constants/components'
 import {
   EVENT_NAME_BLUR,
@@ -141,7 +141,7 @@ const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormTags = /*#__PURE__*/ Vue.extend({
+export const BFormTags = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_TAGS,
   compatConfig: {
     MODE: 3,

--- a/src/components/form-tags/form-tags.js
+++ b/src/components/form-tags/form-tags.js
@@ -143,6 +143,10 @@ const props = makePropsConfigurable(
 // @vue/component
 export const BFormTags = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_TAGS,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [
     listenersMixin,
     idMixin,

--- a/src/components/form-tags/form-tags.spec.js
+++ b/src/components/form-tags/form-tags.spec.js
@@ -650,6 +650,7 @@ describe('form-tags', () => {
 
   it('form native reset event triggers reset', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('form', [
           h(BFormTags, {

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -67,6 +67,9 @@ export const BFormTextarea = /*#__PURE__*/ Vue.extend({
     }
   },
   computed: {
+    type() {
+      return null
+    },
     computedStyle() {
       const styles = {
         // Setting `noResize` to true will disable the ability for the user to

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_TEXTAREA } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { getCS, getStyle, isVisible, requestAF, setStyle } from '../../utils/dom'
@@ -43,7 +43,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormTextarea = /*#__PURE__*/ Vue.extend({
+export const BFormTextarea = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_TEXTAREA,
   compatConfig: {
     MODE: 3,

--- a/src/components/form-textarea/form-textarea.js
+++ b/src/components/form-textarea/form-textarea.js
@@ -45,6 +45,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BFormTextarea = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_TEXTAREA,
+  compatConfig: {
+    MODE: 3,
+    CUSTOM_DIR: 'suppress-warning'
+  },
   directives: {
     'b-visible': VBVisible
   },

--- a/src/components/form-timepicker/form-timepicker.js
+++ b/src/components/form-timepicker/form-timepicker.js
@@ -66,6 +66,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BFormTimepicker = /*#__PURE__*/ Vue.extend({
   name: NAME_FORM_TIMEPICKER,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   mixins: [idMixin, modelMixin],
   props,
   data() {

--- a/src/components/form-timepicker/form-timepicker.js
+++ b/src/components/form-timepicker/form-timepicker.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_TIMEPICKER } from '../../constants/components'
 import { EVENT_NAME_CONTEXT, EVENT_NAME_SHOWN, EVENT_NAME_HIDDEN } from '../../constants/events'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_DATE_STRING, PROP_TYPE_STRING } from '../../constants/props'
@@ -64,7 +64,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormTimepicker = /*#__PURE__*/ Vue.extend({
+export const BFormTimepicker = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_TIMEPICKER,
   compatConfig: {
     MODE: 3,

--- a/src/components/form/form-datalist.js
+++ b/src/components/form/form-datalist.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_FORM_DATALIST } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { htmlOrText } from '../../utils/html'
@@ -20,7 +20,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormDatalist = /*#__PURE__*/ Vue.extend({
+export const BFormDatalist = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_DATALIST,
   mixins: [formOptionsMixin, normalizeSlotMixin],
   props,

--- a/src/components/form/form-invalid-feedback.js
+++ b/src/components/form/form-invalid-feedback.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_FORM_INVALID_FEEDBACK } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormInvalidFeedback = /*#__PURE__*/ Vue.extend({
+export const BFormInvalidFeedback = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_INVALID_FEEDBACK,
   functional: true,
   props,

--- a/src/components/form/form-text.js
+++ b/src/components/form/form-text.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_FORM_TEXT } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -18,7 +18,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormText = /*#__PURE__*/ Vue.extend({
+export const BFormText = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_TEXT,
   functional: true,
   props,

--- a/src/components/form/form-valid-feedback.js
+++ b/src/components/form/form-valid-feedback.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_FORM_VALID_FEEDBACK } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormValidFeedback = /*#__PURE__*/ Vue.extend({
+export const BFormValidFeedback = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_VALID_FEEDBACK,
   functional: true,
   props,

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_FORM } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -18,7 +18,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BForm = /*#__PURE__*/ Vue.extend({
+export const BForm = /*#__PURE__*/ defineComponent({
   name: NAME_FORM,
   functional: true,
   props,

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -104,7 +104,9 @@ export const BImgLazy = /*#__PURE__*/ Vue.extend({
   },
   mounted() {
     // If `IntersectionObserver` is not available, image is always shown
-    this.isShown = HAS_INTERACTION_OBSERVER_SUPPORT ? this[MODEL_PROP_NAME_SHOW] : true
+    this.$nextTick(() => {
+      this.isShown = HAS_INTERACTION_OBSERVER_SUPPORT ? this[MODEL_PROP_NAME_SHOW] : true
+    })
   },
   methods: {
     updateShowProp() {

--- a/src/components/image/img-lazy.js
+++ b/src/components/image/img-lazy.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_IMG_LAZY } from '../../constants/components'
 import { HAS_INTERACTION_OBSERVER_SUPPORT } from '../../constants/env'
 import { MODEL_EVENT_NAME_PREFIX } from '../../constants/events'
@@ -39,7 +39,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BImgLazy = /*#__PURE__*/ Vue.extend({
+export const BImgLazy = /*#__PURE__*/ defineComponent({
   name: NAME_IMG_LAZY,
   directives: {
     'b-visible': VBVisible

--- a/src/components/image/img.js
+++ b/src/components/image/img.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_IMG } from '../../constants/components'
 import {
   PROP_TYPE_ARRAY_STRING,
@@ -72,7 +72,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BImg = /*#__PURE__*/ Vue.extend({
+export const BImg = /*#__PURE__*/ defineComponent({
   name: NAME_IMG,
   compatConfig: {
     MODE: 3,

--- a/src/components/image/img.js
+++ b/src/components/image/img.js
@@ -74,6 +74,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BImg = /*#__PURE__*/ Vue.extend({
   name: NAME_IMG,
+  compatConfig: {
+    MODE: 3,
+    CUSTOM_DIR: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { props, data }) {

--- a/src/components/input-group/input-group-addon.js
+++ b/src/components/input-group/input-group-addon.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_INPUT_GROUP_ADDON } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -19,7 +19,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BInputGroupAddon = /*#__PURE__*/ Vue.extend({
+export const BInputGroupAddon = /*#__PURE__*/ defineComponent({
   name: NAME_INPUT_GROUP_ADDON,
   functional: true,
   props,

--- a/src/components/input-group/input-group-append.js
+++ b/src/components/input-group/input-group-append.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_INPUT_GROUP_APPEND } from '../../constants/components'
 import { omit } from '../../utils/object'
 import { makePropsConfigurable } from '../../utils/props'
@@ -14,7 +14,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BInputGroupAppend = /*#__PURE__*/ Vue.extend({
+export const BInputGroupAppend = /*#__PURE__*/ defineComponent({
   name: NAME_INPUT_GROUP_APPEND,
   functional: true,
   props,

--- a/src/components/input-group/input-group-prepend.js
+++ b/src/components/input-group/input-group-prepend.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_INPUT_GROUP_PREPEND } from '../../constants/components'
 import { omit } from '../../utils/object'
 import { makePropsConfigurable } from '../../utils/props'
@@ -14,7 +14,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BInputGroupPrepend = /*#__PURE__*/ Vue.extend({
+export const BInputGroupPrepend = /*#__PURE__*/ defineComponent({
   name: NAME_INPUT_GROUP_PREPEND,
   functional: true,
   props,

--- a/src/components/input-group/input-group-text.js
+++ b/src/components/input-group/input-group-text.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_INPUT_GROUP_TEXT } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -15,7 +15,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BInputGroupText = /*#__PURE__*/ Vue.extend({
+export const BInputGroupText = /*#__PURE__*/ defineComponent({
   name: NAME_INPUT_GROUP_TEXT,
   functional: true,
   props,

--- a/src/components/input-group/input-group.js
+++ b/src/components/input-group/input-group.js
@@ -29,6 +29,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BInputGroup = /*#__PURE__*/ Vue.extend({
   name: NAME_INPUT_GROUP,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { props, data, slots, scopedSlots }) {

--- a/src/components/input-group/input-group.js
+++ b/src/components/input-group/input-group.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_INPUT_GROUP } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { SLOT_NAME_APPEND, SLOT_NAME_DEFAULT, SLOT_NAME_PREPEND } from '../../constants/slots'
@@ -27,7 +27,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BInputGroup = /*#__PURE__*/ Vue.extend({
+export const BInputGroup = /*#__PURE__*/ defineComponent({
   name: NAME_INPUT_GROUP,
   compatConfig: {
     MODE: 3,

--- a/src/components/jumbotron/jumbotron.js
+++ b/src/components/jumbotron/jumbotron.js
@@ -38,6 +38,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BJumbotron = /*#__PURE__*/ Vue.extend({
   name: NAME_JUMBOTRON,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { props, data, slots, scopedSlots }) {

--- a/src/components/jumbotron/jumbotron.js
+++ b/src/components/jumbotron/jumbotron.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_JUMBOTRON } from '../../constants/components'
 import {
   PROP_TYPE_BOOLEAN,
@@ -36,7 +36,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BJumbotron = /*#__PURE__*/ Vue.extend({
+export const BJumbotron = /*#__PURE__*/ defineComponent({
   name: NAME_JUMBOTRON,
   compatConfig: {
     MODE: 3,

--- a/src/components/layout/container.js
+++ b/src/components/layout/container.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_CONTAINER } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -17,7 +17,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BContainer = /*#__PURE__*/ Vue.extend({
+export const BContainer = /*#__PURE__*/ defineComponent({
   name: NAME_CONTAINER,
   functional: true,
   props,

--- a/src/components/layout/form-row.js
+++ b/src/components/layout/form-row.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_FORM_ROW } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -15,7 +15,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BFormRow = /*#__PURE__*/ Vue.extend({
+export const BFormRow = /*#__PURE__*/ defineComponent({
   name: NAME_FORM_ROW,
   functional: true,
   props,

--- a/src/components/layout/row.js
+++ b/src/components/layout/row.js
@@ -65,7 +65,7 @@ export const generateProps = () => {
 
 // --- Main component ---
 
-// We do not use `Vue.extend()` here as that would evaluate the props
+// We do not use `defineComponent()` here as that would evaluate the props
 // immediately, which we do not want to happen
 // @vue/component
 export const BRow = {

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -105,7 +105,10 @@ export const BLink = /*#__PURE__*/ Vue.extend({
       return this.isRouterLink
         ? {
             ...pluckProps(
-              omit({ ...routerLinkProps, ...nuxtLinkProps }, ['event', 'prefetch', 'routerTag']),
+              omit(
+                { ...routerLinkProps, ...(this.computedTag === 'nuxt-link' ? nuxtLinkProps : {}) },
+                ['event', 'prefetch', 'routerTag']
+              ),
               this
             ),
             // Only add these props, when actually defined

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -14,6 +14,7 @@ import { isBoolean, isEvent, isFunction, isUndefined } from '../../utils/inspect
 import { omit, sortKeys } from '../../utils/object'
 import { makeProp, makePropsConfigurable, pluckProps } from '../../utils/props'
 import { computeHref, computeRel, computeTag, isRouterLink } from '../../utils/router'
+import { getInstanceFromVNode } from '../../utils/get-instance-from-vnode'
 import { attrsMixin } from '../../mixins/attrs'
 import { listenOnRootMixin } from '../../mixins/listen-on-root'
 import { listenersMixin } from '../../mixins/listeners'
@@ -162,8 +163,8 @@ export const BLink = /*#__PURE__*/ Vue.extend({
         // Router links do not emit instance `click` events, so we
         // add in an `$emit('click', event)` on its Vue instance
         /* istanbul ignore next: difficult to test, but we know it works */
-        if (isRouterLink && event.currentTarget.__vue__) {
-          event.currentTarget.__vue__.$emit(EVENT_NAME_CLICK, event)
+        if (isRouterLink && getInstanceFromVNode(event.currentTarget)) {
+          getInstanceFromVNode(event.currentTarget).$emit(EVENT_NAME_CLICK, event)
         }
         // Call the suppliedHandler(s), if any provided
         concat(suppliedHandler)

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_LINK } from '../../constants/components'
 import { EVENT_NAME_CLICK } from '../../constants/events'
 import {
@@ -75,7 +75,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BLink = /*#__PURE__*/ Vue.extend({
+export const BLink = /*#__PURE__*/ defineComponent({
   name: NAME_LINK,
   // Mixin order is important!
   mixins: [attrsMixin, listenersMixin, listenOnRootMixin, normalizeSlotMixin],

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -283,6 +283,7 @@ describe('b-link', () => {
     it('should emit "bv::link::clicked" on $root when clicked on', async () => {
       const spy = jest.fn()
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [h(BLink, { props: { href: '/foo' } }, 'link')])
         }
@@ -301,6 +302,7 @@ describe('b-link', () => {
     it('should not emit "bv::link::clicked" on $root when clicked on when disabled', async () => {
       const spy = jest.fn()
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [h(BLink, { props: { href: '/foo', disabled: true } }, 'link')])
         }
@@ -319,6 +321,7 @@ describe('b-link', () => {
     it('should emit "clicked::link" on $root when clicked on', async () => {
       const spy = jest.fn()
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [h(BLink, { props: { href: '/foo' } }, 'link')])
         }
@@ -337,6 +340,7 @@ describe('b-link', () => {
     it('should not emit "clicked::link" on $root when clicked on when disabled', async () => {
       const spy = jest.fn()
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [h(BLink, { props: { href: '/foo', disabled: true } }, 'link')])
         }
@@ -369,6 +373,7 @@ describe('b-link', () => {
       // Fake Gridsome `<g-link>` component
       const GLink = {
         name: 'GLink',
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         props: {
           to: {
             type: [String, Object],
@@ -385,6 +390,11 @@ describe('b-link', () => {
       localVue.component('GLink', GLink)
 
       const App = {
+        compatConfig: {
+          MODE: 3,
+          RENDER_FUNCTION: 'suppress-warning',
+          COMPONENT_FUNCTIONAL: 'suppress-warning'
+        },
         router,
         components: { BLink },
         render(h) {

--- a/src/components/list-group/list-group-item.js
+++ b/src/components/list-group/list-group-item.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_LIST_GROUP_ITEM } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { arrayIncludes } from '../../utils/array'
@@ -32,7 +32,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BListGroupItem = /*#__PURE__*/ Vue.extend({
+export const BListGroupItem = /*#__PURE__*/ defineComponent({
   name: NAME_LIST_GROUP_ITEM,
   functional: true,
   props,

--- a/src/components/list-group/list-group.js
+++ b/src/components/list-group/list-group.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_LIST_GROUP } from '../../constants/components'
 import {
   PROP_TYPE_BOOLEAN,
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BListGroup = /*#__PURE__*/ Vue.extend({
+export const BListGroup = /*#__PURE__*/ defineComponent({
   name: NAME_LIST_GROUP,
   functional: true,
   props,

--- a/src/components/media/media-aside.js
+++ b/src/components/media/media-aside.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_MEDIA_ASIDE } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -17,7 +17,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BMediaAside = /*#__PURE__*/ Vue.extend({
+export const BMediaAside = /*#__PURE__*/ defineComponent({
   name: NAME_MEDIA_ASIDE,
   functional: true,
   props,

--- a/src/components/media/media-body.js
+++ b/src/components/media/media-body.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_MEDIA_BODY } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -15,7 +15,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BMediaBody = /*#__PURE__*/ Vue.extend({
+export const BMediaBody = /*#__PURE__*/ defineComponent({
   name: NAME_MEDIA_BODY,
   functional: true,
   props,

--- a/src/components/media/media.js
+++ b/src/components/media/media.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_MEDIA } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { SLOT_NAME_ASIDE, SLOT_NAME_DEFAULT } from '../../constants/slots'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BMedia = /*#__PURE__*/ Vue.extend({
+export const BMedia = /*#__PURE__*/ defineComponent({
   name: NAME_MEDIA,
   compatConfig: {
     MODE: 3,

--- a/src/components/media/media.js
+++ b/src/components/media/media.js
@@ -24,6 +24,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BMedia = /*#__PURE__*/ Vue.extend({
   name: NAME_MEDIA,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { props, data, slots, scopedSlots, children }) {

--- a/src/components/modal/helpers/bv-modal.js
+++ b/src/components/modal/helpers/bv-modal.js
@@ -71,6 +71,11 @@ const plugin = Vue => {
   // @vue/component
   const BMsgBox = Vue.extend({
     name: NAME_MSG_BOX,
+    compatConfig: {
+      MODE: 3,
+      INSTANCE_DESTROY: 'suppress-warning',
+      INSTANCE_LISTENERS: 'suppress-warning'
+    },
     extends: BModal,
     mixins: [useParentMixin],
     destroyed() {

--- a/src/components/modal/helpers/bv-modal.js
+++ b/src/components/modal/helpers/bv-modal.js
@@ -26,6 +26,7 @@ import { warn, warnNotClient, warnNoPromiseSupport } from '../../../utils/warn'
 import { createNewChildComponent } from '../../../utils/create-new-child-component'
 import { getEventRoot } from '../../../utils/get-event-root'
 import { BModal, props as modalProps } from '../modal'
+import { defineComponent } from '../../../vue'
 
 // --- Constants ---
 
@@ -69,7 +70,7 @@ const plugin = Vue => {
   // Create a private sub-component that extends BModal
   // which self-destructs after hidden
   // @vue/component
-  const BMsgBox = Vue.extend({
+  const BMsgBox = defineComponent({
     name: NAME_MSG_BOX,
     compatConfig: {
       MODE: 3,

--- a/src/components/modal/helpers/bv-modal.spec.js
+++ b/src/components/modal/helpers/bv-modal.spec.js
@@ -8,6 +8,7 @@ Vue.use(ModalPlugin)
 describe('$bvModal', () => {
   it('$bvModal.show() and $bvModal.hide() works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('b-modal', { props: { static: true, id: 'test1' } }, 'content')
       }
@@ -55,6 +56,7 @@ describe('$bvModal', () => {
 
   it('$bvModal.msgBoxOk() works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('div', 'app')
       }
@@ -116,6 +118,7 @@ describe('$bvModal', () => {
 
   it('$bvModal.msgBoxConfirm() works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('div', 'app')
       }

--- a/src/components/modal/helpers/modal-manager.js
+++ b/src/components/modal/helpers/modal-manager.js
@@ -3,7 +3,7 @@
  * Handles controlling modal stacking zIndexes and body adjustments/classes
  */
 
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { IS_BROWSER } from '../../../constants/env'
 import {
   addClass,
@@ -35,7 +35,7 @@ const SELECTOR_NAVBAR_TOGGLER = '.navbar-toggler'
 // --- Main component ---
 
 // @vue/component
-const ModalManager = /*#__PURE__*/ Vue.extend({
+const ModalManager = /*#__PURE__*/ defineComponent({
   data() {
     return {
       modals: [],

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -178,6 +178,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BModal = /*#__PURE__*/ Vue.extend({
   name: NAME_MODAL,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [
     attrsMixin,
     idMixin,

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1,4 +1,4 @@
-import { COMPONENT_UID_KEY, Vue } from '../../vue'
+import { COMPONENT_UID_KEY, defineComponent } from '../../vue'
 import { NAME_MODAL } from '../../constants/components'
 import { IS_BROWSER } from '../../constants/env'
 import {
@@ -176,7 +176,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BModal = /*#__PURE__*/ Vue.extend({
+export const BModal = /*#__PURE__*/ defineComponent({
   name: NAME_MODAL,
   compatConfig: {
     MODE: 3,

--- a/src/components/modal/modal.spec.js
+++ b/src/components/modal/modal.spec.js
@@ -1,5 +1,6 @@
 import { createWrapper, mount } from '@vue/test-utils'
 import { waitNT, waitRAF } from '../../../tests/utils'
+import { getInstanceFromVNode } from '../../utils/get-instance-from-vnode'
 import { BModal } from './modal'
 import { BvModalEvent } from './helpers/bv-modal-event.class'
 
@@ -175,8 +176,8 @@ describe('modal', () => {
       expect(outer).toBeDefined()
       expect(outer).not.toBe(null)
 
-      expect(outer.__vue__).toBeDefined() // Target
-      expect(outer.__vue__.$options.name).toBe('BVTransporterTarget')
+      expect(getInstanceFromVNode(outer)).toBeDefined() // Target
+      expect(getInstanceFromVNode(outer).$options.name).toBe('BVTransporterTarget')
       expect(outer.parentElement).toBeDefined()
       expect(outer.parentElement).toBe(document.body)
 

--- a/src/components/modal/modal.spec.js
+++ b/src/components/modal/modal.spec.js
@@ -1,4 +1,5 @@
 import { createWrapper, mount } from '@vue/test-utils'
+import { isVue3 } from '../../vue'
 import { waitNT, waitRAF } from '../../../tests/utils'
 import { getInstanceFromVNode } from '../../utils/get-instance-from-vnode'
 import { BModal } from './modal'
@@ -177,7 +178,9 @@ describe('modal', () => {
       expect(outer).not.toBe(null)
 
       expect(getInstanceFromVNode(outer)).toBeDefined() // Target
-      expect(getInstanceFromVNode(outer).$options.name).toBe('BVTransporterTarget')
+      if (!isVue3) {
+        expect(getInstanceFromVNode(outer).$options.name).toBe('BVTransporterTarget')
+      }
       expect(outer.parentElement).toBeDefined()
       expect(outer.parentElement).toBe(document.body)
 

--- a/src/components/modal/modal.spec.js
+++ b/src/components/modal/modal.spec.js
@@ -1043,6 +1043,7 @@ describe('modal', () => {
   describe('focus management', () => {
     it('returns focus to previous active element when return focus not set and not using v-b-toggle', async () => {
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [
             h('button', { class: 'trigger', attrs: { id: 'trigger', type: 'button' } }, 'trigger'),
@@ -1116,6 +1117,7 @@ describe('modal', () => {
 
     it('returns focus to element specified in toggle() method', async () => {
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [
             h('button', { class: 'trigger', attrs: { id: 'trigger', type: 'button' } }, 'trigger'),
@@ -1201,6 +1203,7 @@ describe('modal', () => {
 
     it('if focus leaves modal it returns to modal', async () => {
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [
             h('button', { attrs: { id: 'button', type: 'button' } }, 'Button'),
@@ -1282,6 +1285,7 @@ describe('modal', () => {
 
     it('it allows focus for elements when "no-enforce-focus" enabled', async () => {
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [
             h('button', { attrs: { id: 'button1', type: 'button' } }, 'Button 1'),
@@ -1350,6 +1354,7 @@ describe('modal', () => {
 
     it('it allows focus for elements in "ignore-enforce-focus-selector" prop', async () => {
       const App = {
+        compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
         render(h) {
           return h('div', [
             h('button', { attrs: { id: 'button1', type: 'button' } }, 'Button 1'),

--- a/src/components/nav/nav-form.js
+++ b/src/components/nav/nav-form.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_NAV_FORM } from '../../constants/components'
 import { PROP_TYPE_ARRAY_OBJECT_STRING } from '../../constants/props'
 import { omit, sortKeys } from '../../utils/object'
@@ -20,7 +20,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BNavForm = /*#__PURE__*/ Vue.extend({
+export const BNavForm = /*#__PURE__*/ defineComponent({
   name: NAME_NAV_FORM,
   functional: true,
   props,

--- a/src/components/nav/nav-item-dropdown.js
+++ b/src/components/nav/nav-item-dropdown.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_NAV_ITEM_DROPDOWN } from '../../constants/components'
 import { SLOT_NAME_BUTTON_CONTENT, SLOT_NAME_DEFAULT, SLOT_NAME_TEXT } from '../../constants/slots'
 import { htmlOrText } from '../../utils/html'
@@ -32,7 +32,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BNavItemDropdown = /*#__PURE__*/ Vue.extend({
+export const BNavItemDropdown = /*#__PURE__*/ defineComponent({
   name: NAME_NAV_ITEM_DROPDOWN,
   mixins: [idMixin, dropdownMixin, normalizeSlotMixin],
   props,

--- a/src/components/nav/nav-item.js
+++ b/src/components/nav/nav-item.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_NAV_ITEM } from '../../constants/components'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_OBJECT } from '../../constants/props'
 import { omit, sortKeys } from '../../utils/object'
@@ -21,7 +21,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BNavItem = /*#__PURE__*/ Vue.extend({
+export const BNavItem = /*#__PURE__*/ defineComponent({
   name: NAME_NAV_ITEM,
   functional: true,
   props,

--- a/src/components/nav/nav-text.js
+++ b/src/components/nav/nav-text.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_NAV_TEXT } from '../../constants/components'
 
 // --- Props ---
@@ -8,7 +8,7 @@ export const props = {}
 // --- Main component ---
 
 // @vue/component
-export const BNavText = /*#__PURE__*/ Vue.extend({
+export const BNavText = /*#__PURE__*/ defineComponent({
   name: NAME_NAV_TEXT,
   functional: true,
   props,

--- a/src/components/nav/nav.js
+++ b/src/components/nav/nav.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_NAV } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -31,7 +31,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BNav = /*#__PURE__*/ Vue.extend({
+export const BNav = /*#__PURE__*/ defineComponent({
   name: NAME_NAV,
   functional: true,
   props,

--- a/src/components/navbar/navbar-brand.js
+++ b/src/components/navbar/navbar-brand.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_NAVBAR_BRAND } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { omit, sortKeys } from '../../utils/object'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BNavbarBrand = /*#__PURE__*/ Vue.extend({
+export const BNavbarBrand = /*#__PURE__*/ defineComponent({
   name: NAME_NAVBAR_BRAND,
   functional: true,
   props,

--- a/src/components/navbar/navbar-nav.js
+++ b/src/components/navbar/navbar-nav.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_NAVBAR_NAV } from '../../constants/components'
 import { pick } from '../../utils/object'
 import { makePropsConfigurable } from '../../utils/props'
@@ -21,7 +21,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BNavbarNav = /*#__PURE__*/ Vue.extend({
+export const BNavbarNav = /*#__PURE__*/ defineComponent({
   name: NAME_NAVBAR_NAV,
   functional: true,
   props,

--- a/src/components/navbar/navbar-toggle.js
+++ b/src/components/navbar/navbar-toggle.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_COLLAPSE, NAME_NAVBAR_TOGGLE } from '../../constants/components'
 import { EVENT_NAME_CLICK } from '../../constants/events'
 import { PROP_TYPE_ARRAY_STRING, PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
@@ -30,7 +30,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BNavbarToggle = /*#__PURE__*/ Vue.extend({
+export const BNavbarToggle = /*#__PURE__*/ defineComponent({
   name: NAME_NAVBAR_TOGGLE,
   compatConfig: {
     MODE: 3,

--- a/src/components/navbar/navbar-toggle.js
+++ b/src/components/navbar/navbar-toggle.js
@@ -32,6 +32,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BNavbarToggle = /*#__PURE__*/ Vue.extend({
   name: NAME_NAVBAR_TOGGLE,
+  compatConfig: {
+    MODE: 3,
+    CUSTOM_DIR: 'suppress-warning'
+  },
   directives: { VBToggle },
   mixins: [listenOnRootMixin, normalizeSlotMixin],
   props,

--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -33,7 +33,7 @@ export const BNavbar = /*#__PURE__*/ Vue.extend({
   name: NAME_NAVBAR,
   mixins: [normalizeSlotMixin],
   provide() {
-    return { bvNavbar: this }
+    return { getBvNavbar: () => this }
   },
   props,
   computed: {

--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_NAVBAR } from '../../constants/components'
 import {
   PROP_TYPE_BOOLEAN,
@@ -29,7 +29,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BNavbar = /*#__PURE__*/ Vue.extend({
+export const BNavbar = /*#__PURE__*/ defineComponent({
   name: NAME_NAVBAR,
   mixins: [normalizeSlotMixin],
   provide() {

--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_OVERLAY } from '../../constants/components'
 import { EVENT_NAME_CLICK, EVENT_NAME_HIDDEN, EVENT_NAME_SHOWN } from '../../constants/events'
 import {
@@ -52,7 +52,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BOverlay = /*#__PURE__*/ Vue.extend({
+export const BOverlay = /*#__PURE__*/ defineComponent({
   name: NAME_OVERLAY,
   mixins: [normalizeSlotMixin],
   props,

--- a/src/components/pagination-nav/pagination-nav.js
+++ b/src/components/pagination-nav/pagination-nav.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_PAGINATION_NAV } from '../../constants/components'
 import { IS_BROWSER } from '../../constants/env'
 import { EVENT_NAME_CHANGE, EVENT_NAME_PAGE_CLICK } from '../../constants/events'
@@ -64,7 +64,7 @@ const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BPaginationNav = /*#__PURE__*/ Vue.extend({
+export const BPaginationNav = /*#__PURE__*/ defineComponent({
   name: NAME_PAGINATION_NAV,
   // The render function is brought in via the pagination mixin
   mixins: [paginationMixin],

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_PAGINATION } from '../../constants/components'
 import { EVENT_NAME_CHANGE, EVENT_NAME_PAGE_CLICK } from '../../constants/events'
 import { PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
@@ -39,7 +39,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BPagination = /*#__PURE__*/ Vue.extend({
+export const BPagination = /*#__PURE__*/ defineComponent({
   name: NAME_PAGINATION,
   // The render function is brought in via the `paginationMixin`
   mixins: [paginationMixin],

--- a/src/components/pagination/pagination.spec.js
+++ b/src/components/pagination/pagination.spec.js
@@ -662,6 +662,7 @@ describe('pagination', () => {
 
   it('clicking buttons updates the v-model', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       methods: {
         onPageClick(bvEvent, page) {
           // Prevent 3rd page from being selected

--- a/src/components/popover/helpers/bv-popover-template.js
+++ b/src/components/popover/helpers/bv-popover-template.js
@@ -1,10 +1,10 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { NAME_POPOVER_TEMPLATE } from '../../../constants/components'
 import { isFunction, isUndefinedOrNull } from '../../../utils/inspect'
 import { BVTooltipTemplate } from '../../tooltip/helpers/bv-tooltip-template'
 
 // @vue/component
-export const BVPopoverTemplate = /*#__PURE__*/ Vue.extend({
+export const BVPopoverTemplate = /*#__PURE__*/ defineComponent({
   name: NAME_POPOVER_TEMPLATE,
   extends: BVTooltipTemplate,
   computed: {

--- a/src/components/popover/helpers/bv-popover.js
+++ b/src/components/popover/helpers/bv-popover.js
@@ -10,7 +10,11 @@ import { BVTooltip } from '../../tooltip/helpers/bv-tooltip'
 import { BVPopoverTemplate } from './bv-popover-template'
 
 // @vue/component
-export const BVPopover = /*#__PURE__*/ Vue.extend({
+export const BVPopover = /*#__PURE__*/ defineComponent({
+  compatConfig: {
+    INSTANCE_LISTENERS: 'suppress-warning',
+    INSTANCE_EVENT_EMITTER: 'suppress-warning'
+  },
   name: NAME_POPOVER_HELPER,
   extends: BVTooltip,
   computed: {

--- a/src/components/popover/helpers/bv-popover.js
+++ b/src/components/popover/helpers/bv-popover.js
@@ -4,7 +4,7 @@
 // Handles trigger events, etc.
 // Instantiates template on demand
 
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { NAME_POPOVER_HELPER } from '../../../constants/components'
 import { BVTooltip } from '../../tooltip/helpers/bv-tooltip'
 import { BVPopoverTemplate } from './bv-popover-template'

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_POPOVER } from '../../constants/components'
 import { EVENT_NAME_CLICK } from '../../constants/events'
 import { PROP_TYPE_ARRAY_STRING, PROP_TYPE_STRING } from '../../constants/props'
@@ -23,7 +23,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BPopover = /*#__PURE__*/ Vue.extend({
+export const BPopover = /*#__PURE__*/ defineComponent({
   name: NAME_POPOVER,
   extends: BTooltip,
   inheritAttrs: false,

--- a/src/components/popover/popover.spec.js
+++ b/src/components/popover/popover.spec.js
@@ -4,6 +4,7 @@ import { BPopover } from './popover'
 
 // Our test application definition
 const App = {
+  compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
   props: [
     'triggers',
     'show',

--- a/src/components/progress/progress-bar.js
+++ b/src/components/progress/progress-bar.js
@@ -34,12 +34,15 @@ export const BProgressBar = /*#__PURE__*/ Vue.extend({
   name: NAME_PROGRESS_BAR,
   mixins: [normalizeSlotMixin],
   inject: {
-    bvProgress: {
-      default: /* istanbul ignore next */ () => ({})
+    getBvProgress: {
+      default: /* istanbul ignore next */ () => () => ({})
     }
   },
   props,
   computed: {
+    bvProgress() {
+      return this.getBvProgress()
+    },
     progressBarClasses() {
       const { computedAnimated, computedVariant } = this
       return [

--- a/src/components/progress/progress-bar.js
+++ b/src/components/progress/progress-bar.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_PROGRESS_BAR } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { htmlOrText } from '../../utils/html'
@@ -30,7 +30,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BProgressBar = /*#__PURE__*/ Vue.extend({
+export const BProgressBar = /*#__PURE__*/ defineComponent({
   name: NAME_PROGRESS_BAR,
   mixins: [normalizeSlotMixin],
   inject: {

--- a/src/components/progress/progress-bar.spec.js
+++ b/src/components/progress/progress-bar.spec.js
@@ -38,9 +38,9 @@ describe('progress-bar', () => {
   it('has class bg-info when parent variant=info', async () => {
     const wrapper = mount(BProgressBar, {
       provide: {
-        bvProgress: {
+        getBvProgress: () => ({
           variant: 'info'
-        }
+        })
       }
     })
 
@@ -53,9 +53,9 @@ describe('progress-bar', () => {
   it('has class bg-primary when prop variant=primary and parent variant=info', async () => {
     const wrapper = mount(BProgressBar, {
       provide: {
-        bvProgress: {
+        getBvProgress: () => ({
           variant: 'info'
-        }
+        })
       },
       propsData: {
         variant: 'primary'
@@ -83,9 +83,9 @@ describe('progress-bar', () => {
   it('has class progress-bar-striped when parent prop striped set', async () => {
     const wrapper = mount(BProgressBar, {
       provide: {
-        bvProgress: {
+        getBvProgress: () => ({
           striped: true
-        }
+        })
       }
     })
 
@@ -112,9 +112,9 @@ describe('progress-bar', () => {
   it('has class progress-bar-animated and progress-bar-striped when parent prop animated set', async () => {
     const wrapper = mount(BProgressBar, {
       provide: {
-        bvProgress: {
+        getBvProgress: () => ({
           animated: true
-        }
+        })
       }
     })
 
@@ -159,9 +159,9 @@ describe('progress-bar', () => {
   it('has max set when parent max set', async () => {
     const wrapper = mount(BProgressBar, {
       provide: {
-        bvProgress: {
+        getBvProgress: () => ({
           max: 50
-        }
+        })
       },
       propsData: {
         value: 25

--- a/src/components/progress/progress.js
+++ b/src/components/progress/progress.js
@@ -31,7 +31,7 @@ export const BProgress = /*#__PURE__*/ Vue.extend({
   name: NAME_PROGRESS,
   mixins: [normalizeSlotMixin],
   provide() {
-    return { bvProgress: this }
+    return { getBvProgress: () => this }
   },
   props,
   computed: {

--- a/src/components/progress/progress.js
+++ b/src/components/progress/progress.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_PROGRESS } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { omit, sortKeys } from '../../utils/object'
@@ -27,7 +27,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BProgress = /*#__PURE__*/ Vue.extend({
+export const BProgress = /*#__PURE__*/ defineComponent({
   name: NAME_PROGRESS,
   mixins: [normalizeSlotMixin],
   provide() {

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_COLLAPSE, NAME_SIDEBAR } from '../../constants/components'
 import { IS_BROWSER } from '../../constants/env'
 import { EVENT_NAME_CHANGE, EVENT_NAME_HIDDEN, EVENT_NAME_SHOWN } from '../../constants/events'
@@ -201,7 +201,7 @@ const renderBackdrop = (h, ctx) => {
 // --- Main component ---
 
 // @vue/component
-export const BSidebar = /*#__PURE__*/ Vue.extend({
+export const BSidebar = /*#__PURE__*/ defineComponent({
   name: NAME_SIDEBAR,
   compatConfig: {
     MODE: 3,

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -203,6 +203,11 @@ const renderBackdrop = (h, ctx) => {
 // @vue/component
 export const BSidebar = /*#__PURE__*/ Vue.extend({
   name: NAME_SIDEBAR,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [attrsMixin, idMixin, modelMixin, listenOnRootMixin, normalizeSlotMixin],
   inheritAttrs: false,
   props,

--- a/src/components/skeleton/skeleton-icon.js
+++ b/src/components/skeleton/skeleton-icon.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_SKELETON_ICON } from '../../constants/components'
 import { PROP_TYPE_OBJECT, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -18,7 +18,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BSkeletonIcon = /*#__PURE__*/ Vue.extend({
+export const BSkeletonIcon = /*#__PURE__*/ defineComponent({
   name: NAME_SKELETON_ICON,
   functional: true,
   props,

--- a/src/components/skeleton/skeleton-img.js
+++ b/src/components/skeleton/skeleton-img.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_SKELETON_IMG } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -23,7 +23,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BSkeletonImg = /*#__PURE__*/ Vue.extend({
+export const BSkeletonImg = /*#__PURE__*/ defineComponent({
   name: NAME_SKELETON_IMG,
   functional: true,
   props,

--- a/src/components/skeleton/skeleton-table.js
+++ b/src/components/skeleton/skeleton-table.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_SKELETON_TABLE } from '../../constants/components'
 import {
   PROP_TYPE_BOOLEAN,
@@ -32,7 +32,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BSkeletonTable = /*#__PURE__*/ Vue.extend({
+export const BSkeletonTable = /*#__PURE__*/ defineComponent({
   name: NAME_SKELETON_TABLE,
   functional: true,
   props,

--- a/src/components/skeleton/skeleton-wrapper.js
+++ b/src/components/skeleton/skeleton-wrapper.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_SKELETON_WRAPPER } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN } from '../../constants/props'
 import { SLOT_NAME_DEFAULT, SLOT_NAME_LOADING } from '../../constants/slots'
@@ -17,7 +17,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BSkeletonWrapper = /*#__PURE__*/ Vue.extend({
+export const BSkeletonWrapper = /*#__PURE__*/ defineComponent({
   name: NAME_SKELETON_WRAPPER,
   compatConfig: {
     MODE: 3,

--- a/src/components/skeleton/skeleton-wrapper.js
+++ b/src/components/skeleton/skeleton-wrapper.js
@@ -19,6 +19,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BSkeletonWrapper = /*#__PURE__*/ Vue.extend({
   name: NAME_SKELETON_WRAPPER,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { data, props, slots, scopedSlots }) {

--- a/src/components/skeleton/skeleton.js
+++ b/src/components/skeleton/skeleton.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_SKELETON } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -20,7 +20,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BSkeleton = /*#__PURE__*/ Vue.extend({
+export const BSkeleton = /*#__PURE__*/ defineComponent({
   name: NAME_SKELETON,
   functional: true,
   props,

--- a/src/components/spinner/spinner.js
+++ b/src/components/spinner/spinner.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_SPINNER } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../constants/props'
 import { SLOT_NAME_LABEL } from '../../constants/slots'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BSpinner = /*#__PURE__*/ Vue.extend({
+export const BSpinner = /*#__PURE__*/ defineComponent({
   name: NAME_SPINNER,
   compatConfig: {
     MODE: 3,

--- a/src/components/spinner/spinner.js
+++ b/src/components/spinner/spinner.js
@@ -24,6 +24,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BSpinner = /*#__PURE__*/ Vue.extend({
   name: NAME_SPINNER,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   functional: true,
   props,
   render(h, { props, data, slots, scopedSlots }) {

--- a/src/components/table/helpers/mixin-bottom-row.js
+++ b/src/components/table/helpers/mixin-bottom-row.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { SLOT_NAME_BOTTOM_ROW } from '../../../constants/slots'
 import { isFunction } from '../../../utils/inspect'
 import { BTr } from '../tr'
@@ -10,7 +10,7 @@ export const props = {}
 // --- Mixin ---
 
 // @vue/component
-export const bottomRowMixin = Vue.extend({
+export const bottomRowMixin = defineComponent({
   props,
   methods: {
     renderBottomRow() {

--- a/src/components/table/helpers/mixin-busy.js
+++ b/src/components/table/helpers/mixin-busy.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { MODEL_EVENT_NAME_PREFIX } from '../../../constants/events'
 import { PROP_TYPE_BOOLEAN } from '../../../constants/props'
 import { SLOT_NAME_TABLE_BUSY } from '../../../constants/slots'
@@ -22,7 +22,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const busyMixin = Vue.extend({
+export const busyMixin = defineComponent({
   props,
   data() {
     return {

--- a/src/components/table/helpers/mixin-caption.js
+++ b/src/components/table/helpers/mixin-caption.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { PROP_TYPE_STRING } from '../../../constants/props'
 import { SLOT_NAME_TABLE_CAPTION } from '../../../constants/slots'
 import { htmlOrText } from '../../../utils/html'
@@ -16,7 +16,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const captionMixin = Vue.extend({
+export const captionMixin = defineComponent({
   props,
   computed: {
     captionId() {

--- a/src/components/table/helpers/mixin-colgroup.js
+++ b/src/components/table/helpers/mixin-colgroup.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { SLOT_NAME_TABLE_COLGROUP } from '../../../constants/slots'
 
 // --- Props ---
@@ -8,7 +8,7 @@ export const props = {}
 // --- Mixin ---
 
 // @vue/component
-export const colgroupMixin = Vue.extend({
+export const colgroupMixin = defineComponent({
   methods: {
     renderColgroup() {
       const { computedFields: fields } = this

--- a/src/components/table/helpers/mixin-empty.js
+++ b/src/components/table/helpers/mixin-empty.js
@@ -8,6 +8,7 @@ import {
 import { htmlOrText } from '../../../utils/html'
 import { isFunction } from '../../../utils/inspect'
 import { makeProp } from '../../../utils/props'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 import { BTr } from '../tr'
 import { BTd } from '../td'
 
@@ -28,14 +29,14 @@ export const emptyMixin = Vue.extend({
   props,
   methods: {
     renderEmpty() {
-      const { computedItems: items } = this
+      const { computedItems: items, computedBusy } = safeVueInstance(this)
       const h = this.$createElement
 
       let $empty = h()
       if (
         this.showEmpty &&
         (!items || items.length === 0) &&
-        !(this.computedBusy && this.hasNormalizedSlot(SLOT_NAME_TABLE_BUSY))
+        !(computedBusy && this.hasNormalizedSlot(SLOT_NAME_TABLE_BUSY))
       ) {
         const {
           computedFields: fields,

--- a/src/components/table/helpers/mixin-empty.js
+++ b/src/components/table/helpers/mixin-empty.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../../../constants/props'
 import {
   SLOT_NAME_EMPTY,
@@ -25,7 +25,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const emptyMixin = Vue.extend({
+export const emptyMixin = defineComponent({
   props,
   methods: {
     renderEmpty() {

--- a/src/components/table/helpers/mixin-filtering.js
+++ b/src/components/table/helpers/mixin-filtering.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { NAME_TABLE } from '../../../constants/components'
 import { EVENT_NAME_FILTERED } from '../../../constants/events'
 import {
@@ -40,7 +40,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const filteringMixin = Vue.extend({
+export const filteringMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/components/table/helpers/mixin-filtering.js
+++ b/src/components/table/helpers/mixin-filtering.js
@@ -41,6 +41,10 @@ export const props = {
 
 // @vue/component
 export const filteringMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   props,
   data() {
     return {

--- a/src/components/table/helpers/mixin-items.js
+++ b/src/components/table/helpers/mixin-items.js
@@ -1,10 +1,12 @@
 import { Vue } from '../../../vue'
 import { EVENT_NAME_CONTEXT_CHANGED } from '../../../constants/events'
 import { PROP_TYPE_ARRAY, PROP_TYPE_STRING } from '../../../constants/props'
+import { useParentMixin } from '../../../mixins/use-parent'
 import { isArray, isFunction, isString } from '../../../utils/inspect'
 import { looseEqual } from '../../../utils/loose-equal'
 import { mathMax } from '../../../utils/math'
 import { makeModelMixin } from '../../../utils/model'
+
 import { toInteger } from '../../../utils/number'
 import { clone, sortKeys } from '../../../utils/object'
 import { makeProp } from '../../../utils/props'
@@ -42,7 +44,7 @@ export const props = sortKeys({
 
 // @vue/component
 export const itemsMixin = Vue.extend({
-  mixins: [modelMixin],
+  mixins: [modelMixin, useParentMixin],
   props,
   data() {
     const { items } = this
@@ -64,15 +66,15 @@ export const itemsMixin = Vue.extend({
       // Mainly for formatter lookup and use in `scopedSlots` for convenience
       // If the field has a formatter, it normalizes formatter to a
       // function ref or `undefined` if no formatter
-      const { $parent } = this
+      const { bvParent } = this
       return this.computedFields.reduce((obj, f) => {
         // We use object spread here so we don't mutate the original field object
         obj[f.key] = clone(f)
         if (f.formatter) {
           // Normalize formatter to a function ref or `undefined`
           let formatter = f.formatter
-          if (isString(formatter) && isFunction($parent[formatter])) {
-            formatter = $parent[formatter]
+          if (isString(formatter) && isFunction(bvParent[formatter])) {
+            formatter = bvParent[formatter]
           } else if (!isFunction(formatter)) {
             /* istanbul ignore next */
             formatter = undefined

--- a/src/components/table/helpers/mixin-items.js
+++ b/src/components/table/helpers/mixin-items.js
@@ -10,6 +10,7 @@ import { makeModelMixin } from '../../../utils/model'
 import { toInteger } from '../../../utils/number'
 import { clone, sortKeys } from '../../../utils/object'
 import { makeProp } from '../../../utils/props'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 import { normalizeFields } from './normalize-fields'
 
 // --- Constants ---
@@ -86,24 +87,26 @@ export const itemsMixin = Vue.extend({
       }, {})
     },
     computedItems() {
+      const { paginatedItems, sortedItems, filteredItems, localItems } = safeVueInstance(this)
       // Fallback if various mixins not provided
       return (
-        this.paginatedItems ||
-        this.sortedItems ||
-        this.filteredItems ||
-        this.localItems ||
+        paginatedItems ||
+        sortedItems ||
+        filteredItems ||
+        localItems ||
         /* istanbul ignore next */
         []
       ).slice()
     },
     context() {
+      const { perPage, currentPage } = safeVueInstance(this)
       // Current state of sorting, filtering and pagination props/values
       return {
         filter: this.localFilter,
         sortBy: this.localSortBy,
         sortDesc: this.localSortDesc,
-        perPage: mathMax(toInteger(this.perPage, 0), 0),
-        currentPage: mathMax(toInteger(this.currentPage, 0), 1),
+        perPage: mathMax(toInteger(perPage, 0), 0),
+        currentPage: mathMax(toInteger(currentPage, 0), 1),
         apiUrl: this.apiUrl
       }
     }

--- a/src/components/table/helpers/mixin-items.js
+++ b/src/components/table/helpers/mixin-items.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { EVENT_NAME_CONTEXT_CHANGED } from '../../../constants/events'
 import { PROP_TYPE_ARRAY, PROP_TYPE_STRING } from '../../../constants/props'
 import { useParentMixin } from '../../../mixins/use-parent'
@@ -44,7 +44,7 @@ export const props = sortKeys({
 // --- Mixin ---
 
 // @vue/component
-export const itemsMixin = Vue.extend({
+export const itemsMixin = defineComponent({
   mixins: [modelMixin, useParentMixin],
   props,
   data() {

--- a/src/components/table/helpers/mixin-pagination.js
+++ b/src/components/table/helpers/mixin-pagination.js
@@ -3,6 +3,7 @@ import { PROP_TYPE_NUMBER_STRING } from '../../../constants/props'
 import { mathMax } from '../../../utils/math'
 import { toInteger } from '../../../utils/number'
 import { makeProp } from '../../../utils/props'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 
 // --- Props ---
 
@@ -21,7 +22,8 @@ export const paginationMixin = Vue.extend({
       return this.hasProvider ? !!this.noProviderPaging : true
     },
     paginatedItems() {
-      let items = this.sortedItems || this.filteredItems || this.localItems || []
+      const { sortedItems, filteredItems, localItems } = safeVueInstance(this)
+      let items = sortedItems || filteredItems || localItems || []
       const currentPage = mathMax(toInteger(this.currentPage, 1), 1)
       const perPage = mathMax(toInteger(this.perPage, 0), 0)
       // Apply local pagination

--- a/src/components/table/helpers/mixin-pagination.js
+++ b/src/components/table/helpers/mixin-pagination.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { PROP_TYPE_NUMBER_STRING } from '../../../constants/props'
 import { mathMax } from '../../../utils/math'
 import { toInteger } from '../../../utils/number'
@@ -15,7 +15,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const paginationMixin = Vue.extend({
+export const paginationMixin = defineComponent({
   props,
   computed: {
     localPaging() {

--- a/src/components/table/helpers/mixin-provider.js
+++ b/src/components/table/helpers/mixin-provider.js
@@ -11,6 +11,7 @@ import { isArray, isFunction, isPromise } from '../../../utils/inspect'
 import { looseEqual } from '../../../utils/loose-equal'
 import { clone } from '../../../utils/object'
 import { makeProp } from '../../../utils/props'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 import { warn } from '../../../utils/warn'
 import { listenOnRootMixin } from '../../../mixins/listen-on-root'
 
@@ -100,11 +101,11 @@ export const providerMixin = Vue.extend({
   },
   methods: {
     refresh() {
-      const { items, refresh } = this
+      const { items, refresh, computedBusy } = safeVueInstance(this)
 
       // Public Method: Force a refresh of the provider function
       this.$off(EVENT_NAME_REFRESHED, refresh)
-      if (this.computedBusy) {
+      if (computedBusy) {
         // Can't force an update when forced busy by user (busy prop === true)
         if (this.localBusy && this.hasProvider) {
           // But if provider running (localBusy), re-schedule refresh once `refreshed` emitted
@@ -137,7 +138,7 @@ export const providerMixin = Vue.extend({
         return
       }
       // If table is busy, wait until refreshed before calling again
-      if (this.computedBusy) {
+      if (safeVueInstance(this).computedBusy) {
         // Schedule a new refresh once `refreshed` is emitted
         this.$nextTick(this.refresh)
         return

--- a/src/components/table/helpers/mixin-provider.js
+++ b/src/components/table/helpers/mixin-provider.js
@@ -37,6 +37,9 @@ export const props = {
 
 // @vue/component
 export const providerMixin = Vue.extend({
+  compatConfig: {
+    INSTANCE_LISTENERS: 'suppress-warning'
+  },
   mixins: [listenOnRootMixin],
   props,
   computed: {

--- a/src/components/table/helpers/mixin-provider.js
+++ b/src/components/table/helpers/mixin-provider.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { NAME_TABLE } from '../../../constants/components'
 import { EVENT_NAME_REFRESH, EVENT_NAME_REFRESHED } from '../../../constants/events'
 import {
@@ -36,7 +36,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const providerMixin = Vue.extend({
+export const providerMixin = defineComponent({
   compatConfig: {
     INSTANCE_LISTENERS: 'suppress-warning'
   },

--- a/src/components/table/helpers/mixin-selectable.js
+++ b/src/components/table/helpers/mixin-selectable.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import {
   EVENT_NAME_CONTEXT_CHANGED,
   EVENT_NAME_FILTERED,
@@ -36,7 +36,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const selectableMixin = Vue.extend({
+export const selectableMixin = defineComponent({
   props,
   data() {
     return {

--- a/src/components/table/helpers/mixin-sorting.js
+++ b/src/components/table/helpers/mixin-sorting.js
@@ -14,6 +14,7 @@ import {
 import { arrayIncludes } from '../../../utils/array'
 import { isFunction, isUndefinedOrNull } from '../../../utils/inspect'
 import { makeProp } from '../../../utils/props'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 import { stableSort } from '../../../utils/stable-sort'
 import { trim } from '../../../utils/string'
 import { defaultSortCompare } from './default-sort-compare'
@@ -93,9 +94,11 @@ export const sortingMixin = Vue.extend({
         sortCompareLocale: locale,
         sortNullLast: nullLast,
         sortCompare,
-        localSorting
-      } = this
-      const items = (this.filteredItems || this.localItems || []).slice()
+        localSorting,
+        filteredItems,
+        localItems
+      } = safeVueInstance(this)
+      const items = (filteredItems || localItems || []).slice()
       const localeOptions = { ...this.sortCompareOptions, usage: 'sort' }
 
       if (sortBy && localSorting) {

--- a/src/components/table/helpers/mixin-sorting.js
+++ b/src/components/table/helpers/mixin-sorting.js
@@ -71,6 +71,9 @@ export const props = {
 
 // @vue/component
 export const sortingMixin = Vue.extend({
+  compatConfig: {
+    INSTANCE_LISTENERS: 'suppress-warning'
+  },
   props,
   data() {
     return {

--- a/src/components/table/helpers/mixin-sorting.js
+++ b/src/components/table/helpers/mixin-sorting.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import {
   EVENT_NAME_HEAD_CLICKED,
   EVENT_NAME_SORT_CHANGED,
@@ -70,7 +70,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const sortingMixin = Vue.extend({
+export const sortingMixin = defineComponent({
   compatConfig: {
     INSTANCE_LISTENERS: 'suppress-warning'
   },

--- a/src/components/table/helpers/mixin-stacked.js
+++ b/src/components/table/helpers/mixin-stacked.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { PROP_TYPE_BOOLEAN_STRING } from '../../../constants/props'
 import { makeProp } from '../../../utils/props'
 
@@ -11,7 +11,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const stackedMixin = Vue.extend({
+export const stackedMixin = defineComponent({
   props,
   computed: {
     isStacked() {

--- a/src/components/table/helpers/mixin-table-renderer.js
+++ b/src/components/table/helpers/mixin-table-renderer.js
@@ -41,7 +41,7 @@ export const tableRendererMixin = Vue.extend({
   mixins: [attrsMixin],
   provide() {
     return {
-      bvTable: this
+      getBvTable: () => this
     }
   },
   // Don't place attributes on root element automatically,

--- a/src/components/table/helpers/mixin-table-renderer.js
+++ b/src/components/table/helpers/mixin-table-renderer.js
@@ -8,6 +8,7 @@ import {
 import { identity } from '../../../utils/identity'
 import { isBoolean } from '../../../utils/inspect'
 import { makeProp } from '../../../utils/props'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 import { toString } from '../../../utils/string'
 import { attrsMixin } from '../../../mixins/attrs'
 
@@ -49,6 +50,9 @@ export const tableRendererMixin = Vue.extend({
   inheritAttrs: false,
   props,
   computed: {
+    isTableSimple() {
+      return false
+    },
     // Layout related computed props
     isResponsive() {
       const { responsive } = this
@@ -75,14 +79,19 @@ export const tableRendererMixin = Vue.extend({
       return isStickyHeader && !isBoolean(isStickyHeader) ? { maxHeight: isStickyHeader } : {}
     },
     tableClasses() {
-      let { hover, tableVariant } = this
-      hover = this.isTableSimple
-        ? hover
-        : hover && this.computedItems.length > 0 && !this.computedBusy
+      let {
+        hover,
+        tableVariant,
+        selectableTableClasses,
+        stackedTableClasses,
+        tableClass,
+        computedBusy
+      } = safeVueInstance(this)
+      hover = this.isTableSimple ? hover : hover && this.computedItems.length > 0 && !computedBusy
 
       return [
         // User supplied classes
-        this.tableClass,
+        tableClass,
         // Styling classes
         {
           'table-striped': this.striped,
@@ -99,9 +108,9 @@ export const tableRendererMixin = Vue.extend({
         },
         tableVariant ? `${this.dark ? 'bg' : 'table'}-${tableVariant}` : '',
         // Stacked table classes
-        this.stackedTableClasses,
+        stackedTableClasses,
         // Selectable classes
-        this.selectableTableClasses
+        selectableTableClasses
       ]
     },
     tableAttrs() {
@@ -109,13 +118,14 @@ export const tableRendererMixin = Vue.extend({
         computedItems: items,
         filteredItems,
         computedFields: fields,
-        selectableTableAttrs
-      } = this
+        selectableTableAttrs,
+        computedBusy
+      } = safeVueInstance(this)
 
       const ariaAttrs = this.isTableSimple
         ? {}
         : {
-            'aria-busy': toString(this.computedBusy),
+            'aria-busy': toString(computedBusy),
             'aria-colcount': toString(fields.length),
             // Preserve user supplied `aria-describedby`, if provided
             'aria-describedby':
@@ -149,7 +159,7 @@ export const tableRendererMixin = Vue.extend({
       renderThead,
       renderTbody,
       renderTfoot
-    } = this
+    } = safeVueInstance(this)
 
     const $content = []
     if (this.isTableSimple) {

--- a/src/components/table/helpers/mixin-table-renderer.js
+++ b/src/components/table/helpers/mixin-table-renderer.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import {
   PROP_TYPE_ARRAY_OBJECT_STRING,
   PROP_TYPE_BOOLEAN,
@@ -38,7 +38,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const tableRendererMixin = Vue.extend({
+export const tableRendererMixin = defineComponent({
   mixins: [attrsMixin],
   provide() {
     return {

--- a/src/components/table/helpers/mixin-tbody-row.js
+++ b/src/components/table/helpers/mixin-tbody-row.js
@@ -10,6 +10,7 @@ import {
   PROP_TYPE_OBJECT_FUNCTION
 } from '../../../constants/props'
 import { SLOT_NAME_ROW_DETAILS } from '../../../constants/slots'
+import { useParentMixin } from '../../../mixins/use-parent'
 import { get } from '../../../utils/get'
 import { isFunction, isString, isUndefinedOrNull } from '../../../utils/inspect'
 import { makeProp } from '../../../utils/props'
@@ -31,30 +32,31 @@ export const props = {
 
 // @vue/component
 export const tbodyRowMixin = Vue.extend({
+  mixins: [useParentMixin],
   props,
   methods: {
     // Methods for computing classes, attributes and styles for table cells
     getTdValues(item, key, tdValue, defaultValue) {
-      const { $parent } = this
+      const { bvParent } = this
       if (tdValue) {
         const value = get(item, key, '')
         if (isFunction(tdValue)) {
           return tdValue(value, key, item)
-        } else if (isString(tdValue) && isFunction($parent[tdValue])) {
-          return $parent[tdValue](value, key, item)
+        } else if (isString(tdValue) && isFunction(bvParent[tdValue])) {
+          return bvParent[tdValue](value, key, item)
         }
         return tdValue
       }
       return defaultValue
     },
     getThValues(item, key, thValue, type, defaultValue) {
-      const { $parent } = this
+      const { bvParent } = this
       if (thValue) {
         const value = get(item, key, '')
         if (isFunction(thValue)) {
           return thValue(value, key, item, type)
-        } else if (isString(thValue) && isFunction($parent[thValue])) {
-          return $parent[thValue](value, key, item, type)
+        } else if (isString(thValue) && isFunction(bvParent[thValue])) {
+          return bvParent[thValue](value, key, item, type)
         }
         return thValue
       }

--- a/src/components/table/helpers/mixin-tbody-row.js
+++ b/src/components/table/helpers/mixin-tbody-row.js
@@ -14,6 +14,7 @@ import { useParentMixin } from '../../../mixins/use-parent'
 import { get } from '../../../utils/get'
 import { isFunction, isString, isUndefinedOrNull } from '../../../utils/inspect'
 import { makeProp } from '../../../utils/props'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 import { toString } from '../../../utils/string'
 import { BTr } from '../tr'
 import { BTd } from '../td'
@@ -160,7 +161,7 @@ export const tbodyRowMixin = Vue.extend({
       }
       // If table supports selectable mode, then add in the following scope
       // this.supportsSelectableRows will be undefined if mixin isn't loaded
-      if (this.supportsSelectableRows) {
+      if (safeVueInstance(this).supportsSelectableRows) {
         slotScope.rowSelected = this.isRowSelected(rowIndex)
         slotScope.selectRow = () => this.selectRow(rowIndex)
         slotScope.unselectRow = () => this.unselectRow(rowIndex)
@@ -193,13 +194,13 @@ export const tbodyRowMixin = Vue.extend({
         currentPage,
         perPage,
         tbodyTrClass,
-        tbodyTrAttr
-      } = this
+        tbodyTrAttr,
+        hasSelectableRowClick
+      } = safeVueInstance(this)
       const h = this.$createElement
       const hasDetailsSlot = this.hasNormalizedSlot(SLOT_NAME_ROW_DETAILS)
       const rowShowDetails = item[FIELD_KEY_SHOW_DETAILS] && hasDetailsSlot
-      const hasRowClickHandler =
-        this.$listeners[EVENT_NAME_ROW_CLICKED] || this.hasSelectableRowClick
+      const hasRowClickHandler = this.$listeners[EVENT_NAME_ROW_CLICKED] || hasSelectableRowClick
 
       // We can return more than one TR if rowDetails enabled
       const $rows = []
@@ -232,8 +233,12 @@ export const tbodyRowMixin = Vue.extend({
       const rowId = primaryKeyValue ? this.safeId(`_row_${primaryKeyValue}`) : null
 
       // Selectable classes and attributes
-      const selectableClasses = this.selectableRowClasses ? this.selectableRowClasses(rowIndex) : {}
-      const selectableAttrs = this.selectableRowAttrs ? this.selectableRowAttrs(rowIndex) : {}
+      const selectableClasses = safeVueInstance(this).selectableRowClasses
+        ? this.selectableRowClasses(rowIndex)
+        : {}
+      const selectableAttrs = safeVueInstance(this).selectableRowAttrs
+        ? this.selectableRowAttrs(rowIndex)
+        : {}
 
       // Additional classes and attributes
       const userTrClasses = isFunction(tbodyTrClass) ? tbodyTrClass(item, 'row') : tbodyTrClass
@@ -282,7 +287,7 @@ export const tbodyRowMixin = Vue.extend({
         }
         // If table supports selectable mode, then add in the following scope
         // this.supportsSelectableRows will be undefined if mixin isn't loaded
-        if (this.supportsSelectableRows) {
+        if (safeVueInstance(this).supportsSelectableRows) {
           detailsScope.rowSelected = this.isRowSelected(rowIndex)
           detailsScope.selectRow = () => this.selectRow(rowIndex)
           detailsScope.unselectRow = () => this.unselectRow(rowIndex)

--- a/src/components/table/helpers/mixin-tbody-row.js
+++ b/src/components/table/helpers/mixin-tbody-row.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { Vue, isVue3 } from '../../../vue'
 import {
   EVENT_NAME_ROW_CLICKED,
   EVENT_NAME_ROW_HOVERED,
@@ -33,6 +33,7 @@ export const props = {
 
 // @vue/component
 export const tbodyRowMixin = Vue.extend({
+  compatConfig: { MODE: 3, INSTANCE_LISTENERS: 'suppress-warning' },
   mixins: [useParentMixin],
   props,
   methods: {
@@ -78,7 +79,11 @@ export const tbodyRowMixin = Vue.extend({
       // Returns a function to toggle a row's details slot
       return () => {
         if (hasDetailsSlot) {
-          this.$set(item, FIELD_KEY_SHOW_DETAILS, !item[FIELD_KEY_SHOW_DETAILS])
+          if (isVue3) {
+            item[FIELD_KEY_SHOW_DETAILS] = !item[FIELD_KEY_SHOW_DETAILS]
+          } else {
+            this.$set(item, FIELD_KEY_SHOW_DETAILS, !item[FIELD_KEY_SHOW_DETAILS])
+          }
         }
       }
     },

--- a/src/components/table/helpers/mixin-tbody-row.js
+++ b/src/components/table/helpers/mixin-tbody-row.js
@@ -1,4 +1,4 @@
-import { Vue, isVue3 } from '../../../vue'
+import { defineComponent, isVue3 } from '../../../vue'
 import {
   EVENT_NAME_ROW_CLICKED,
   EVENT_NAME_ROW_HOVERED,
@@ -32,7 +32,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const tbodyRowMixin = Vue.extend({
+export const tbodyRowMixin = defineComponent({
   compatConfig: { MODE: 3, INSTANCE_LISTENERS: 'suppress-warning' },
   mixins: [useParentMixin],
   props,

--- a/src/components/table/helpers/mixin-tbody.js
+++ b/src/components/table/helpers/mixin-tbody.js
@@ -16,6 +16,7 @@ import {
 import { PROP_TYPE_ARRAY_OBJECT_STRING } from '../../../constants/props'
 import { arrayIncludes, from as arrayFrom } from '../../../utils/array'
 import { attemptFocus, closest, isActiveElement, isElement } from '../../../utils/dom'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 import { stopEvent } from '../../../utils/events'
 import { sortKeys } from '../../../utils/object'
 import { makeProp, pluckProps } from '../../../utils/props'
@@ -157,10 +158,16 @@ export const tbodyMixin = Vue.extend({
     //   Row hover handlers are handled by the tbody-row mixin
     //   As mouseenter/mouseleave events do not bubble
     renderTbody() {
-      const { computedItems: items, renderBusy, renderTopRow, renderEmpty, renderBottomRow } = this
+      const {
+        computedItems: items,
+        renderBusy,
+        renderTopRow,
+        renderEmpty,
+        renderBottomRow,
+        hasSelectableRowClick
+      } = safeVueInstance(this)
       const h = this.$createElement
-      const hasRowClickHandler =
-        this.hasListener(EVENT_NAME_ROW_CLICKED) || this.hasSelectableRowClick
+      const hasRowClickHandler = this.hasListener(EVENT_NAME_ROW_CLICKED) || hasSelectableRowClick
 
       // Prepare the tbody rows
       const $rows = []

--- a/src/components/table/helpers/mixin-tbody.js
+++ b/src/components/table/helpers/mixin-tbody.js
@@ -41,6 +41,11 @@ export const props = sortKeys({
 
 // @vue/component
 export const tbodyMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    V_FOR_REF: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [tbodyRowMixin],
   props,
   beforeDestroy() {

--- a/src/components/table/helpers/mixin-tbody.js
+++ b/src/components/table/helpers/mixin-tbody.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import {
   EVENT_NAME_ROW_CLICKED,
   EVENT_NAME_ROW_CONTEXTMENU,
@@ -40,7 +40,7 @@ export const props = sortKeys({
 // --- Mixin ---
 
 // @vue/component
-export const tbodyMixin = Vue.extend({
+export const tbodyMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     V_FOR_REF: 'suppress-warning',

--- a/src/components/table/helpers/mixin-tfoot.js
+++ b/src/components/table/helpers/mixin-tfoot.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import {
   PROP_TYPE_ARRAY_OBJECT_STRING,
   PROP_TYPE_BOOLEAN,
@@ -24,7 +24,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const tfootMixin = Vue.extend({
+export const tfootMixin = defineComponent({
   props,
   methods: {
     renderTFootCustom() {

--- a/src/components/table/helpers/mixin-thead.js
+++ b/src/components/table/helpers/mixin-thead.js
@@ -9,6 +9,7 @@ import { identity } from '../../../utils/identity'
 import { isUndefinedOrNull } from '../../../utils/inspect'
 import { noop } from '../../../utils/noop'
 import { makeProp } from '../../../utils/props'
+import { safeVueInstance } from '../../../utils/safe-vue-instance'
 import { startCase } from '../../../utils/string'
 import { BThead } from '../thead'
 import { BTfoot } from '../tfoot'
@@ -68,7 +69,7 @@ export const theadMixin = Vue.extend({
         footVariant,
         headRowVariant,
         footRowVariant
-      } = this
+      } = safeVueInstance(this)
       const h = this.$createElement
 
       // In always stacked mode, we don't bother rendering the head/foot

--- a/src/components/table/helpers/mixin-thead.js
+++ b/src/components/table/helpers/mixin-thead.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { EVENT_NAME_HEAD_CLICKED } from '../../../constants/events'
 import { CODE_ENTER, CODE_SPACE } from '../../../constants/key-codes'
 import { PROP_TYPE_ARRAY_OBJECT_STRING, PROP_TYPE_STRING } from '../../../constants/props'
@@ -38,7 +38,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const theadMixin = Vue.extend({
+export const theadMixin = defineComponent({
   props,
   methods: {
     fieldClasses(field) {

--- a/src/components/table/helpers/mixin-top-row.js
+++ b/src/components/table/helpers/mixin-top-row.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { SLOT_NAME_TOP_ROW } from '../../../constants/slots'
 import { isFunction } from '../../../utils/inspect'
 import { BTr } from '../tr'
@@ -10,7 +10,7 @@ export const props = {}
 // --- Mixin ---
 
 // @vue/component
-export const topRowMixin = Vue.extend({
+export const topRowMixin = defineComponent({
   methods: {
     renderTopRow() {
       const { computedFields: fields, stacked, tbodyTrClass, tbodyTrAttr } = this

--- a/src/components/table/table-lite.js
+++ b/src/components/table/table-lite.js
@@ -58,5 +58,6 @@ export const BTableLite = /*#__PURE__*/ Vue.extend({
     colgroupMixin
   ],
   props
+
   // Render function is provided by `tableRendererMixin`
 })

--- a/src/components/table/table-lite.js
+++ b/src/components/table/table-lite.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TABLE_LITE } from '../../constants/components'
 import { sortKeys } from '../../utils/object'
 import { makePropsConfigurable } from '../../utils/props'
@@ -35,7 +35,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BTableLite = /*#__PURE__*/ Vue.extend({
+export const BTableLite = /*#__PURE__*/ defineComponent({
   name: NAME_TABLE_LITE,
   // Order of mixins is important!
   // They are merged from first to last, followed by this component

--- a/src/components/table/table-provider.spec.js
+++ b/src/components/table/table-provider.spec.js
@@ -351,6 +351,7 @@ describe('table > provider functions', () => {
     // that prop with the same object reference
     // https://forum.vuejs.org/t/vue-test-utils-watchers-on-object-properties-not-triggered/50900/11?u=tmorehouse
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       data() {
         return {
           filter: {

--- a/src/components/table/table-simple.js
+++ b/src/components/table/table-simple.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TABLE_SIMPLE } from '../../constants/components'
 import { sortKeys } from '../../utils/object'
 import { makePropsConfigurable } from '../../utils/props'
@@ -23,7 +23,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BTableSimple = /*#__PURE__*/ Vue.extend({
+export const BTableSimple = /*#__PURE__*/ defineComponent({
   name: NAME_TABLE_SIMPLE,
   // Order of mixins is important!
   // They are merged from first to last, followed by this component

--- a/src/components/table/table-tbody-row-events.spec.js
+++ b/src/components/table/table-tbody-row-events.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { isVue3 } from '../../vue'
 import { waitNT } from '../../../tests/utils'
 import { BTable } from './table'
 
@@ -245,6 +246,11 @@ describe('table > tbody row events', () => {
   })
 
   it('should not emit row-hovered event when a row is hovered and no listener', async () => {
+    if (isVue3) {
+      // We can't track if we have an event listener in vue3 so we skip this test for vue 3
+      return
+    }
+
     const wrapper = mount(BTable, {
       propsData: {
         fields: testFields,
@@ -309,6 +315,11 @@ describe('table > tbody row events', () => {
   })
 
   it('should not emit row-unhovered event when a row is hovered and no listener', async () => {
+    if (isVue3) {
+      // We can't track if we have an event listener in vue3 so we skip this test for vue 3
+      return
+    }
+
     const wrapper = mount(BTable, {
       propsData: {
         fields: testFields,

--- a/src/components/table/table-tbody-transition.spec.js
+++ b/src/components/table/table-tbody-transition.spec.js
@@ -4,7 +4,9 @@ import { isVue3 } from '../../vue'
 import { BTable } from './table'
 
 // Stub `<transition-group>` component
-vtuConfig.stubs['transition-group'] = TransitionGroupStub
+if (!isVue3) {
+  vtuConfig.stubs['transition-group'] = TransitionGroupStub
+}
 
 const testItems = [{ a: 1, b: 2, c: 3 }, { a: 5, b: 5, c: 6 }, { a: 7, b: 8, c: 9 }]
 const testFields = ['a', 'b', 'c']

--- a/src/components/table/table-tbody-transition.spec.js
+++ b/src/components/table/table-tbody-transition.spec.js
@@ -1,5 +1,6 @@
 import { config as vtuConfig, mount } from '@vue/test-utils'
 import { TransitionGroupStub } from '../../../tests/components'
+import { isVue3 } from '../../vue'
 import { BTable } from './table'
 
 // Stub `<transition-group>` component
@@ -9,6 +10,14 @@ const testItems = [{ a: 1, b: 2, c: 3 }, { a: 5, b: 5, c: 6 }, { a: 7, b: 8, c: 
 const testFields = ['a', 'b', 'c']
 
 describe('table > tbody transition', () => {
+  if (isVue3) {
+    // @vue/test-utils does not support stubbing transition, so impossible to test ATM
+
+    // adding dummy test to keep jest happy
+    it('skipped due to vue3', () => {})
+    return
+  }
+
   it('tbody should not be a transition-group component by default', async () => {
     const wrapper = mount(BTable, {
       attachTo: document.body,

--- a/src/components/table/table-thead-events.spec.js
+++ b/src/components/table/table-thead-events.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { isVue3 } from '../../vue'
 import { BTable } from './table'
 
 const testItems = [{ a: 1, b: 2, c: 3 }]
@@ -6,6 +7,10 @@ const testFields = [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }, { key: '
 
 describe('table > thead events', () => {
   it('should not emit head-clicked event when a head cell is clicked and no head-clicked listener', async () => {
+    if (isVue3) {
+      // We can't track if we have an event listener in vue3 so we skip this test for vue 3
+      return
+    }
     const wrapper = mount(BTable, {
       propsData: {
         fields: testFields,

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TABLE } from '../../constants/components'
 import { sortKeys } from '../../utils/object'
 import { makePropsConfigurable } from '../../utils/props'
@@ -53,7 +53,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BTable = /*#__PURE__*/ Vue.extend({
+export const BTable = /*#__PURE__*/ defineComponent({
   name: NAME_TABLE,
   // Order of mixins is important!
   // They are merged from first to last, followed by this component

--- a/src/components/table/tbody.js
+++ b/src/components/table/tbody.js
@@ -27,18 +27,21 @@ export const BTbody = /*#__PURE__*/ Vue.extend({
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   provide() {
     return {
-      bvTableRowGroup: this
+      getBvTableRowGroup: () => this
     }
   },
   inject: {
     // Sniffed by `<b-tr>` / `<b-td>` / `<b-th>`
-    bvTable: {
-      default: /* istanbul ignore next */ () => ({})
+    getBvTable: {
+      default: /* istanbul ignore next */ () => () => ({})
     }
   },
   inheritAttrs: false,
   props,
   computed: {
+    bvTable() {
+      return this.getBvTable()
+    },
     // Sniffed by `<b-tr>` / `<b-td>` / `<b-th>`
     isTbody() {
       return true

--- a/src/components/table/tbody.js
+++ b/src/components/table/tbody.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TBODY } from '../../constants/components'
 import { PROP_TYPE_OBJECT } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 //   In Bootstrap v5, we won't need "sniffing" as table element variants properly inherit
 //   to the child elements, so this can be converted to a functional component
 // @vue/component
-export const BTbody = /*#__PURE__*/ Vue.extend({
+export const BTbody = /*#__PURE__*/ defineComponent({
   name: NAME_TBODY,
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   provide() {

--- a/src/components/table/td.js
+++ b/src/components/table/td.js
@@ -45,13 +45,16 @@ export const BTd = /*#__PURE__*/ Vue.extend({
   // Mixin order is important!
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   inject: {
-    bvTableTr: {
-      default: /* istanbul ignore next */ () => ({})
+    getBvTableTr: {
+      default: /* istanbul ignore next */ () => () => ({})
     }
   },
   inheritAttrs: false,
   props,
   computed: {
+    bvTableTr() {
+      return this.getBvTableTr()
+    },
     // Overridden by `<b-th>`
     tag() {
       return 'td'

--- a/src/components/table/td.js
+++ b/src/components/table/td.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TABLE_CELL } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { isTag } from '../../utils/dom'
@@ -40,7 +40,7 @@ export const props = makePropsConfigurable(
 //   In Bootstrap v5, we won't need "sniffing" as table element variants properly inherit
 //   to the child elements, so this can be converted to a functional component
 // @vue/component
-export const BTd = /*#__PURE__*/ Vue.extend({
+export const BTd = /*#__PURE__*/ defineComponent({
   name: NAME_TABLE_CELL,
   // Mixin order is important!
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],

--- a/src/components/table/tfoot.js
+++ b/src/components/table/tfoot.js
@@ -27,18 +27,21 @@ export const BTfoot = /*#__PURE__*/ Vue.extend({
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   provide() {
     return {
-      bvTableRowGroup: this
+      getBvTableRowGroup: () => this
     }
   },
   inject: {
     // Sniffed by `<b-tr>` / `<b-td>` / `<b-th>`
-    bvTable: {
-      default: /* istanbul ignore next */ () => ({})
+    getBvTable: {
+      default: /* istanbul ignore next */ () => () => ({})
     }
   },
   inheritAttrs: false,
   props,
   computed: {
+    bvTable() {
+      return this.getBvTable()
+    },
     // Sniffed by `<b-tr>` / `<b-td>` / `<b-th>`
     isTfoot() {
       return true

--- a/src/components/table/tfoot.js
+++ b/src/components/table/tfoot.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TFOOT } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -22,7 +22,7 @@ export const props = makePropsConfigurable(
 //   In Bootstrap v5, we won't need "sniffing" as table element variants properly inherit
 //   to the child elements, so this can be converted to a functional component
 // @vue/component
-export const BTfoot = /*#__PURE__*/ Vue.extend({
+export const BTfoot = /*#__PURE__*/ defineComponent({
   name: NAME_TFOOT,
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   provide() {

--- a/src/components/table/th.js
+++ b/src/components/table/th.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TH } from '../../constants/components'
 import { makePropsConfigurable } from '../../utils/props'
 import { BTd, props as BTdProps } from './td'
@@ -13,7 +13,7 @@ export const props = makePropsConfigurable(BTdProps, NAME_TH)
 //   In Bootstrap v5, we won't need "sniffing" as table element variants properly inherit
 //   to the child elements, so this can be converted to a functional component
 // @vue/component
-export const BTh = /*#__PURE__*/ Vue.extend({
+export const BTh = /*#__PURE__*/ defineComponent({
   name: NAME_TH,
   extends: BTd,
   props,

--- a/src/components/table/thead.js
+++ b/src/components/table/thead.js
@@ -28,18 +28,21 @@ export const BThead = /*#__PURE__*/ Vue.extend({
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   provide() {
     return {
-      bvTableRowGroup: this
+      getBvTableRowGroup: () => this
     }
   },
   inject: {
     // Sniffed by `<b-tr>` / `<b-td>` / `<b-th>`
-    bvTable: {
-      default: /* istanbul ignore next */ () => ({})
+    getBvTable: {
+      default: /* istanbul ignore next */ () => () => ({})
     }
   },
   inheritAttrs: false,
   props,
   computed: {
+    bvTable() {
+      return this.getBvTable()
+    },
     // Sniffed by `<b-tr>` / `<b-td>` / `<b-th>`
     isThead() {
       return true

--- a/src/components/table/thead.js
+++ b/src/components/table/thead.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_THEAD } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -23,7 +23,7 @@ export const props = makePropsConfigurable(
 //   In Bootstrap v5, we won't need "sniffing" as table element variants properly inherit
 //   to the child elements, so this can be converted to a functional component
 // @vue/component
-export const BThead = /*#__PURE__*/ Vue.extend({
+export const BThead = /*#__PURE__*/ defineComponent({
   name: NAME_THEAD,
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   provide() {

--- a/src/components/table/tr.js
+++ b/src/components/table/tr.js
@@ -31,17 +31,20 @@ export const BTr = /*#__PURE__*/ Vue.extend({
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   provide() {
     return {
-      bvTableTr: this
+      getBvTableTr: () => this
     }
   },
   inject: {
-    bvTableRowGroup: {
-      default: /* istanbul ignore next */ () => ({})
+    getBvTableRowGroup: {
+      default: /* istanbul ignore next */ () => () => ({})
     }
   },
   inheritAttrs: false,
   props,
   computed: {
+    bvTableRowGroup() {
+      return this.getBvTableRowGroup()
+    },
     // Sniffed by `<b-td>` / `<b-th>`
     inTbody() {
       return this.bvTableRowGroup.isTbody

--- a/src/components/table/tr.js
+++ b/src/components/table/tr.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TR } from '../../constants/components'
 import { PROP_TYPE_STRING } from '../../constants/props'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
@@ -26,7 +26,7 @@ export const props = makePropsConfigurable(
 //   In Bootstrap v5, we won't need "sniffing" as table element variants properly inherit
 //   to the child elements, so this can be converted to a functional component
 // @vue/component
-export const BTr = /*#__PURE__*/ Vue.extend({
+export const BTr = /*#__PURE__*/ defineComponent({
   name: NAME_TR,
   mixins: [attrsMixin, listenersMixin, normalizeSlotMixin],
   provide() {

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -47,8 +47,8 @@ export const BTab = /*#__PURE__*/ Vue.extend({
   name: NAME_TAB,
   mixins: [idMixin, normalizeSlotMixin],
   inject: {
-    bvTabs: {
-      default: () => ({})
+    getBvTabs: {
+      default: () => () => ({})
     }
   },
   props,
@@ -58,6 +58,9 @@ export const BTab = /*#__PURE__*/ Vue.extend({
     }
   },
   computed: {
+    bvTabs() {
+      return this.getBvTabs()
+    },
     // For parent sniffing of child
     _isTab() {
       return true

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TAB } from '../../constants/components'
 import { MODEL_EVENT_NAME_PREFIX } from '../../constants/events'
 import {
@@ -43,7 +43,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BTab = /*#__PURE__*/ Vue.extend({
+export const BTab = /*#__PURE__*/ defineComponent({
   name: NAME_TAB,
   compatConfig: {
     MODE: 3,

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -45,6 +45,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BTab = /*#__PURE__*/ Vue.extend({
   name: NAME_TAB,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [idMixin, normalizeSlotMixin],
   inject: {
     getBvTabs: {

--- a/src/components/tabs/tab.spec.js
+++ b/src/components/tabs/tab.spec.js
@@ -125,12 +125,12 @@ describe('tab', () => {
     const wrapper = mount(BTab, {
       provide() {
         return {
-          bvTabs: {
+          getBvTabs: () => ({
             fade: false,
             lazy: false,
             card: true,
             noKeyNav: true
-          }
+          })
         }
       }
     })
@@ -147,12 +147,12 @@ describe('tab', () => {
     const wrapper = mount(BTab, {
       provide() {
         return {
-          bvTabs: {
+          getBvTabs: () => ({
             fade: false,
             lazy: false,
             card: true,
             noKeyNav: true
-          }
+          })
         }
       },
       propsData: {
@@ -174,7 +174,7 @@ describe('tab', () => {
     const wrapper = mount(BTab, {
       provide() {
         return {
-          bvTabs: {
+          getBvTabs: () => ({
             fade: false,
             lazy: false,
             card: false,
@@ -184,7 +184,7 @@ describe('tab', () => {
               vm = tab
               return true
             }
-          }
+          })
         }
       },
       slots: {
@@ -209,7 +209,7 @@ describe('tab', () => {
     const wrapper = mount(BTab, {
       provide() {
         return {
-          bvTabs: {
+          getBvTabs: () => ({
             fade: false,
             lazy: false,
             card: false,
@@ -226,7 +226,7 @@ describe('tab', () => {
               tab.localActive = false
               return true
             }
-          }
+          })
         }
       }
     })
@@ -265,7 +265,7 @@ describe('tab', () => {
     const wrapper = mount(BTab, {
       provide() {
         return {
-          bvTabs: {
+          getBvTabs: () => ({
             fade: false,
             lazy: false,
             card: false,
@@ -276,7 +276,7 @@ describe('tab', () => {
               tab.localActive = true
               return true
             }
-          }
+          })
         }
       },
       propsData: { disabled: true }
@@ -300,7 +300,7 @@ describe('tab', () => {
     const wrapper = mount(BTab, {
       provide() {
         return {
-          bvTabs: {
+          getBvTabs: () => ({
             fade: false,
             lazy: false,
             card: false,
@@ -311,7 +311,7 @@ describe('tab', () => {
               tab.localActive = false
               return true
             }
-          }
+          })
         }
       }
     })

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -70,8 +70,8 @@ const notDisabled = tab => !tab.disabled
 const BVTabButton = /*#__PURE__*/ Vue.extend({
   name: NAME_TAB_BUTTON_HELPER,
   inject: {
-    bvTabs: {
-      default: /* istanbul ignore next */ () => ({})
+    getBvTabs: {
+      default: /* istanbul ignore next */ () => () => ({})
     }
   },
   props: {
@@ -83,6 +83,11 @@ const BVTabButton = /*#__PURE__*/ Vue.extend({
     // Reference to the child <b-tab> instance
     tab: makeProp(),
     tabIndex: makeProp(PROP_TYPE_NUMBER)
+  },
+  computed: {
+    bvTabs() {
+      return this.getBvTabs()
+    }
   },
   methods: {
     focus() {
@@ -218,7 +223,7 @@ export const BTabs = /*#__PURE__*/ Vue.extend({
   mixins: [idMixin, modelMixin, normalizeSlotMixin],
   provide() {
     return {
-      bvTabs: this
+      getBvTabs: () => this
     }
   },
   props,

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -357,7 +357,7 @@ export const BTabs = /*#__PURE__*/ Vue.extend({
     },
     getTabs() {
       const $tabs = this.registeredTabs.filter(
-        $tab => $tab.$children.filter($t => $t._isTab).length === 0
+        $tab => $tab.$children.filter($t => $t && $t._isTab).length === 0
       )
 
       // DOM Order of Tabs

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -362,9 +362,11 @@ export const BTabs = /*#__PURE__*/ Vue.extend({
       }
     },
     getTabs() {
-      const $tabs = this.registeredTabs.filter(
-        $tab => $tab.$children.filter($t => $t && $t._isTab).length === 0
-      )
+      const $tabs = this.registeredTabs
+      // Dropped intentionally
+      // .filter(
+      //   $tab => $tab.$children.filter($t => $t && $t._isTab).length === 0
+      // )
 
       // DOM Order of Tabs
       let order = []

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -219,6 +219,12 @@ export const props = makePropsConfigurable(
 
 // @vue/component
 export const BTabs = /*#__PURE__*/ Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    V_FOR_REF: 'suppress-warning',
+    WATCH_ARRAY: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   name: NAME_TABS,
   mixins: [idMixin, modelMixin, normalizeSlotMixin],
   provide() {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -1,4 +1,4 @@
-import { COMPONENT_UID_KEY, Vue } from '../../vue'
+import { COMPONENT_UID_KEY, defineComponent } from '../../vue'
 import { NAME_TABS, NAME_TAB_BUTTON_HELPER } from '../../constants/components'
 import { IS_BROWSER } from '../../constants/env'
 import {
@@ -67,7 +67,7 @@ const notDisabled = tab => !tab.disabled
 // --- Helper components ---
 
 // @vue/component
-const BVTabButton = /*#__PURE__*/ Vue.extend({
+const BVTabButton = /*#__PURE__*/ defineComponent({
   name: NAME_TAB_BUTTON_HELPER,
   inject: {
     getBvTabs: {
@@ -218,7 +218,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BTabs = /*#__PURE__*/ Vue.extend({
+export const BTabs = /*#__PURE__*/ defineComponent({
   compatConfig: {
     MODE: 3,
     V_FOR_REF: 'suppress-warning',

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -35,7 +35,12 @@ describe('tabs', () => {
   it('has correct card classes when prop card is true', async () => {
     const wrapper = mount(BTabs, {
       propsData: { card: true },
-      slots: { default: [BTab, BTab, BTab] }
+      slots: {
+        default: {
+          components: { BTab },
+          template: '<div><b-tab /><b-tab /><b-tab /></div>'
+        }
+      }
     })
 
     await waitNT(wrapper.vm)
@@ -55,7 +60,12 @@ describe('tabs', () => {
   it('has correct card classes when props card and vertical are true', async () => {
     const wrapper = mount(BTabs, {
       propsData: { card: true, vertical: true },
-      slots: { default: [BTab, BTab, BTab] }
+      slots: {
+        default: {
+          components: { BTab },
+          template: '<div><b-tab /><b-tab /><b-tab /></div>'
+        }
+      }
     })
 
     await waitNT(wrapper.vm)
@@ -84,7 +94,12 @@ describe('tabs', () => {
     const tabIndex = 1
     const wrapper = mount(BTabs, {
       propsData: { value: tabIndex },
-      slots: { default: [BTab, BTab, BTab] }
+      slots: {
+        default: {
+          components: { BTab },
+          template: '<div><b-tab /><b-tab /><b-tab /></div>'
+        }
+      }
     })
 
     await waitNT(wrapper.vm)

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -114,6 +114,7 @@ describe('tabs', () => {
 
   it('sets correct tab active when first tab is disabled', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(BTabs, [
           h(BTab, { props: { disabled: true } }, 'tab 0'),
@@ -146,6 +147,7 @@ describe('tabs', () => {
 
   it('sets current index based on active prop of b-tab', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(BTabs, [
           h(BTab, { props: { active: false } }, 'tab 0'),
@@ -178,6 +180,7 @@ describe('tabs', () => {
 
   it('selects first non-disabled tab when active tab disabled', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         activeTab: { type: Number, default: 1 }
       },
@@ -228,6 +231,7 @@ describe('tabs', () => {
 
   it('v-model works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         activeTab: { type: Number, default: 0 }
       },
@@ -274,6 +278,7 @@ describe('tabs', () => {
 
   it('v-model works when trying to activate a disabled tab', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         activeTab: { type: Number, default: 0 }
       },
@@ -323,6 +328,7 @@ describe('tabs', () => {
 
   it('`activate-tab` event works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         activeTab: { type: Number, default: 0 }
       },
@@ -392,6 +398,7 @@ describe('tabs', () => {
 
   it('clicking on tab activates the tab, and tab emits click event', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(BTabs, { props: { value: 0 } }, [
           h(BTab, { props: { title: 'one' } }, 'tab 0'),
@@ -464,6 +471,7 @@ describe('tabs', () => {
 
   it('pressing space on tab activates the tab, and tab emits click event', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(BTabs, { props: { value: 0, noKeyNav: true } }, [
           h(BTab, { props: { title: 'one' } }, 'tab 0'),
@@ -536,6 +544,7 @@ describe('tabs', () => {
 
   it('key nav works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(BTabs, { props: { value: 0 } }, [
           h(BTab, { props: { title: 'one' } }, 'tab 0'),
@@ -612,6 +621,7 @@ describe('tabs', () => {
 
   it('disabling active tab selects first non-disabled tab', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         disabledTabs: { type: Array, default: () => [] }
       },
@@ -668,6 +678,7 @@ describe('tabs', () => {
 
   it('tab title slots are reactive', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(BTabs, { props: { value: 2 } }, [
           h(BTab, { props: { title: 'original' } }, 'tab content')
@@ -705,6 +716,7 @@ describe('tabs', () => {
   it('"active-nav-item-class" is applied to active nav item', async () => {
     const activeNavItemClass = 'text-success'
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         activeTab: { type: Number, default: 0 }
       },
@@ -749,6 +761,7 @@ describe('tabs', () => {
   it('"active-tab-class" is applied to active tab', async () => {
     const activeTabClass = 'text-success'
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         activeTab: { type: Number, default: 0 }
       },
@@ -789,6 +802,7 @@ describe('tabs', () => {
 
   it('emits "changed" event when tabs change', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       props: {
         tabs: {
           type: Array,

--- a/src/components/time/time.js
+++ b/src/components/time/time.js
@@ -1,5 +1,5 @@
 // BTime control (not form input control)
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TIME } from '../../constants/components'
 import { EVENT_NAME_CONTEXT } from '../../constants/events'
 import { CODE_LEFT, CODE_RIGHT } from '../../constants/key-codes'
@@ -107,7 +107,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BTime = /*#__PURE__*/ Vue.extend({
+export const BTime = /*#__PURE__*/ defineComponent({
   compatConfig: {
     MODE: 3,
     V_FOR_REF: 'suppress-warning',

--- a/src/components/time/time.js
+++ b/src/components/time/time.js
@@ -108,6 +108,11 @@ export const props = makePropsConfigurable(
 
 // @vue/component
 export const BTime = /*#__PURE__*/ Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    V_FOR_REF: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   name: NAME_TIME,
   mixins: [idMixin, modelMixin, normalizeSlotMixin],
   props,

--- a/src/components/toast/helpers/bv-toast.js
+++ b/src/components/toast/helpers/bv-toast.js
@@ -30,6 +30,7 @@ import { warn, warnNotClient } from '../../../utils/warn'
 import { createNewChildComponent } from '../../../utils/create-new-child-component'
 import { getEventRoot } from '../../../utils/get-event-root'
 import { BToast, props as toastProps } from '../toast'
+import { defineComponent } from '../../../vue'
 
 // --- Constants ---
 
@@ -65,7 +66,7 @@ const plugin = Vue => {
   // Create a private sub-component constructor that
   // extends BToast and self-destructs after hidden
   // @vue/component
-  const BVToastPop = Vue.extend({
+  const BVToastPop = defineComponent({
     name: NAME_TOAST_POP,
     compatConfig: {
       MODE: 3,

--- a/src/components/toast/helpers/bv-toast.js
+++ b/src/components/toast/helpers/bv-toast.js
@@ -67,6 +67,10 @@ const plugin = Vue => {
   // @vue/component
   const BVToastPop = Vue.extend({
     name: NAME_TOAST_POP,
+    compatConfig: {
+      MODE: 3,
+      INSTANCE_DESTROY: 'suppress-warning'
+    },
     extends: BToast,
     mixins: [useParentMixin],
     destroyed() {

--- a/src/components/toast/helpers/bv-toast.spec.js
+++ b/src/components/toast/helpers/bv-toast.spec.js
@@ -8,6 +8,7 @@ Vue.use(ToastPlugin)
 describe('$bvToast', () => {
   it('$bvToast.show() and $bvToast.hide() works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(
           'b-toast',
@@ -69,6 +70,7 @@ describe('$bvToast', () => {
 
   it('$bvModal.toast() works', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h('div', 'app')
       }

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -26,6 +26,7 @@ import { toInteger } from '../../utils/number'
 import { pick, sortKeys } from '../../utils/object'
 import { makeProp, makePropsConfigurable, pluckProps } from '../../utils/props'
 import { isLink } from '../../utils/router'
+import { createNewChildComponent } from '../../utils/create-new-child-component'
 import { attrsMixin } from '../../mixins/attrs'
 import { idMixin, props as idProps } from '../../mixins/id'
 import { listenOnRootMixin } from '../../mixins/listen-on-root'
@@ -264,8 +265,7 @@ export const BToast = /*#__PURE__*/ Vue.extend({
         const div = document.createElement('div')
         document.body.appendChild(div)
 
-        const toaster = new BToaster({
-          parent: this.$root,
+        const toaster = createNewChildComponent(this.bvEventRoot, BToaster, {
           propsData: { name: computedToaster }
         })
 

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -88,6 +88,10 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BToast = /*#__PURE__*/ Vue.extend({
   name: NAME_TOAST,
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [
     attrsMixin,
     idMixin,

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -1,5 +1,5 @@
 import { Portal, Wormhole } from 'portal-vue'
-import { COMPONENT_UID_KEY, Vue } from '../../vue'
+import { COMPONENT_UID_KEY, defineComponent } from '../../vue'
 import { NAME_TOAST, NAME_TOASTER } from '../../constants/components'
 import {
   EVENT_NAME_CHANGE,
@@ -86,7 +86,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BToast = /*#__PURE__*/ Vue.extend({
+export const BToast = /*#__PURE__*/ defineComponent({
   name: NAME_TOAST,
   compatConfig: {
     MODE: 3,

--- a/src/components/toast/toaster.js
+++ b/src/components/toast/toaster.js
@@ -14,6 +14,10 @@ import { normalizeSlotMixin } from '../../mixins/normalize-slot'
 
 // @vue/component
 export const DefaultTransition = /*#__PURE__*/ Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [normalizeSlotMixin],
   data() {
     return {

--- a/src/components/toast/toaster.js
+++ b/src/components/toast/toaster.js
@@ -1,5 +1,5 @@
 import { PortalTarget, Wormhole } from 'portal-vue'
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TOASTER } from '../../constants/components'
 import { EVENT_NAME_DESTROYED } from '../../constants/events'
 import { PROP_TYPE_STRING } from '../../constants/props'
@@ -13,7 +13,7 @@ import { normalizeSlotMixin } from '../../mixins/normalize-slot'
 // --- Helper components ---
 
 // @vue/component
-export const DefaultTransition = /*#__PURE__*/ Vue.extend({
+export const DefaultTransition = /*#__PURE__*/ defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'
@@ -66,7 +66,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BToaster = /*#__PURE__*/ Vue.extend({
+export const BToaster = /*#__PURE__*/ defineComponent({
   name: NAME_TOASTER,
   mixins: [listenOnRootMixin],
   props,

--- a/src/components/toast/toaster.spec.js
+++ b/src/components/toast/toaster.spec.js
@@ -1,5 +1,6 @@
 import { PortalTarget } from 'portal-vue'
 import { mount } from '@vue/test-utils'
+import { isVue3 } from '../../vue'
 import { waitNT, waitRAF } from '../../../tests/utils'
 import { BToaster } from './toaster'
 
@@ -27,7 +28,9 @@ describe('b-toaster', () => {
 
     expect(wrapper.find('.b-toaster-slot').exists()).toBe(true)
     const $slot = wrapper.find('.b-toaster-slot')
-    expect($slot.findComponent(PortalTarget).exists()).toBe(true)
+    if (!isVue3) {
+      expect($slot.findComponent(PortalTarget).exists()).toBe(true)
+    }
     expect($slot.element.tagName).toBe('DIV')
     expect($slot.classes()).toContain('b-toaster-slot')
     expect($slot.classes()).toContain('vue-portal-target')
@@ -60,7 +63,9 @@ describe('b-toaster', () => {
 
     expect(wrapper.find('.b-toaster-slot').exists()).toBe(true)
     const $slot = wrapper.find('.b-toaster-slot')
-    expect($slot.findComponent(PortalTarget).exists()).toBe(true)
+    if (!isVue3) {
+      expect($slot.findComponent(PortalTarget).exists()).toBe(true)
+    }
     expect($slot.element.tagName).toBe('DIV')
     expect($slot.classes()).toContain('b-toaster-slot')
     expect($slot.classes()).toContain('vue-portal-target')

--- a/src/components/tooltip/helpers/bv-popper.js
+++ b/src/components/tooltip/helpers/bv-popper.js
@@ -21,6 +21,7 @@ import {
   PROP_TYPE_STRING
 } from '../../../constants/props'
 import { HTMLElement, SVGElement } from '../../../constants/safe-types'
+import { useParentMixin } from '../../../mixins/use-parent'
 import { getCS, requestAF, select } from '../../../utils/dom'
 import { toFloat } from '../../../utils/number'
 import { makeProp } from '../../../utils/props'
@@ -83,6 +84,7 @@ export const props = {
 // @vue/component
 export const BVPopper = /*#__PURE__*/ Vue.extend({
   name: NAME_POPPER,
+  mixins: [useParentMixin],
   props,
   data() {
     return {
@@ -148,7 +150,7 @@ export const BVPopper = /*#__PURE__*/ Vue.extend({
       })
     }
     // Self destruct if parent destroyed
-    this.$parent.$once(HOOK_EVENT_NAME_DESTROYED, handleDestroy)
+    this.bvParent.$once(HOOK_EVENT_NAME_DESTROYED, handleDestroy)
     // Self destruct after hidden
     this.$once(EVENT_NAME_HIDDEN, handleDestroy)
   },

--- a/src/components/tooltip/helpers/bv-popper.js
+++ b/src/components/tooltip/helpers/bv-popper.js
@@ -84,6 +84,12 @@ export const props = {
 // @vue/component
 export const BVPopper = /*#__PURE__*/ Vue.extend({
   name: NAME_POPPER,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_DESTROY: 'suppress-warning',
+    INSTANCE_LISTENERS: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [useParentMixin],
   props,
   data() {

--- a/src/components/tooltip/helpers/bv-popper.js
+++ b/src/components/tooltip/helpers/bv-popper.js
@@ -6,7 +6,7 @@
 //
 
 import Popper from 'popper.js'
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { NAME_POPPER } from '../../../constants/components'
 import {
   EVENT_NAME_HIDDEN,
@@ -82,7 +82,7 @@ export const props = {
 // --- Main component ---
 
 // @vue/component
-export const BVPopper = /*#__PURE__*/ Vue.extend({
+export const BVPopper = /*#__PURE__*/ defineComponent({
   name: NAME_POPPER,
   compatConfig: {
     MODE: 3,

--- a/src/components/tooltip/helpers/bv-tooltip-template.js
+++ b/src/components/tooltip/helpers/bv-tooltip-template.js
@@ -64,7 +64,7 @@ export const BVTooltipTemplate = /*#__PURE__*/ Vue.extend({
 
       return {
         // Apply attributes from root tooltip component
-        ...this.$parent.$parent.$attrs,
+        ...this.bvParent.bvParent.$attrs,
 
         id,
         role: 'tooltip',

--- a/src/components/tooltip/helpers/bv-tooltip-template.js
+++ b/src/components/tooltip/helpers/bv-tooltip-template.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../../vue'
+import { defineComponent } from '../../../vue'
 import { NAME_TOOLTIP_TEMPLATE } from '../../../constants/components'
 import {
   EVENT_NAME_FOCUSIN,
@@ -24,7 +24,7 @@ export const props = {
 // --- Main component ---
 
 // @vue/component
-export const BVTooltipTemplate = /*#__PURE__*/ Vue.extend({
+export const BVTooltipTemplate = /*#__PURE__*/ defineComponent({
   name: NAME_TOOLTIP_TEMPLATE,
   extends: BVPopper,
   mixins: [scopedStyleMixin],

--- a/src/components/tooltip/helpers/bv-tooltip.js
+++ b/src/components/tooltip/helpers/bv-tooltip.js
@@ -24,6 +24,7 @@ import {
 } from '../../../constants/events'
 import { useParentMixin } from '../../../mixins/use-parent'
 import { arrayIncludes, concat, from as arrayFrom } from '../../../utils/array'
+import { getInstanceFromVNode } from '../../../utils/get-instance-from-vnode'
 import {
   attemptFocus,
   closest,
@@ -795,8 +796,8 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
       //   Dropdown shown and hidden events will need to emit
       //   Note: Dropdown auto-ID happens in a `$nextTick()` after mount
       //         So the ID lookup would need to be done in a `$nextTick()`
-      if (target.__vue__) {
-        target.__vue__[on ? '$on' : '$off'](EVENT_NAME_SHOWN, this.forceHide)
+      if (getInstanceFromVNode(target)) {
+        getInstanceFromVNode(target)[on ? '$on' : '$off'](EVENT_NAME_SHOWN, this.forceHide)
       }
     },
     // --- Event handlers ---

--- a/src/components/tooltip/helpers/bv-tooltip.js
+++ b/src/components/tooltip/helpers/bv-tooltip.js
@@ -755,9 +755,9 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
     visibleCheck(on) {
       this.clearVisibilityInterval()
       const target = this.getTarget()
-      const tip = this.getTemplateElement()
       if (on) {
         this.$_visibleInterval = setInterval(() => {
+          const tip = this.getTemplateElement()
           if (tip && this.localShow && (!target.parentNode || !isVisible(target))) {
             // Target element is no longer visible or not in DOM, so force-hide the tooltip
             this.forceHide()

--- a/src/components/tooltip/helpers/bv-tooltip.js
+++ b/src/components/tooltip/helpers/bv-tooltip.js
@@ -262,7 +262,8 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
         })
       })
     }
-
+  },
+  mounted() {
     this.$nextTick(() => {
       const target = this.getTarget()
       if (target && contains(document.body, target)) {

--- a/src/components/tooltip/helpers/bv-tooltip.js
+++ b/src/components/tooltip/helpers/bv-tooltip.js
@@ -142,6 +142,12 @@ const templateData = {
 // @vue/component
 export const BVTooltip = /*#__PURE__*/ Vue.extend({
   name: NAME_TOOLTIP_HELPER,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_DESTROY: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning',
+    INSTANCE_EVENT_EMITTER: 'suppress-warning'
+  },
   mixins: [listenOnRootMixin, useParentMixin],
   data() {
     return {

--- a/src/components/tooltip/helpers/bv-tooltip.js
+++ b/src/components/tooltip/helpers/bv-tooltip.js
@@ -3,7 +3,7 @@
 // Handles trigger events, etc.
 // Instantiates template on demand
 
-import { COMPONENT_UID_KEY, Vue } from '../../../vue'
+import { COMPONENT_UID_KEY, defineComponent } from '../../../vue'
 import { NAME_MODAL, NAME_TOOLTIP_HELPER } from '../../../constants/components'
 import {
   EVENT_NAME_DISABLE,
@@ -140,7 +140,7 @@ const templateData = {
 // --- Main component ---
 
 // @vue/component
-export const BVTooltip = /*#__PURE__*/ Vue.extend({
+export const BVTooltip = /*#__PURE__*/ defineComponent({
   name: NAME_TOOLTIP_HELPER,
   compatConfig: {
     MODE: 3,

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -23,10 +23,12 @@ import {
   PROP_TYPE_STRING
 } from '../../constants/props'
 import { HTMLElement, SVGElement } from '../../constants/safe-types'
+import { useParentMixin } from '../../mixins/use-parent'
 import { getScopeId } from '../../utils/get-scope-id'
 import { isUndefinedOrNull } from '../../utils/inspect'
 import { pick } from '../../utils/object'
 import { makeProp, makePropsConfigurable } from '../../utils/props'
+import { createNewChildComponent } from '../../utils/create-new-child-component'
 import { normalizeSlotMixin } from '../../mixins/normalize-slot'
 import { BVTooltip } from './helpers/bv-tooltip'
 
@@ -83,7 +85,7 @@ export const props = makePropsConfigurable(
 // @vue/component
 export const BTooltip = /*#__PURE__*/ Vue.extend({
   name: NAME_TOOLTIP,
-  mixins: [normalizeSlotMixin],
+  mixins: [normalizeSlotMixin, useParentMixin],
   inheritAttrs: false,
   props,
   data() {
@@ -191,10 +193,9 @@ export const BTooltip = /*#__PURE__*/ Vue.extend({
       // Ensure we have initial content
       this.updateContent()
       // Pass down the scoped style attribute if available
-      const scopeId = getScopeId(this) || getScopeId(this.$parent)
+      const scopeId = getScopeId(this) || getScopeId(this.bvParent)
       // Create the instance
-      const $toolpop = (this.$_toolpop = new Component({
-        parent: this,
+      const $toolpop = (this.$_toolpop = createNewChildComponent(this, Component, {
         // Pass down the scoped style ID
         _scopeId: scopeId || undefined
       }))

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { defineComponent } from '../../vue'
 import { NAME_TOOLTIP } from '../../constants/components'
 import {
   EVENT_NAME_CLOSE,
@@ -83,7 +83,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BTooltip = /*#__PURE__*/ Vue.extend({
+export const BTooltip = /*#__PURE__*/ defineComponent({
   compatConfig: {
     INSTANCE_LISTENERS: 'suppress-warning',
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -84,6 +84,10 @@ export const props = makePropsConfigurable(
 
 // @vue/component
 export const BTooltip = /*#__PURE__*/ Vue.extend({
+  compatConfig: {
+    INSTANCE_LISTENERS: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   name: NAME_TOOLTIP,
   mixins: [normalizeSlotMixin, useParentMixin],
   inheritAttrs: false,

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -6,6 +6,7 @@ const MODAL_CLOSE_EVENT = 'bv::modal::hidden'
 
 // Our test application
 const App = {
+  compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
   props: [
     'target',
     'triggers',

--- a/src/components/transition/bv-transition.js
+++ b/src/components/transition/bv-transition.js
@@ -70,10 +70,13 @@ export const BVTransition = /*#__PURE__*/ Vue.extend({
       // We always need `css` true
       css: true
     }
+
+    const dataCopy = { ...data }
+    delete dataCopy.props
     return h(
       'transition',
       // Any transition event listeners will get merged here
-      mergeData(data, { props: transProps }),
+      mergeData(dataCopy, { props: transProps }),
       children
     )
   }

--- a/src/components/transition/bv-transition.js
+++ b/src/components/transition/bv-transition.js
@@ -4,7 +4,7 @@
 // the transition has finished the enter transition
 // (show and fade classes are only applied during transition)
 
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_TRANSITION } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_OBJECT, PROP_TYPE_STRING } from '../../constants/props'
 import { isPlainObject } from '../../utils/inspect'
@@ -45,7 +45,7 @@ export const props = {
 // --- Main component ---
 
 // @vue/component
-export const BVTransition = /*#__PURE__*/ Vue.extend({
+export const BVTransition = /*#__PURE__*/ defineComponent({
   name: NAME_TRANSITION,
   functional: true,
   props,

--- a/src/components/transporter/transporter.js
+++ b/src/components/transporter/transporter.js
@@ -1,4 +1,4 @@
-import { Vue } from '../../vue'
+import { Vue, isVue3 } from '../../vue'
 import { NAME_TRANSPORTER, NAME_TRANSPORTER_TARGET } from '../../constants/components'
 import { IS_BROWSER } from '../../constants/env'
 import {
@@ -79,7 +79,7 @@ export const props = {
 // --- Main component ---
 
 // @vue/component
-export const BVTransporter = /*#__PURE__*/ Vue.extend({
+const BVTransporterVue2 = /*#__PURE__*/ Vue.extend({
   name: NAME_TRANSPORTER,
   mixins: [normalizeSlotMixin],
   props,
@@ -177,3 +177,26 @@ export const BVTransporter = /*#__PURE__*/ Vue.extend({
     return h()
   }
 })
+
+const BVTransporterVue3 = /*#__PURE__*/ Vue.extend({
+  name: NAME_TRANSPORTER,
+  mixins: [normalizeSlotMixin],
+  props,
+  render(h) {
+    if (this.disabled) {
+      const $nodes = concat(this.normalizeSlot()).filter(identity)
+      if ($nodes.length > 0) {
+        return $nodes[0]
+      }
+    }
+    return h(
+      Vue.Teleport,
+      {
+        to: this.container
+      },
+      this.normalizeSlot()
+    )
+  }
+})
+
+export const BVTransporter = isVue3 ? BVTransporterVue3 : BVTransporterVue2

--- a/src/components/transporter/transporter.js
+++ b/src/components/transporter/transporter.js
@@ -13,6 +13,7 @@ import { identity } from '../../utils/identity'
 import { isFunction, isString } from '../../utils/inspect'
 import { normalizeSlotMixin } from '../../mixins/normalize-slot'
 import { makeProp } from '../../utils/props'
+import { createNewChildComponent } from '../../utils/create-new-child-component'
 
 // --- Helper components ---
 
@@ -129,9 +130,8 @@ export const BVTransporter = /*#__PURE__*/ Vue.extend({
         if ($container) {
           const $el = document.createElement('div')
           $container.appendChild($el)
-          this.$_target = new BVTransporterTarget({
+          this.$_target = createNewChildComponent(this, BVTransporterTarget, {
             el: $el,
-            parent: this,
             propsData: {
               // Initial nodes to be rendered
               nodes: concat(this.normalizeSlot())

--- a/src/components/transporter/transporter.js
+++ b/src/components/transporter/transporter.js
@@ -81,6 +81,11 @@ export const props = {
 // @vue/component
 const BVTransporterVue2 = /*#__PURE__*/ Vue.extend({
   name: NAME_TRANSPORTER,
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [normalizeSlotMixin],
   props,
   watch: {
@@ -131,12 +136,12 @@ const BVTransporterVue2 = /*#__PURE__*/ Vue.extend({
           const $el = document.createElement('div')
           $container.appendChild($el)
           this.$_target = createNewChildComponent(this, BVTransporterTarget, {
-            el: $el,
             propsData: {
               // Initial nodes to be rendered
               nodes: concat(this.normalizeSlot())
             }
           })
+          this.$_target.$mount($el)
         }
       }
     },

--- a/src/components/transporter/transporter.js
+++ b/src/components/transporter/transporter.js
@@ -1,4 +1,4 @@
-import { Vue, isVue3 } from '../../vue'
+import { defineComponent, Vue, isVue3 } from '../../vue'
 import { NAME_TRANSPORTER, NAME_TRANSPORTER_TARGET } from '../../constants/components'
 import { IS_BROWSER } from '../../constants/env'
 import {
@@ -31,7 +31,7 @@ import { createNewChildComponent } from '../../utils/create-new-child-component'
 // Transporter target used by BVTransporter
 // Supports only a single root element
 // @vue/component
-const BVTransporterTarget = /*#__PURE__*/ Vue.extend({
+const BVTransporterTarget = /*#__PURE__*/ defineComponent({
   // As an abstract component, it doesn't appear in the $parent chain of
   // components, which means the next parent of any component rendered inside
   // of this one will be the parent from which is was portal'd
@@ -79,7 +79,7 @@ export const props = {
 // --- Main component ---
 
 // @vue/component
-const BVTransporterVue2 = /*#__PURE__*/ Vue.extend({
+const BVTransporterVue2 = /*#__PURE__*/ defineComponent({
   name: NAME_TRANSPORTER,
   compatConfig: {
     MODE: 3,
@@ -183,7 +183,7 @@ const BVTransporterVue2 = /*#__PURE__*/ Vue.extend({
   }
 })
 
-const BVTransporterVue3 = /*#__PURE__*/ Vue.extend({
+const BVTransporterVue3 = /*#__PURE__*/ defineComponent({
   name: NAME_TRANSPORTER,
   mixins: [normalizeSlotMixin],
   props,

--- a/src/components/transporter/transporter.spec.js
+++ b/src/components/transporter/transporter.spec.js
@@ -1,3 +1,4 @@
+import { isVue3 } from '../../vue'
 import { mount } from '@vue/test-utils'
 import { waitNT } from '../../../tests/utils'
 import { getInstanceFromVNode } from '../../utils/get-instance-from-vnode'
@@ -45,7 +46,9 @@ describe('utils/transporter component', () => {
     expect(target).toBeDefined()
     expect(target).not.toBe(null)
     expect(getInstanceFromVNode(target)).toBeDefined() // Target
-    expect(getInstanceFromVNode(target).$options.name).toBe('BVTransporterTarget')
+    if (!isVue3) {
+      expect(getInstanceFromVNode(target).$options.name).toBe('BVTransporterTarget')
+    }
     expect(target.tagName).toEqual('DIV')
     expect(target.parentElement).toBeDefined()
     expect(target.parentElement).toBe(document.body)

--- a/src/components/transporter/transporter.spec.js
+++ b/src/components/transporter/transporter.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { waitNT } from '../../../tests/utils'
+import { getInstanceFromVNode } from '../../utils/get-instance-from-vnode'
 import { BVTransporter } from './transporter'
 
 describe('utils/transporter component', () => {
@@ -43,8 +44,8 @@ describe('utils/transporter component', () => {
     const target = document.getElementById('foobar')
     expect(target).toBeDefined()
     expect(target).not.toBe(null)
-    expect(target.__vue__).toBeDefined() // Target
-    expect(target.__vue__.$options.name).toBe('BVTransporterTarget')
+    expect(getInstanceFromVNode(target)).toBeDefined() // Target
+    expect(getInstanceFromVNode(target).$options.name).toBe('BVTransporterTarget')
     expect(target.tagName).toEqual('DIV')
     expect(target.parentElement).toBeDefined()
     expect(target.parentElement).toBe(document.body)

--- a/src/components/transporter/transporter.spec.js
+++ b/src/components/transporter/transporter.spec.js
@@ -7,6 +7,7 @@ import { BVTransporter } from './transporter'
 describe('utils/transporter component', () => {
   it('renders in-pace when disabled=true', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(BVTransporter, { props: { disabled: true } }, [h('div', 'content')])
       }
@@ -25,6 +26,7 @@ describe('utils/transporter component', () => {
 
   it('does not render in-pace when disabled=false', async () => {
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       render(h) {
         return h(BVTransporter, { props: { disabled: false } }, [
           h('div', { attrs: { id: 'foobar' } }, 'content')

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -1,3 +1,5 @@
+import { isVue3 } from '../vue'
+
 export const EVENT_NAME_ACTIVATE_TAB = 'activate-tab'
 export const EVENT_NAME_BLUR = 'blur'
 export const EVENT_NAME_CANCEL = 'cancel'
@@ -54,8 +56,8 @@ export const EVENT_NAME_TOGGLE = 'toggle'
 export const EVENT_NAME_UNPAUSED = 'unpaused'
 export const EVENT_NAME_UPDATE = 'update'
 
-export const HOOK_EVENT_NAME_BEFORE_DESTROY = 'hook:beforeDestroy'
-export const HOOK_EVENT_NAME_DESTROYED = 'hook:destroyed'
+export const HOOK_EVENT_NAME_BEFORE_DESTROY = isVue3 ? 'vnodeBeforeUnmount' : 'hook:beforeDestroy'
+export const HOOK_EVENT_NAME_DESTROYED = isVue3 ? 'vNodeUnmounted' : 'hook:destroyed'
 
 export const MODEL_EVENT_NAME_PREFIX = 'update:'
 

--- a/src/directives/hover/hover.spec.js
+++ b/src/directives/hover/hover.spec.js
@@ -6,6 +6,10 @@ describe('v-b-hover directive', () => {
     let hovered1 = false
     let hovered2 = false
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning'
+      },
       data() {
         return {
           text: 'FOO',

--- a/src/directives/modal/modal.js
+++ b/src/directives/modal/modal.js
@@ -5,6 +5,7 @@ import { getAttr, hasAttr, isDisabled, matches, select, setAttr } from '../../ut
 import { getRootActionEventName, eventOn, eventOff } from '../../utils/events'
 import { isString } from '../../utils/inspect'
 import { keys } from '../../utils/object'
+import { getEventRoot } from '../../utils/get-event-root'
 
 // Emitted show event for modal
 const ROOT_ACTION_EVENT_NAME_SHOW = getRootActionEventName(NAME_MODAL, EVENT_NAME_SHOW)
@@ -52,7 +53,7 @@ const bind = (el, binding, vnode) => {
           type === 'click' ||
           (type === 'keydown' && (key === CODE_ENTER || key === CODE_SPACE))
         ) {
-          vnode.context.$root.$emit(ROOT_ACTION_EVENT_NAME_SHOW, target, currentTarget)
+          getEventRoot(vnode.context).$emit(ROOT_ACTION_EVENT_NAME_SHOW, target, currentTarget)
         }
       }
     }

--- a/src/directives/modal/modal.js
+++ b/src/directives/modal/modal.js
@@ -6,6 +6,7 @@ import { getRootActionEventName, eventOn, eventOff } from '../../utils/events'
 import { isString } from '../../utils/inspect'
 import { keys } from '../../utils/object'
 import { getEventRoot } from '../../utils/get-event-root'
+import { getInstanceFromDirective } from '../../utils/get-instance-from-directive'
 
 // Emitted show event for modal
 const ROOT_ACTION_EVENT_NAME_SHOW = getRootActionEventName(NAME_MODAL, EVENT_NAME_SHOW)
@@ -53,7 +54,11 @@ const bind = (el, binding, vnode) => {
           type === 'click' ||
           (type === 'keydown' && (key === CODE_ENTER || key === CODE_SPACE))
         ) {
-          getEventRoot(vnode.context).$emit(ROOT_ACTION_EVENT_NAME_SHOW, target, currentTarget)
+          getEventRoot(getInstanceFromDirective(vnode, binding)).$emit(
+            ROOT_ACTION_EVENT_NAME_SHOW,
+            target,
+            currentTarget
+          )
         }
       }
     }

--- a/src/directives/modal/modal.spec.js
+++ b/src/directives/modal/modal.spec.js
@@ -7,6 +7,11 @@ describe('v-b-modal directive', () => {
   it('works on buttons', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bModal: VBModal
       },
@@ -37,6 +42,11 @@ describe('v-b-modal directive', () => {
   it('works on links', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bModal: VBModal
       },
@@ -75,6 +85,12 @@ describe('v-b-modal directive', () => {
   it('works on non-buttons', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_LISTENERS: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bModal: VBModal
       },
@@ -119,6 +135,12 @@ describe('v-b-modal directive', () => {
   it('works on non-buttons using keydown space', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_LISTENERS: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bModal: VBModal
       },
@@ -156,6 +178,12 @@ describe('v-b-modal directive', () => {
   it('works on non-buttons using keydown enter', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_LISTENERS: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bModal: VBModal
       },

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -16,6 +16,7 @@ import {
 import { looseEqual } from '../../utils/loose-equal'
 import { toInteger } from '../../utils/number'
 import { keys } from '../../utils/object'
+import { createNewChildComponent } from '../../utils/create-new-child-component'
 import { BVPopover } from '../../components/popover/helpers/bv-popover'
 
 // Key which we use to store tooltip object on element
@@ -185,11 +186,10 @@ const applyPopover = (el, bindings, vnode) => {
   }
   const config = parseBindings(bindings, vnode)
   if (!el[BV_POPOVER]) {
-    const $parent = vnode.context
-    el[BV_POPOVER] = new BVPopover({
-      parent: $parent,
+    const parent = vnode.context
+    el[BV_POPOVER] = createNewChildComponent(parent, BVPopover, {
       // Add the parent's scoped style attribute data
-      _scopeId: getScopeId($parent, undefined)
+      _scopeId: getScopeId(parent, undefined)
     })
     el[BV_POPOVER].__bv_prev_data__ = {}
     el[BV_POPOVER].$on(EVENT_NAME_SHOW, () => /* istanbul ignore next: for now */ {

--- a/src/directives/popover/popover.js
+++ b/src/directives/popover/popover.js
@@ -5,6 +5,7 @@ import { concat } from '../../utils/array'
 import { getComponentConfig } from '../../utils/config'
 import { getScopeId } from '../../utils/get-scope-id'
 import { identity } from '../../utils/identity'
+import { getInstanceFromDirective } from '../../utils/get-instance-from-directive'
 import {
   isFunction,
   isNumber,
@@ -18,6 +19,7 @@ import { toInteger } from '../../utils/number'
 import { keys } from '../../utils/object'
 import { createNewChildComponent } from '../../utils/create-new-child-component'
 import { BVPopover } from '../../components/popover/helpers/bv-popover'
+import { nextTick } from '../../vue'
 
 // Key which we use to store tooltip object on element
 const BV_POPOVER = '__BV_Popover__'
@@ -186,7 +188,7 @@ const applyPopover = (el, bindings, vnode) => {
   }
   const config = parseBindings(bindings, vnode)
   if (!el[BV_POPOVER]) {
-    const parent = vnode.context
+    const parent = getInstanceFromDirective(vnode, bindings)
     el[BV_POPOVER] = createNewChildComponent(parent, BVPopover, {
       // Add the parent's scoped style attribute data
       _scopeId: getScopeId(parent, undefined)
@@ -263,7 +265,7 @@ export const VBPopover = {
   // waits until the containing component and children have finished updating
   componentUpdated(el, bindings, vnode) {
     // Performed in a `$nextTick()` to prevent endless render/update loops
-    vnode.context.$nextTick(() => {
+    nextTick(() => {
       applyPopover(el, bindings, vnode)
     })
   },

--- a/src/directives/popover/popover.spec.js
+++ b/src/directives/popover/popover.spec.js
@@ -44,6 +44,10 @@ describe('v-b-popover directive', () => {
     jest.useFakeTimers()
 
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning'
+      },
       directives: {
         bPopover: VBPopover
       },
@@ -79,6 +83,10 @@ describe('v-b-popover directive', () => {
     jest.useFakeTimers()
 
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning'
+      },
       directives: {
         bPopover: VBPopover
       },

--- a/src/directives/scrollspy/scrollspy.js
+++ b/src/directives/scrollspy/scrollspy.js
@@ -3,6 +3,7 @@ import { isNumber, isObject, isString } from '../../utils/inspect'
 import { mathRound } from '../../utils/math'
 import { toInteger } from '../../utils/number'
 import { keys } from '../../utils/object'
+import { getEventRoot } from '../../utils/get-event-root'
 import { BVScrollspy } from './helpers/bv-scrollspy.class'
 
 // Key we use to store our instance
@@ -64,9 +65,9 @@ const applyScrollspy = (el, bindings, vnode) => /* istanbul ignore next: not eas
   }
   const config = parseBindings(bindings)
   if (el[BV_SCROLLSPY]) {
-    el[BV_SCROLLSPY].updateConfig(config, vnode.context.$root)
+    el[BV_SCROLLSPY].updateConfig(config, getEventRoot(vnode.context))
   } else {
-    el[BV_SCROLLSPY] = new BVScrollspy(el, config, vnode.context.$root)
+    el[BV_SCROLLSPY] = new BVScrollspy(el, config, getEventRoot(vnode.context))
   }
 }
 

--- a/src/directives/scrollspy/scrollspy.js
+++ b/src/directives/scrollspy/scrollspy.js
@@ -4,6 +4,7 @@ import { mathRound } from '../../utils/math'
 import { toInteger } from '../../utils/number'
 import { keys } from '../../utils/object'
 import { getEventRoot } from '../../utils/get-event-root'
+import { getInstanceFromDirective } from '../../utils/get-instance-from-directive'
 import { BVScrollspy } from './helpers/bv-scrollspy.class'
 
 // Key we use to store our instance
@@ -65,9 +66,13 @@ const applyScrollspy = (el, bindings, vnode) => /* istanbul ignore next: not eas
   }
   const config = parseBindings(bindings)
   if (el[BV_SCROLLSPY]) {
-    el[BV_SCROLLSPY].updateConfig(config, getEventRoot(vnode.context))
+    el[BV_SCROLLSPY].updateConfig(config, getEventRoot(getInstanceFromDirective(vnode, bindings)))
   } else {
-    el[BV_SCROLLSPY] = new BVScrollspy(el, config, getEventRoot(vnode.context))
+    el[BV_SCROLLSPY] = new BVScrollspy(
+      el,
+      config,
+      getEventRoot(getInstanceFromDirective(vnode, bindings))
+    )
   }
 }
 

--- a/src/directives/toggle/toggle.js
+++ b/src/directives/toggle/toggle.js
@@ -4,6 +4,7 @@ import { EVENT_OPTIONS_PASSIVE } from '../../constants/events'
 import { CODE_ENTER, CODE_SPACE } from '../../constants/key-codes'
 import { RX_HASH, RX_HASH_ID, RX_SPACE_SPLIT } from '../../constants/regex'
 import { arrayIncludes, concat } from '../../utils/array'
+import { getInstanceFromDirective } from '../../utils/get-instance-from-directive'
 import {
   addClass,
   getAttr,
@@ -106,9 +107,9 @@ const removeClickListener = el => {
   el[BV_TOGGLE_CLICK_HANDLER] = null
 }
 
-const addClickListener = (el, vnode) => {
+const addClickListener = (el, instance) => {
   removeClickListener(el)
-  if (vnode.context) {
+  if (instance) {
     const handler = event => {
       if (
         !(event.type === 'keydown' && !arrayIncludes(KEYDOWN_KEY_CODES, event.keyCode)) &&
@@ -116,7 +117,7 @@ const addClickListener = (el, vnode) => {
       ) {
         const targets = el[BV_TOGGLE_TARGETS] || []
         targets.forEach(target => {
-          getEventRoot(vnode.context).$emit(ROOT_ACTION_EVENT_NAME_TOGGLE, target)
+          getEventRoot(instance).$emit(ROOT_ACTION_EVENT_NAME_TOGGLE, target)
         })
       }
     }
@@ -128,9 +129,9 @@ const addClickListener = (el, vnode) => {
   }
 }
 
-const removeRootListeners = (el, vnode) => {
-  if (el[BV_TOGGLE_ROOT_HANDLER] && vnode.context) {
-    getEventRoot(vnode.context).$off(
+const removeRootListeners = (el, instance) => {
+  if (el[BV_TOGGLE_ROOT_HANDLER] && instance) {
+    getEventRoot(instance).$off(
       [ROOT_EVENT_NAME_STATE, ROOT_EVENT_NAME_SYNC_STATE],
       el[BV_TOGGLE_ROOT_HANDLER]
     )
@@ -138,9 +139,9 @@ const removeRootListeners = (el, vnode) => {
   el[BV_TOGGLE_ROOT_HANDLER] = null
 }
 
-const addRootListeners = (el, vnode) => {
-  removeRootListeners(el, vnode)
-  if (vnode.context) {
+const addRootListeners = (el, instance) => {
+  removeRootListeners(el, instance)
+  if (instance) {
     const handler = (id, state) => {
       // `state` will be `true` if target is expanded
       if (arrayIncludes(el[BV_TOGGLE_TARGETS] || [], id)) {
@@ -152,7 +153,7 @@ const addRootListeners = (el, vnode) => {
     }
     el[BV_TOGGLE_ROOT_HANDLER] = handler
     // Listen for toggle state changes (public) and sync (private)
-    getEventRoot(vnode.context).$on([ROOT_EVENT_NAME_STATE, ROOT_EVENT_NAME_SYNC_STATE], handler)
+    getEventRoot(instance).$on([ROOT_EVENT_NAME_STATE, ROOT_EVENT_NAME_SYNC_STATE], handler)
   }
 }
 
@@ -178,7 +179,7 @@ const resetProp = (el, prop) => {
 // Handle directive updates
 const handleUpdate = (el, binding, vnode) => {
   /* istanbul ignore next: should never happen */
-  if (!IS_BROWSER || !vnode.context) {
+  if (!IS_BROWSER || !getInstanceFromDirective(vnode, binding)) {
     return
   }
 
@@ -218,7 +219,7 @@ const handleUpdate = (el, binding, vnode) => {
   // Wrap in a `requestAF()` to allow any previous
   // click handling to occur first
   requestAF(() => {
-    addClickListener(el, vnode)
+    addClickListener(el, getInstanceFromDirective(vnode, binding))
   })
 
   // If targets array has changed, update
@@ -229,7 +230,10 @@ const handleUpdate = (el, binding, vnode) => {
     // Request a state update from targets so that we can
     // ensure expanded state is correct (in most cases)
     targets.forEach(target => {
-      getEventRoot(vnode.context).$emit(ROOT_ACTION_EVENT_NAME_REQUEST_STATE, target)
+      getEventRoot(getInstanceFromDirective(vnode, binding)).$emit(
+        ROOT_ACTION_EVENT_NAME_REQUEST_STATE,
+        target
+      )
     })
   }
 }
@@ -244,7 +248,7 @@ export const VBToggle = {
     // Assume no targets initially
     el[BV_TOGGLE_TARGETS] = []
     // Add our root listeners
-    addRootListeners(el, vnode)
+    addRootListeners(el, getInstanceFromDirective(vnode, binding))
     // Initial update of trigger
     handleUpdate(el, binding, vnode)
   },
@@ -253,7 +257,7 @@ export const VBToggle = {
   unbind(el, binding, vnode) {
     removeClickListener(el)
     // Remove our $root listener
-    removeRootListeners(el, vnode)
+    removeRootListeners(el, getInstanceFromDirective(vnode, binding))
     // Reset custom props
     resetProp(el, BV_TOGGLE_ROOT_HANDLER)
     resetProp(el, BV_TOGGLE_CLICK_HANDLER)

--- a/src/directives/toggle/toggle.js
+++ b/src/directives/toggle/toggle.js
@@ -21,6 +21,7 @@ import { getRootActionEventName, getRootEventName, eventOn, eventOff } from '../
 import { isString } from '../../utils/inspect'
 import { looseEqual } from '../../utils/loose-equal'
 import { keys } from '../../utils/object'
+import { getEventRoot } from '../../utils/get-event-root'
 
 // --- Constants ---
 
@@ -115,7 +116,7 @@ const addClickListener = (el, vnode) => {
       ) {
         const targets = el[BV_TOGGLE_TARGETS] || []
         targets.forEach(target => {
-          vnode.context.$root.$emit(ROOT_ACTION_EVENT_NAME_TOGGLE, target)
+          getEventRoot(vnode.context).$emit(ROOT_ACTION_EVENT_NAME_TOGGLE, target)
         })
       }
     }
@@ -129,7 +130,7 @@ const addClickListener = (el, vnode) => {
 
 const removeRootListeners = (el, vnode) => {
   if (el[BV_TOGGLE_ROOT_HANDLER] && vnode.context) {
-    vnode.context.$root.$off(
+    getEventRoot(vnode.context).$off(
       [ROOT_EVENT_NAME_STATE, ROOT_EVENT_NAME_SYNC_STATE],
       el[BV_TOGGLE_ROOT_HANDLER]
     )
@@ -151,7 +152,7 @@ const addRootListeners = (el, vnode) => {
     }
     el[BV_TOGGLE_ROOT_HANDLER] = handler
     // Listen for toggle state changes (public) and sync (private)
-    vnode.context.$root.$on([ROOT_EVENT_NAME_STATE, ROOT_EVENT_NAME_SYNC_STATE], handler)
+    getEventRoot(vnode.context).$on([ROOT_EVENT_NAME_STATE, ROOT_EVENT_NAME_SYNC_STATE], handler)
   }
 }
 
@@ -228,7 +229,7 @@ const handleUpdate = (el, binding, vnode) => {
     // Request a state update from targets so that we can
     // ensure expanded state is correct (in most cases)
     targets.forEach(target => {
-      vnode.context.$root.$emit(ROOT_ACTION_EVENT_NAME_REQUEST_STATE, target)
+      getEventRoot(vnode.context).$emit(ROOT_ACTION_EVENT_NAME_REQUEST_STATE, target)
     })
   }
 }

--- a/src/directives/toggle/toggle.spec.js
+++ b/src/directives/toggle/toggle.spec.js
@@ -15,6 +15,12 @@ describe('v-b-toggle directive', () => {
   it('works on buttons', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_EVENT_EMITTER: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bToggle: VBToggle
       },
@@ -61,6 +67,12 @@ describe('v-b-toggle directive', () => {
   it('works on passing ID as directive value', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_EVENT_EMITTER: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bToggle: VBToggle
       },
@@ -105,6 +117,12 @@ describe('v-b-toggle directive', () => {
   it('works on passing ID as directive argument', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_EVENT_EMITTER: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bToggle: VBToggle
       },
@@ -149,6 +167,12 @@ describe('v-b-toggle directive', () => {
   it('works on passing ID as href value on links', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_EVENT_EMITTER: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bToggle: VBToggle
       },
@@ -195,6 +219,12 @@ describe('v-b-toggle directive', () => {
   it('works with multiple targets, and updates when targets change', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_EVENT_EMITTER: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bToggle: VBToggle
       },
@@ -275,6 +305,12 @@ describe('v-b-toggle directive', () => {
   it('works on non-buttons', async () => {
     const spy = jest.fn()
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_EVENT_EMITTER: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bToggle: VBToggle
       },
@@ -369,6 +405,12 @@ describe('v-b-toggle directive', () => {
 
   it('responds to state update events', async () => {
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_EVENT_EMITTER: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bToggle: VBToggle
       },
@@ -414,6 +456,12 @@ describe('v-b-toggle directive', () => {
 
   it('responds to private sync state update events', async () => {
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning',
+        INSTANCE_EVENT_EMITTER: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       directives: {
         bToggle: VBToggle
       },

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -2,9 +2,11 @@ import { NAME_TOOLTIP } from '../../constants/components'
 import { IS_BROWSER } from '../../constants/env'
 import { EVENT_NAME_SHOW } from '../../constants/events'
 import { concat } from '../../utils/array'
+import { isVue3, nextTick } from '../../vue'
 import { getComponentConfig } from '../../utils/config'
 import { getScopeId } from '../../utils/get-scope-id'
 import { identity } from '../../utils/identity'
+import { getInstanceFromDirective } from '../../utils/get-instance-from-directive'
 import {
   isFunction,
   isNumber,
@@ -69,7 +71,6 @@ const parseBindings = (bindings, vnode) => /* istanbul ignore next: not easy to 
     variant: getComponentConfig(NAME_TOOLTIP, 'variant'),
     customClass: getComponentConfig(NAME_TOOLTIP, 'customClass')
   }
-
   // Process `bindings.value`
   if (isString(bindings.value) || isNumber(bindings.value)) {
     // Value is tooltip content (HTML optionally supported)
@@ -85,8 +86,8 @@ const parseBindings = (bindings, vnode) => /* istanbul ignore next: not easy to 
   // If title is not provided, try title attribute
   if (isUndefined(config.title)) {
     // Try attribute
-    const data = vnode.data || {}
-    config.title = data.attrs && !isUndefinedOrNull(data.attrs.title) ? data.attrs.title : undefined
+    const attrs = isVue3 ? vnode.props : (vnode.data || {}).attrs
+    config.title = attrs && !isUndefinedOrNull(attrs.title) ? attrs.title : undefined
   }
 
   // Normalize delay
@@ -191,7 +192,7 @@ const applyTooltip = (el, bindings, vnode) => {
   }
   const config = parseBindings(bindings, vnode)
   if (!el[BV_TOOLTIP]) {
-    const parent = vnode.context
+    const parent = getInstanceFromDirective(vnode, bindings)
     el[BV_TOOLTIP] = createNewChildComponent(parent, BVTooltip, {
       // Add the parent's scoped style attribute data
       _scopeId: getScopeId(parent, undefined)
@@ -259,7 +260,7 @@ export const VBTooltip = {
   // waits until the containing component and children have finished updating
   componentUpdated(el, bindings, vnode) {
     // Performed in a `$nextTick()` to prevent render update loops
-    vnode.context.$nextTick(() => {
+    nextTick(() => {
       applyTooltip(el, bindings, vnode)
     })
   },

--- a/src/directives/tooltip/tooltip.js
+++ b/src/directives/tooltip/tooltip.js
@@ -16,6 +16,7 @@ import {
 import { looseEqual } from '../../utils/loose-equal'
 import { toInteger } from '../../utils/number'
 import { keys } from '../../utils/object'
+import { createNewChildComponent } from '../../utils/create-new-child-component'
 import { BVTooltip } from '../../components/tooltip/helpers/bv-tooltip'
 
 // Key which we use to store tooltip object on element
@@ -190,11 +191,10 @@ const applyTooltip = (el, bindings, vnode) => {
   }
   const config = parseBindings(bindings, vnode)
   if (!el[BV_TOOLTIP]) {
-    const $parent = vnode.context
-    el[BV_TOOLTIP] = new BVTooltip({
-      parent: $parent,
+    const parent = vnode.context
+    el[BV_TOOLTIP] = createNewChildComponent(parent, BVTooltip, {
       // Add the parent's scoped style attribute data
-      _scopeId: getScopeId($parent, undefined)
+      _scopeId: getScopeId(parent, undefined)
     })
     el[BV_TOOLTIP].__bv_prev_data__ = {}
     el[BV_TOOLTIP].$on(EVENT_NAME_SHOW, () => /* istanbul ignore next: for now */ {

--- a/src/directives/tooltip/tooltip.spec.js
+++ b/src/directives/tooltip/tooltip.spec.js
@@ -44,6 +44,10 @@ describe('v-b-tooltip directive', () => {
     jest.useFakeTimers()
 
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning'
+      },
       directives: {
         bTooltip: VBTooltip
       },
@@ -79,6 +83,10 @@ describe('v-b-tooltip directive', () => {
     jest.useFakeTimers()
 
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning'
+      },
       directives: {
         bTooltip: VBTooltip
       },
@@ -131,6 +139,10 @@ describe('v-b-tooltip directive', () => {
     jest.useFakeTimers()
 
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning'
+      },
       directives: {
         bTooltip: VBTooltip
       },
@@ -178,6 +190,10 @@ describe('v-b-tooltip directive', () => {
     jest.useFakeTimers()
 
     const App = {
+      compatConfig: {
+        MODE: 3,
+        CUSTOM_DIR: 'suppress-warning'
+      },
       directives: {
         bTooltip: VBTooltip
       },

--- a/src/directives/visible/visible.js
+++ b/src/directives/visible/visible.js
@@ -36,11 +36,12 @@ import { requestAF } from '../../utils/dom'
 import { isFunction } from '../../utils/inspect'
 import { looseEqual } from '../../utils/loose-equal'
 import { clone, keys } from '../../utils/object'
+import { nextTick } from '../../vue'
 
 const OBSERVER_PROP_NAME = '__bv__visibility_observer'
 
 class VisibilityObserver {
-  constructor(el, options, vnode) {
+  constructor(el, options) {
     this.el = el
     this.callback = options.callback
     this.margin = options.margin || 0
@@ -49,10 +50,10 @@ class VisibilityObserver {
     this.visible = undefined
     this.doneOnce = false
     // Create the observer instance (if possible)
-    this.createObserver(vnode)
+    this.createObserver()
   }
 
-  createObserver(vnode) {
+  createObserver() {
     // Remove any previous observer
     if (this.observer) {
       /* istanbul ignore next */
@@ -87,7 +88,7 @@ class VisibilityObserver {
 
     // Start observing in a `$nextTick()` (to allow DOM to complete rendering)
     /* istanbul ignore next: IntersectionObserver not supported in JSDOM */
-    vnode.context.$nextTick(() => {
+    nextTick(() => {
       requestAF(() => {
         // Placed in an `if` just in case we were destroyed before
         // this `requestAnimationFrame` runs
@@ -127,7 +128,7 @@ const destroy = el => {
   delete el[OBSERVER_PROP_NAME]
 }
 
-const bind = (el, { value, modifiers }, vnode) => {
+const bind = (el, { value, modifiers }) => {
   // `value` is the callback function
   const options = {
     margin: '0px',
@@ -146,7 +147,7 @@ const bind = (el, { value, modifiers }, vnode) => {
   // Destroy any previous observer
   destroy(el)
   // Create new observer
-  el[OBSERVER_PROP_NAME] = new VisibilityObserver(el, options, vnode)
+  el[OBSERVER_PROP_NAME] = new VisibilityObserver(el, options)
   // Store the current modifiers on the object (cloned)
   el[OBSERVER_PROP_NAME]._prevModifiers = clone(modifiers)
 }

--- a/src/icons/helpers/icon-base.js
+++ b/src/icons/helpers/icon-base.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { NAME_ICON_BASE } from '../../constants/components'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_NUMBER_STRING, PROP_TYPE_STRING } from '../../constants/props'
 import { identity } from '../../utils/identity'
@@ -49,7 +49,7 @@ export const props = {
 
 // Shared private base component to reduce bundle/runtime size
 // @vue/component
-export const BVIconBase = /*#__PURE__*/ Vue.extend({
+export const BVIconBase = /*#__PURE__*/ defineComponent({
   name: NAME_ICON_BASE,
   functional: true,
   props,

--- a/src/icons/helpers/make-icon.js
+++ b/src/icons/helpers/make-icon.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../../vue'
+import { defineComponent, mergeData } from '../../vue'
 import { omit } from '../../utils/object'
 import { kebabCase, pascalCase, trim } from '../../utils/string'
 import { BVIconBase, props as BVIconBaseProps } from './icon-base'
@@ -21,7 +21,7 @@ export const makeIcon = (name, content) => {
   const iconTitle = kebabName.replace(/-/g, ' ')
   const svgContent = trim(content || '')
 
-  return /*#__PURE__*/ Vue.extend({
+  return /*#__PURE__*/ defineComponent({
     name: iconName,
     functional: true,
     props: iconProps,

--- a/src/icons/icon.js
+++ b/src/icons/icon.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../vue'
+import { defineComponent, mergeData, Vue } from '../vue'
 import { NAME_ICON } from '../constants/components'
 import { PROP_TYPE_STRING } from '../constants/props'
 import { RX_ICON_PREFIX } from '../constants/regex'
@@ -36,7 +36,7 @@ export const props = makePropsConfigurable(
 // Helper BIcon component
 // Requires the requested icon component to be installed
 // @vue/component
-export const BIcon = /*#__PURE__*/ Vue.extend({
+export const BIcon = /*#__PURE__*/ defineComponent({
   name: NAME_ICON,
   functional: true,
   props,

--- a/src/icons/icons.spec.js
+++ b/src/icons/icons.spec.js
@@ -184,6 +184,7 @@ describe('icons', () => {
 
   it('b-icon with custom icon works', async () => {
     const ParentComponent = {
+      compatConfig: { MODE: 3, COMPONENT_FUNCTIONAL: 'suppress-warning' },
       name: 'ParentComponent',
       components: {
         // For testing user defined Icons

--- a/src/icons/iconstack.js
+++ b/src/icons/iconstack.js
@@ -1,4 +1,4 @@
-import { Vue, mergeData } from '../vue'
+import { defineComponent, mergeData } from '../vue'
 import { NAME_ICONSTACK } from '../constants/components'
 import { omit } from '../utils/object'
 import { makePropsConfigurable } from '../utils/props'
@@ -14,7 +14,7 @@ export const props = makePropsConfigurable(
 // --- Main component ---
 
 // @vue/component
-export const BIconstack = /*#__PURE__*/ Vue.extend({
+export const BIconstack = /*#__PURE__*/ defineComponent({
   name: NAME_ICONSTACK,
   functional: true,
   props,

--- a/src/mixins/attrs.js
+++ b/src/mixins/attrs.js
@@ -1,3 +1,13 @@
 import { makePropCacheMixin } from '../utils/cache'
+import { Vue, isVue3 } from '../vue'
 
-export const attrsMixin = makePropCacheMixin('$attrs', 'bvAttrs')
+const attrsMixinVue2 = makePropCacheMixin('$attrs', 'bvAttrs')
+const attrsMixinVue3 = Vue.extend({
+  computed: {
+    bvAttrs() {
+      return this.$attrs
+    }
+  }
+})
+
+export const attrsMixin = isVue3 ? attrsMixinVue3 : attrsMixinVue2

--- a/src/mixins/attrs.js
+++ b/src/mixins/attrs.js
@@ -1,8 +1,8 @@
 import { makePropCacheMixin } from '../utils/cache'
-import { Vue, isVue3 } from '../vue'
+import { defineComponent, isVue3 } from '../vue'
 
 const attrsMixinVue2 = makePropCacheMixin('$attrs', 'bvAttrs')
-const attrsMixinVue3 = Vue.extend({
+const attrsMixinVue3 = defineComponent({
   computed: {
     bvAttrs() {
       return this.$attrs

--- a/src/mixins/attrs.spec.js
+++ b/src/mixins/attrs.spec.js
@@ -1,3 +1,4 @@
+import { isVue3 } from '../vue'
 import { mount } from '@vue/test-utils'
 import { attrsMixin } from './attrs'
 
@@ -159,15 +160,19 @@ describe('mixins > attrs', () => {
     await wrapper1.setProps({ value1: 'foo' })
     expect($inputs1.at(0).vm.value).toBe('foo')
     expect($inputs1.at(1).vm.value).toBe(undefined)
-    // Both `Input1`'s are re-rendered (See: https://github.com/vuejs/vue/issues/7257)
-    expect(input1RenderCount).toBe(4)
+    if (!isVue3) {
+      // Both `Input1`'s are re-rendered (See: https://github.com/vuejs/vue/issues/7257)
+      expect(input1RenderCount).toBe(4)
+    }
 
     // Update the value for the second `Input1`
     await wrapper1.setProps({ value2: 'bar' })
     expect($inputs1.at(0).vm.value).toBe('foo')
     expect($inputs1.at(1).vm.value).toBe('bar')
-    // Both `Input1`'s are re-rendered (See: https://github.com/vuejs/vue/issues/7257)
-    expect(input1RenderCount).toBe(6)
+    if (!isVue3) {
+      // Both `Input1`'s are re-rendered (See: https://github.com/vuejs/vue/issues/7257)
+      expect(input1RenderCount).toBe(6)
+    }
 
     // Update the value for the first `Input2`
     await wrapper2.setProps({ value1: 'foo' })

--- a/src/mixins/attrs.spec.js
+++ b/src/mixins/attrs.spec.js
@@ -7,6 +7,7 @@ import { attrsMixin } from './attrs'
 describe('mixins > attrs', () => {
   it('works', async () => {
     const BTest = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       name: 'BTest',
       mixins: [attrsMixin],
       inheritAttrs: false,
@@ -15,6 +16,7 @@ describe('mixins > attrs', () => {
       }
     }
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       name: 'App',
       props: {
         attrs: {
@@ -98,6 +100,11 @@ describe('mixins > attrs', () => {
 
     const Input1 = {
       props: ['value'],
+      compatConfig: {
+        MODE: 3,
+        RENDER_FUNCTION: 'suppress-warning',
+        COMPONENT_V_MODEL: 'suppress-warning'
+      },
       render(h) {
         input1RenderCount++
         return h('input', {
@@ -109,6 +116,11 @@ describe('mixins > attrs', () => {
     }
     const Input2 = {
       props: ['value'],
+      compatConfig: {
+        MODE: 3,
+        RENDER_FUNCTION: 'suppress-warning',
+        COMPONENT_V_MODEL: 'suppress-warning'
+      },
       mixins: [attrsMixin],
       render(h) {
         input2RenderCount++

--- a/src/mixins/card.js
+++ b/src/mixins/card.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { NAME_CARD } from '../constants/components'
 import { PROP_TYPE_STRING } from '../constants/props'
 import { makeProp, makePropsConfigurable } from '../utils/props'
@@ -18,6 +18,6 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const cardMixin = Vue.extend({
+export const cardMixin = defineComponent({
   props
 })

--- a/src/mixins/click-out.js
+++ b/src/mixins/click-out.js
@@ -1,10 +1,10 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { EVENT_OPTIONS_NO_CAPTURE } from '../constants/events'
 import { contains } from '../utils/dom'
 import { eventOn, eventOff } from '../utils/events'
 
 // @vue/component
-export const clickOutMixin = Vue.extend({
+export const clickOutMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/mixins/click-out.js
+++ b/src/mixins/click-out.js
@@ -5,6 +5,10 @@ import { eventOn, eventOff } from '../utils/events'
 
 // @vue/component
 export const clickOutMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   data() {
     return {
       listenForClickOut: false

--- a/src/mixins/click-out.spec.js
+++ b/src/mixins/click-out.spec.js
@@ -6,6 +6,11 @@ describe('utils/click-out', () => {
   it('works', async () => {
     let count = 0
     const App = {
+      compatConfig: {
+        MODE: 3,
+        RENDER_FUNCTION: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       mixins: [clickOutMixin],
       // `listenForClickOut` comes from the mixin data
       created() {

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -87,10 +87,10 @@ export const props = makePropsConfigurable(
 export const dropdownMixin = Vue.extend({
   mixins: [idMixin, listenOnRootMixin, clickOutMixin, focusInMixin],
   provide() {
-    return { bvDropdown: this }
+    return { getBvDropdown: () => this }
   },
   inject: {
-    bvNavbar: { default: null }
+    getBvNavbar: { default: () => () => null }
   },
   props,
   data() {
@@ -100,6 +100,9 @@ export const dropdownMixin = Vue.extend({
     }
   },
   computed: {
+    bvNavbar() {
+      return this.getBvNavbar()
+    },
     inNavbar() {
       return !isNull(this.bvNavbar)
     },

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -286,8 +286,8 @@ export const dropdownMixin = Vue.extend({
       // Hide the dropdown when it loses focus
       this.listenForFocusIn = isOpen
       // Hide the dropdown when another dropdown is opened
-      const method = isOpen ? '$on' : '$off'
-      this.$root[method](ROOT_EVENT_NAME_SHOWN, this.rootCloseListener)
+      const method = isOpen ? 'listenOnRoot' : 'listenOffRoot'
+      this[method](ROOT_EVENT_NAME_SHOWN, this.rootCloseListener)
     },
     rootCloseListener(vm) {
       if (vm !== this) {

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -1,5 +1,5 @@
 import Popper from 'popper.js'
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { NAME_DROPDOWN } from '../constants/components'
 import { HAS_TOUCH_SUPPORT } from '../constants/env'
 import {
@@ -84,7 +84,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const dropdownMixin = Vue.extend({
+export const dropdownMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/mixins/dropdown.js
+++ b/src/mixins/dropdown.js
@@ -85,6 +85,10 @@ export const props = makePropsConfigurable(
 
 // @vue/component
 export const dropdownMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [idMixin, listenOnRootMixin, clickOutMixin, focusInMixin],
   provide() {
     return { getBvDropdown: () => this }

--- a/src/mixins/focus-in.js
+++ b/src/mixins/focus-in.js
@@ -4,6 +4,10 @@ import { eventOn, eventOff } from '../utils/events'
 
 // @vue/component
 export const focusInMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   data() {
     return {
       listenForFocusIn: false

--- a/src/mixins/focus-in.js
+++ b/src/mixins/focus-in.js
@@ -1,9 +1,9 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { EVENT_OPTIONS_NO_CAPTURE } from '../constants/events'
 import { eventOn, eventOff } from '../utils/events'
 
 // @vue/component
-export const focusInMixin = Vue.extend({
+export const focusInMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/mixins/focus-in.spec.js
+++ b/src/mixins/focus-in.spec.js
@@ -6,6 +6,11 @@ describe('mixins/focus-in', () => {
   it('works', async () => {
     let count = 0
     const App = {
+      compatConfig: {
+        MODE: 3,
+        RENDER_FUNCTION: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       mixins: [focusInMixin],
       // listenForFocusIn comes from the mixin
       created() {

--- a/src/mixins/form-control.js
+++ b/src/mixins/form-control.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../constants/props'
 import { attemptFocus, isVisible, matches, requestAF, select } from '../utils/dom'
 import { makeProp, makePropsConfigurable } from '../utils/props'
@@ -24,7 +24,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const formControlMixin = Vue.extend({
+export const formControlMixin = defineComponent({
   props,
   mounted() {
     this.handleAutofocus()

--- a/src/mixins/form-custom.js
+++ b/src/mixins/form-custom.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { PROP_TYPE_BOOLEAN } from '../constants/props'
 import { makeProp, makePropsConfigurable } from '../utils/props'
 
@@ -14,7 +14,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const formCustomMixin = Vue.extend({
+export const formCustomMixin = defineComponent({
   props,
   computed: {
     custom() {

--- a/src/mixins/form-options.js
+++ b/src/mixins/form-options.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { PROP_TYPE_ARRAY_OBJECT, PROP_TYPE_STRING } from '../constants/props'
 import { get } from '../utils/get'
 import { stripTags } from '../utils/html'
@@ -28,7 +28,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const formOptionsMixin = Vue.extend({
+export const formOptionsMixin = defineComponent({
   props,
   computed: {
     formOptions() {

--- a/src/mixins/form-radio-check-group.js
+++ b/src/mixins/form-radio-check-group.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { PROP_TYPE_BOOLEAN, PROP_TYPE_BOOLEAN_STRING, PROP_TYPE_STRING } from '../constants/props'
 import { SLOT_NAME_FIRST } from '../constants/slots'
 import { htmlOrText } from '../utils/html'
@@ -55,7 +55,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const formRadioCheckGroupMixin = Vue.extend({
+export const formRadioCheckGroupMixin = defineComponent({
   mixins: [
     idMixin,
     modelMixin,

--- a/src/mixins/form-radio-check.js
+++ b/src/mixins/form-radio-check.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { PROP_TYPE_ANY, PROP_TYPE_BOOLEAN, PROP_TYPE_STRING } from '../constants/props'
 import { EVENT_NAME_CHANGE } from '../constants/events'
 import { attemptBlur, attemptFocus } from '../utils/dom'
@@ -51,7 +51,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const formRadioCheckMixin = Vue.extend({
+export const formRadioCheckMixin = defineComponent({
   mixins: [
     attrsMixin,
     idMixin,

--- a/src/mixins/form-selection.js
+++ b/src/mixins/form-selection.js
@@ -1,7 +1,7 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 
 // @vue/component
-export const formSelectionMixin = Vue.extend({
+export const formSelectionMixin = defineComponent({
   computed: {
     selectionStart: {
       // Expose selectionStart for formatters, etc

--- a/src/mixins/form-size.js
+++ b/src/mixins/form-size.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { PROP_TYPE_STRING } from '../constants/props'
 import { makeProp, makePropsConfigurable } from '../utils/props'
 
@@ -14,7 +14,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const formSizeMixin = Vue.extend({
+export const formSizeMixin = defineComponent({
   props,
   computed: {
     sizeFormClass() {

--- a/src/mixins/form-state.js
+++ b/src/mixins/form-state.js
@@ -10,6 +10,7 @@ import { Vue } from '../vue'
 import { PROP_TYPE_BOOLEAN } from '../constants/props'
 import { isBoolean } from '../utils/inspect'
 import { makeProp, makePropsConfigurable } from '../utils/props'
+import { safeVueInstance } from '../utils/safe-vue-instance'
 
 // --- Props ---
 
@@ -36,7 +37,7 @@ export const formStateMixin = Vue.extend({
       return state === true ? 'is-valid' : state === false ? 'is-invalid' : null
     },
     computedAriaInvalid() {
-      const { ariaInvalid } = this
+      const ariaInvalid = safeVueInstance(this).ariaInvalid
       if (ariaInvalid === true || ariaInvalid === 'true' || ariaInvalid === '') {
         return 'true'
       }

--- a/src/mixins/form-state.js
+++ b/src/mixins/form-state.js
@@ -6,7 +6,7 @@
  *  - false for is-invalid
  *  - null for no contextual state
  */
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { PROP_TYPE_BOOLEAN } from '../constants/props'
 import { isBoolean } from '../utils/inspect'
 import { makeProp, makePropsConfigurable } from '../utils/props'
@@ -25,7 +25,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const formStateMixin = Vue.extend({
+export const formStateMixin = defineComponent({
   props,
   computed: {
     computedState() {

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -62,6 +62,10 @@ export const props = makePropsConfigurable(
 
 // @vue/component
 export const formTextMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   mixins: [modelMixin],
   props,
   data() {

--- a/src/mixins/form-text.js
+++ b/src/mixins/form-text.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import {
   EVENT_NAME_BLUR,
   EVENT_NAME_CHANGE,
@@ -61,7 +61,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const formTextMixin = Vue.extend({
+export const formTextMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/mixins/form-validity.js
+++ b/src/mixins/form-validity.js
@@ -1,7 +1,7 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 
 // @vue/component
-export const formValidityMixin = Vue.extend({
+export const formValidityMixin = defineComponent({
   computed: {
     validity: {
       // Expose validity property

--- a/src/mixins/has-listener.js
+++ b/src/mixins/has-listener.js
@@ -2,13 +2,16 @@
 // either via `v-on:name` (in the parent) or programmatically
 // via `vm.$on('name', ...)`
 // See: https://github.com/vuejs/vue/issues/10825
-import { Vue } from '../vue'
+import { isVue3, Vue } from '../vue'
 import { isArray, isUndefined } from '../utils/inspect'
 
 // @vue/component
 export const hasListenerMixin = Vue.extend({
   methods: {
     hasListener(name) {
+      if (isVue3) {
+        return true
+      }
       // Only includes listeners registered via `v-on:name`
       const $listeners = this.$listeners || {}
       // Includes `v-on:name` and `this.$on('name')` registered listeners

--- a/src/mixins/has-listener.js
+++ b/src/mixins/has-listener.js
@@ -2,11 +2,11 @@
 // either via `v-on:name` (in the parent) or programmatically
 // via `vm.$on('name', ...)`
 // See: https://github.com/vuejs/vue/issues/10825
-import { isVue3, Vue } from '../vue'
+import { isVue3, defineComponent } from '../vue'
 import { isArray, isUndefined } from '../utils/inspect'
 
 // @vue/component
-export const hasListenerMixin = Vue.extend({
+export const hasListenerMixin = defineComponent({
   methods: {
     hasListener(name) {
       if (isVue3) {

--- a/src/mixins/id.js
+++ b/src/mixins/id.js
@@ -1,7 +1,7 @@
 // SSR safe client-side ID attribute generation
 // ID's can only be generated client-side, after mount
 // `this._uid` is not synched between server and client
-import { COMPONENT_UID_KEY, Vue } from '../vue'
+import { COMPONENT_UID_KEY, defineComponent } from '../vue'
 import { PROP_TYPE_STRING } from '../constants/props'
 import { makeProp } from '../utils/props'
 
@@ -14,7 +14,7 @@ export const props = {
 // --- Mixin ---
 
 // @vue/component
-export const idMixin = Vue.extend({
+export const idMixin = defineComponent({
   props,
   data() {
     return {

--- a/src/mixins/listen-on-document.js
+++ b/src/mixins/listen-on-document.js
@@ -13,6 +13,10 @@ const PROP = '$_documentListeners'
 
 // @vue/component
 export const listenOnDocumentMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   created() {
     // Define non-reactive property
     // Object of arrays, keyed by event name,

--- a/src/mixins/listen-on-document.js
+++ b/src/mixins/listen-on-document.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { IS_BROWSER } from '../constants/env'
 import { EVENT_OPTIONS_NO_CAPTURE } from '../constants/events'
 import { arrayIncludes } from '../utils/array'
@@ -12,7 +12,7 @@ const PROP = '$_documentListeners'
 // --- Mixin ---
 
 // @vue/component
-export const listenOnDocumentMixin = Vue.extend({
+export const listenOnDocumentMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/mixins/listen-on-document.spec.js
+++ b/src/mixins/listen-on-document.spec.js
@@ -8,6 +8,11 @@ describe('mixins/listen-on-document', () => {
     const spyFocusin = jest.fn()
 
     const TestComponent = {
+      compatConfig: {
+        MODE: 3,
+        RENDER_FUNCTION: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       mixins: [listenOnDocumentMixin],
       props: {
         offClickOne: {
@@ -33,6 +38,7 @@ describe('mixins/listen-on-document', () => {
     }
 
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       components: { TestComponent },
       props: {
         offClickOne: {

--- a/src/mixins/listen-on-root.js
+++ b/src/mixins/listen-on-root.js
@@ -1,7 +1,7 @@
 import { Vue } from '../vue'
 import { arrayIncludes } from '../utils/array'
 import { keys } from '../utils/object'
-
+import { getEventRoot } from '../utils/get-event-root'
 // --- Constants ---
 
 const PROP = '$_rootListeners'
@@ -10,6 +10,11 @@ const PROP = '$_rootListeners'
 
 // @vue/component
 export const listenOnRootMixin = Vue.extend({
+  computed: {
+    bvEventRoot() {
+      return getEventRoot(this)
+    }
+  },
   created() {
     // Define non-reactive property
     // Object of arrays, keyed by event name,
@@ -55,8 +60,8 @@ export const listenOnRootMixin = Vue.extend({
      * @param {function} callback
      */
     listenOnRoot(event, callback) {
-      if (this.$root) {
-        this.$root.$on(event, callback)
+      if (this.bvEventRoot) {
+        this.bvEventRoot.$on(event, callback)
         this.registerRootListener(event, callback)
       }
     },
@@ -75,14 +80,14 @@ export const listenOnRootMixin = Vue.extend({
      * @param {function} callback
      */
     listenOnRootOnce(event, callback) {
-      if (this.$root) {
+      if (this.bvEventRoot) {
         const _callback = (...args) => {
           this.unregisterRootListener(_callback)
           // eslint-disable-next-line node/no-callback-literal
           callback(...args)
         }
 
-        this.$root.$once(event, _callback)
+        this.bvEventRoot.$once(event, _callback)
         this.registerRootListener(event, _callback)
       }
     },
@@ -96,8 +101,8 @@ export const listenOnRootMixin = Vue.extend({
     listenOffRoot(event, callback) {
       this.unregisterRootListener(event, callback)
 
-      if (this.$root) {
-        this.$root.$off(event, callback)
+      if (this.bvEventRoot) {
+        this.bvEventRoot.$off(event, callback)
       }
     },
 
@@ -108,8 +113,8 @@ export const listenOnRootMixin = Vue.extend({
      * @param {*} args
      */
     emitOnRoot(event, ...args) {
-      if (this.$root) {
-        this.$root.$emit(event, ...args)
+      if (this.bvEventRoot) {
+        this.bvEventRoot.$emit(event, ...args)
       }
     }
   }

--- a/src/mixins/listen-on-root.js
+++ b/src/mixins/listen-on-root.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { arrayIncludes } from '../utils/array'
 import { keys } from '../utils/object'
 import { getEventRoot } from '../utils/get-event-root'
@@ -9,7 +9,7 @@ const PROP = '$_rootListeners'
 // --- Mixin ---
 
 // @vue/component
-export const listenOnRootMixin = Vue.extend({
+export const listenOnRootMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/mixins/listen-on-root.js
+++ b/src/mixins/listen-on-root.js
@@ -10,6 +10,10 @@ const PROP = '$_rootListeners'
 
 // @vue/component
 export const listenOnRootMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   computed: {
     bvEventRoot() {
       return getEventRoot(this)

--- a/src/mixins/listen-on-root.spec.js
+++ b/src/mixins/listen-on-root.spec.js
@@ -7,6 +7,11 @@ describe('mixins/listen-on-root', () => {
     const spyOnce = jest.fn()
 
     const TestComponent = {
+      compatConfig: {
+        MODE: 3,
+        RENDER_FUNCTION: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       mixins: [listenOnRootMixin],
       created() {
         this.listenOnRoot('root-on', spyOn)
@@ -18,6 +23,7 @@ describe('mixins/listen-on-root', () => {
     }
 
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       components: { TestComponent },
       props: {
         destroy: {

--- a/src/mixins/listen-on-window.js
+++ b/src/mixins/listen-on-window.js
@@ -13,6 +13,10 @@ const PROP = '$_windowListeners'
 
 // @vue/component
 export const listenOnWindowMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+  },
   created() {
     // Define non-reactive property
     // Object of arrays, keyed by event name,

--- a/src/mixins/listen-on-window.js
+++ b/src/mixins/listen-on-window.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { IS_BROWSER } from '../constants/env'
 import { EVENT_OPTIONS_NO_CAPTURE } from '../constants/events'
 import { arrayIncludes } from '../utils/array'
@@ -12,7 +12,7 @@ const PROP = '$_windowListeners'
 // --- Mixin ---
 
 // @vue/component
-export const listenOnWindowMixin = Vue.extend({
+export const listenOnWindowMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     OPTIONS_BEFORE_DESTROY: 'suppress-warning'

--- a/src/mixins/listen-on-window.spec.js
+++ b/src/mixins/listen-on-window.spec.js
@@ -8,6 +8,11 @@ describe('mixins/listen-on-window', () => {
     const spyScroll = jest.fn()
 
     const TestComponent = {
+      compatConfig: {
+        MODE: 3,
+        RENDER_FUNCTION: 'suppress-warning',
+        OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+      },
       mixins: [listenOnWindowMixin],
       props: {
         offResizeOne: {
@@ -33,6 +38,7 @@ describe('mixins/listen-on-window', () => {
     }
 
     const App = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       components: { TestComponent },
       props: {
         offResizeOne: {

--- a/src/mixins/listeners.js
+++ b/src/mixins/listeners.js
@@ -1,3 +1,24 @@
 import { makePropCacheMixin } from '../utils/cache'
+import { Vue, isVue3 } from '../vue'
 
-export const listenersMixin = makePropCacheMixin('$listeners', 'bvListeners')
+const listenersMixinVue2 = makePropCacheMixin('$listeners', 'bvListeners')
+
+const listenersMixinVue3 = Vue.extend({
+  data() {
+    return {
+      bvListeners: {}
+    }
+  },
+  created() {
+    this.bvListeners = {
+      ...this.$listeners
+    }
+  },
+  beforeUpdate() {
+    this.bvListeners = {
+      ...this.$listeners
+    }
+  }
+})
+
+export const listenersMixin = isVue3 ? listenersMixinVue3 : listenersMixinVue2

--- a/src/mixins/listeners.js
+++ b/src/mixins/listeners.js
@@ -1,9 +1,9 @@
 import { makePropCacheMixin } from '../utils/cache'
-import { Vue, isVue3 } from '../vue'
+import { defineComponent, isVue3 } from '../vue'
 
 const listenersMixinVue2 = makePropCacheMixin('$listeners', 'bvListeners')
 
-const listenersMixinVue3 = Vue.extend({
+const listenersMixinVue3 = defineComponent({
   compatConfig: {
     MODE: 3,
     INSTANCE_LISTENERS: 'suppress-warning'

--- a/src/mixins/listeners.js
+++ b/src/mixins/listeners.js
@@ -4,6 +4,10 @@ import { Vue, isVue3 } from '../vue'
 const listenersMixinVue2 = makePropCacheMixin('$listeners', 'bvListeners')
 
 const listenersMixinVue3 = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_LISTENERS: 'suppress-warning'
+  },
   data() {
     return {
       bvListeners: {}

--- a/src/mixins/listeners.spec.js
+++ b/src/mixins/listeners.spec.js
@@ -1,3 +1,4 @@
+import { isVue3 } from '../vue'
 import { mount } from '@vue/test-utils'
 import { listenersMixin } from './listeners'
 
@@ -133,17 +134,41 @@ describe('mixins > listeners', () => {
     const App1 = {
       components: { Input1 },
       props: ['listenFocus1', 'listenFocus2'],
+      methods: {
+        emit1($event) {
+          if (this.listenFocus1) {
+            this.$emit('focus1', $event)
+          }
+        },
+        emit2($event) {
+          if (this.listenFocus2) {
+            this.$emit('focus2', $event)
+          }
+        }
+      },
       template: `<div>
-        <Input1 @focus="listenFocus1 ? $emit('focus1', $event) : () => {}" />
-        <Input1 @focus="listenFocus2 ? $emit('focus2', $event) : () => {}" />
+        <Input1 @focus="emit1" />
+        <Input1 @focus="emit2" />
       </div>`
     }
     const App2 = {
       components: { Input2 },
       props: ['listenFocus1', 'listenFocus2'],
+      methods: {
+        emit1($event) {
+          if (this.listenFocus1) {
+            this.$emit('focus1', $event)
+          }
+        },
+        emit2($event) {
+          if (this.listenFocus2) {
+            this.$emit('focus2', $event)
+          }
+        }
+      },
       template: `<div>
-        <Input2 @focus="listenFocus1 ? $emit('focus1', $event) : () => {}" />
-        <Input2 @focus="listenFocus2 ? $emit('focus2', $event) : () => {}" />
+        <Input2 @focus="emit1" />
+        <Input2 @focus="emit2" />
       </div>`
     }
 
@@ -172,7 +197,7 @@ describe('mixins > listeners', () => {
     expect(wrapper1.emitted().focus1).toBeTruthy()
     expect(wrapper1.emitted().focus2).not.toBeTruthy()
     // Both `Input1`'s are re-rendered (See: https://github.com/vuejs/vue/issues/7257)
-    expect(input1RenderCount).toBe(4)
+    expect(input1RenderCount).toBe(isVue3 ? 2 : 4)
 
     // Enable focus events for the second input and trigger it
     await wrapper1.setProps({ listenFocus2: true })
@@ -180,7 +205,7 @@ describe('mixins > listeners', () => {
     expect(wrapper1.emitted().focus1).toBeTruthy()
     expect(wrapper1.emitted().focus2).toBeTruthy()
     // Both `Input1`'s are re-rendered (See: https://github.com/vuejs/vue/issues/7257)
-    expect(input1RenderCount).toBe(6)
+    expect(input1RenderCount).toBe(isVue3 ? 2 : 6)
 
     // --- `Input2` tests ---
 

--- a/src/mixins/normalize-slot.js
+++ b/src/mixins/normalize-slot.js
@@ -5,6 +5,10 @@ import { concat } from '../utils/array'
 
 // @vue/component
 export const normalizeSlotMixin = Vue.extend({
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  },
   methods: {
     // Returns `true` if the either a `$scopedSlot` or `$slot` exists with the specified name
     // `name` can be a string name or an array of names

--- a/src/mixins/normalize-slot.js
+++ b/src/mixins/normalize-slot.js
@@ -1,10 +1,10 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { SLOT_NAME_DEFAULT } from '../constants/slots'
 import { hasNormalizedSlot, normalizeSlot } from '../utils/normalize-slot'
 import { concat } from '../utils/array'
 
 // @vue/component
-export const normalizeSlotMixin = Vue.extend({
+export const normalizeSlotMixin = defineComponent({
   compatConfig: {
     MODE: 3,
     INSTANCE_SCOPED_SLOTS: 'suppress-warning'

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -33,6 +33,7 @@ import { makeModelMixin } from '../utils/model'
 import { toInteger } from '../utils/number'
 import { sortKeys } from '../utils/object'
 import { hasPropFunction, makeProp, makePropsConfigurable } from '../utils/props'
+import { safeVueInstance } from '../utils/safe-vue-instance'
 import { toString } from '../utils/string'
 import { warn } from '../utils/warn'
 import { normalizeSlotMixin } from '../mixins/normalize-slot'
@@ -398,7 +399,7 @@ export const paginationMixin = Vue.extend({
       isNav,
       localNumberOfPages: numberOfPages,
       computedCurrentPage: currentPage
-    } = this
+    } = safeVueInstance(this)
     const pageNumbers = this.pageList.map(p => p.number)
     const { showFirstDots, showLastDots } = this.paginationParams
     const fill = this.align === 'fill'
@@ -426,7 +427,7 @@ export const paginationMixin = Vue.extend({
             type: isNav || isDisabled ? null : 'button',
             tabindex: isDisabled || isNav ? null : '-1',
             'aria-label': ariaLabel,
-            'aria-controls': this.ariaControls || null,
+            'aria-controls': safeVueInstance(this).ariaControls || null,
             'aria-disabled': isDisabled ? 'true' : null
           },
           on: isDisabled
@@ -491,7 +492,7 @@ export const paginationMixin = Vue.extend({
         role: isNav ? null : 'menuitemradio',
         type: isNav || disabled ? null : 'button',
         'aria-disabled': disabled ? 'true' : null,
-        'aria-controls': this.ariaControls || null,
+        'aria-controls': safeVueInstance(this).ariaControls || null,
         'aria-label': hasPropFunction(labelPage)
           ? /* istanbul ignore next */ labelPage(pageNumber)
           : `${isFunction(labelPage) ? labelPage() : labelPage} ${pageNumber}`,

--- a/src/mixins/pagination.js
+++ b/src/mixins/pagination.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { NAME_PAGINATION } from '../constants/components'
 import { CODE_DOWN, CODE_LEFT, CODE_RIGHT, CODE_SPACE, CODE_UP } from '../constants/key-codes'
 import {
@@ -148,7 +148,7 @@ export const props = makePropsConfigurable(
 // --- Mixin ---
 
 // @vue/component
-export const paginationMixin = Vue.extend({
+export const paginationMixin = defineComponent({
   mixins: [modelMixin, normalizeSlotMixin],
   props,
   data() {

--- a/src/mixins/scoped-style.js
+++ b/src/mixins/scoped-style.js
@@ -1,11 +1,13 @@
 import { Vue } from '../vue'
+import { useParentMixin } from '../mixins/use-parent'
 import { getScopeId } from '../utils/get-scope-id'
 
 // @vue/component
 export const scopedStyleMixin = Vue.extend({
+  mixins: [useParentMixin],
   computed: {
     scopedStyleAttrs() {
-      const scopeId = getScopeId(this.$parent)
+      const scopeId = getScopeId(this.bvParent)
       return scopeId ? { [scopeId]: '' } : {}
     }
   }

--- a/src/mixins/scoped-style.js
+++ b/src/mixins/scoped-style.js
@@ -1,9 +1,9 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { useParentMixin } from '../mixins/use-parent'
 import { getScopeId } from '../utils/get-scope-id'
 
 // @vue/component
-export const scopedStyleMixin = Vue.extend({
+export const scopedStyleMixin = defineComponent({
   mixins: [useParentMixin],
   computed: {
     scopedStyleAttrs() {

--- a/src/mixins/use-parent.js
+++ b/src/mixins/use-parent.js
@@ -1,0 +1,12 @@
+import { Vue } from '../vue'
+
+// --- Mixin ---
+
+// @vue/component
+export const useParentMixin = Vue.extend({
+  computed: {
+    bvParent() {
+      return this.$parent || (this.$root === this && this.$options.bvParent)
+    }
+  }
+})

--- a/src/mixins/use-parent.js
+++ b/src/mixins/use-parent.js
@@ -1,9 +1,9 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 
 // --- Mixin ---
 
 // @vue/component
-export const useParentMixin = Vue.extend({
+export const useParentMixin = defineComponent({
   computed: {
     bvParent() {
       return this.$parent || (this.$root === this && this.$options.bvParent)

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,4 +1,4 @@
-import { Vue, isVue3 } from '../vue'
+import { defineComponent, isVue3 } from '../vue'
 import { cloneDeep } from './clone-deep'
 import { looseEqual } from './loose-equal'
 import { hasOwnProperty, keys } from './object'
@@ -34,7 +34,7 @@ export const makePropWatcher = propName => ({
 })
 
 export const makePropCacheMixin = (propName, proxyPropName) =>
-  Vue.extend({
+  defineComponent({
     data() {
       return { [proxyPropName]: cloneDeep(this[propName]) }
     },

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { Vue, isVue3 } from '../vue'
 import { cloneDeep } from './clone-deep'
 import { looseEqual } from './loose-equal'
 import { hasOwnProperty, keys } from './object'
@@ -16,11 +16,19 @@ export const makePropWatcher = propName => ({
     }
     for (const key in oldValue) {
       if (!hasOwnProperty(newValue, key)) {
-        this.$delete(this.$data[propName], key)
+        if (isVue3) {
+          delete this.$data[propName][key]
+        } else {
+          this.$delete(this.$data[propName], key)
+        }
       }
     }
     for (const key in newValue) {
-      this.$set(this.$data[propName], key, newValue[key])
+      if (isVue3) {
+        this.$data[propName][key] = newValue[key]
+      } else {
+        this.$set(this.$data[propName], key, newValue[key])
+      }
     }
   }
 })

--- a/src/utils/config.spec.js
+++ b/src/utils/config.spec.js
@@ -1,4 +1,5 @@
 import { createLocalVue } from '@vue/test-utils'
+import { isVue3 } from '../../src/vue'
 import { BootstrapVue } from '../../src'
 import { AlertPlugin } from '../../src/components/alert'
 import { BVConfigPlugin } from '../../src/bv-config'
@@ -53,53 +54,56 @@ describe('utils/config', () => {
     expect(getConfig()).toEqual({})
   })
 
-  it('config via Vue.use(BootstrapVue) works', async () => {
-    const localVue = createLocalVue()
-    const config = {
-      BAlert: { variant: 'foobar' }
-    }
+  if (!isVue3) {
+    // We do not have complete localVue support, so resetting config does not work in proper way
+    it('config via Vue.use(BootstrapVue) works', async () => {
+      const localVue = createLocalVue()
+      const config = {
+        BAlert: { variant: 'foobar' }
+      }
 
-    expect(getConfig()).toEqual({})
+      expect(getConfig()).toEqual({})
 
-    localVue.use(BootstrapVue, config)
-    expect(getConfig()).toEqual(config)
+      localVue.use(BootstrapVue, config)
+      expect(getConfig()).toEqual(config)
 
-    // Reset the configuration
-    resetConfig()
-    expect(getConfig()).toEqual({})
-  })
+      // Reset the configuration
+      resetConfig()
+      expect(getConfig()).toEqual({})
+    })
 
-  it('config via Vue.use(ComponentPlugin) works', async () => {
-    const localVue = createLocalVue()
-    const config = {
-      BAlert: { variant: 'foobar' }
-    }
+    it('config via Vue.use(ComponentPlugin) works', async () => {
+      const localVue = createLocalVue()
+      const config = {
+        BAlert: { variant: 'foobar' }
+      }
 
-    expect(getConfig()).toEqual({})
+      expect(getConfig()).toEqual({})
 
-    localVue.use(AlertPlugin, config)
-    expect(getConfig()).toEqual(config)
+      localVue.use(AlertPlugin, config)
+      expect(getConfig()).toEqual(config)
 
-    // Reset the configuration
-    resetConfig()
-    expect(getConfig()).toEqual({})
-  })
+      // Reset the configuration
+      resetConfig()
+      expect(getConfig()).toEqual({})
+    })
 
-  it('config via Vue.use(BVConfig) works', async () => {
-    const localVue = createLocalVue()
-    const config = {
-      BAlert: { variant: 'foobar' }
-    }
+    it('config via Vue.use(BVConfig) works', async () => {
+      const localVue = createLocalVue()
+      const config = {
+        BAlert: { variant: 'foobar' }
+      }
 
-    expect(getConfig()).toEqual({})
+      expect(getConfig()).toEqual({})
 
-    localVue.use(BVConfigPlugin, config)
-    expect(getConfig()).toEqual(config)
+      localVue.use(BVConfigPlugin, config)
+      expect(getConfig()).toEqual(config)
 
-    // Reset the configuration
-    resetConfig()
-    expect(getConfig()).toEqual({})
-  })
+      // Reset the configuration
+      resetConfig()
+      expect(getConfig()).toEqual({})
+    })
+  }
 
   it('getConfigValue() works', async () => {
     const config = {

--- a/src/utils/create-new-child-component.js
+++ b/src/utils/create-new-child-component.js
@@ -1,0 +1,9 @@
+export const createNewChildComponent = (parent, Component, config = {}) => {
+  const bvEventRoot = parent.$root ? parent.$root.$options.bvEventRoot || parent.$root : null
+
+  return new Component({
+    ...config,
+    bvParent: parent,
+    bvEventRoot
+  })
+}

--- a/src/utils/get-event-root.js
+++ b/src/utils/get-event-root.js
@@ -1,0 +1,7 @@
+export const getEventRoot = vm => {
+  if (!vm.$root) {
+    return null
+  }
+
+  return vm.$root.$options.bvEventRoot || vm.$root
+}

--- a/src/utils/get-instance-from-directive.js
+++ b/src/utils/get-instance-from-directive.js
@@ -1,0 +1,4 @@
+import { isVue3 } from '../vue'
+
+export const getInstanceFromDirective = (vnode, bindings) =>
+  isVue3 ? bindings.instance : vnode.context

--- a/src/utils/get-instance-from-vnode.js
+++ b/src/utils/get-instance-from-vnode.js
@@ -1,0 +1,4 @@
+import { isVue3 } from '../vue'
+
+export const getInstanceFromVNode = vnode =>
+  isVue3 ? vnode.__vueParentComponent.ctx : vnode.__vue__

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -18,6 +18,10 @@ export const makeModelMixin = (
 
   // @vue/component
   const mixin = Vue.extend({
+    compatConfig: {
+      MODE: 3,
+      COMPONENT_V_MODEL: 'suppress-warning'
+    },
     model: {
       prop,
       event

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -1,4 +1,4 @@
-import { Vue } from '../vue'
+import { defineComponent } from '../vue'
 import { EVENT_NAME_INPUT } from '../constants/events'
 import { PROP_TYPE_ANY } from '../constants/props'
 import { makeProp } from './props'
@@ -17,7 +17,7 @@ export const makeModelMixin = (
   }
 
   // @vue/component
-  const mixin = Vue.extend({
+  const mixin = defineComponent({
     compatConfig: {
       MODE: 3,
       COMPONENT_V_MODEL: 'suppress-warning'

--- a/src/utils/props.spec.js
+++ b/src/utils/props.spec.js
@@ -91,6 +91,7 @@ describe('utils/props', () => {
       [NAME]: { text: 'bar' }
     }
     const ConfigurableComponent = {
+      compatConfig: { MODE: 3, RENDER_FUNCTION: 'suppress-warning' },
       name: NAME,
       props: makePropsConfigurable(props, NAME),
       render(h) {

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -2,6 +2,7 @@ import { RX_ENCODED_COMMA, RX_ENCODE_REVERSE, RX_PLUS, RX_QUERY_START } from '..
 import { isTag } from './dom'
 import { isArray, isNull, isPlainObject, isString, isUndefined } from './inspect'
 import { keys } from './object'
+import { safeVueInstance } from './safe-vue-instance'
 import { toString } from './string'
 
 const ANCHOR_TAG = 'a'
@@ -88,7 +89,8 @@ export const isLink = props => !!(props.href || props.to)
 export const isRouterLink = tag => !!(tag && !isTag(tag, 'a'))
 
 export const computeTag = ({ to, disabled, routerComponentName }, thisOrParent) => {
-  const hasRouter = !!thisOrParent.$router
+  const hasRouter = !!safeVueInstance(thisOrParent).$router
+  const hasNuxt = !!safeVueInstance(thisOrParent).$nuxt
   if (!hasRouter || (hasRouter && (disabled || !to))) {
     return ANCHOR_TAG
   }
@@ -101,7 +103,7 @@ export const computeTag = ({ to, disabled, routerComponentName }, thisOrParent) 
   //   exists = names.some(name => !!thisOrParent.$options.components[name])
   //   And may want to cache the result for performance or we just let the render fail
   //   if the component is not registered
-  return routerComponentName || (thisOrParent.$nuxt ? 'nuxt-link' : 'router-link')
+  return routerComponentName || (hasNuxt ? 'nuxt-link' : 'router-link')
 }
 
 export const computeRel = ({ target, rel } = {}) =>

--- a/src/utils/safe-vue-instance.js
+++ b/src/utils/safe-vue-instance.js
@@ -1,0 +1,13 @@
+import { isVue3 } from '../vue'
+
+export function safeVueInstance(target) {
+  if (!isVue3) {
+    return target
+  }
+
+  return new Proxy(target, {
+    get(target, prop) {
+      return prop in target ? target[prop] : undefined
+    }
+  })
+}

--- a/src/vue.js
+++ b/src/vue.js
@@ -2,7 +2,116 @@ import Vue from 'vue'
 import { mergeData } from 'vue-functional-data-merge'
 
 // --- Constants ---
-
 const COMPONENT_UID_KEY = '_uid'
 
-export { COMPONENT_UID_KEY, Vue, mergeData }
+const isVue3 = Vue.version.startsWith('3')
+
+const ALLOWED_FIELDS_IN_DATA = [
+  'class',
+  'staticClass',
+  'style',
+  'attrs',
+  'props',
+  'domProps',
+  'on',
+  'nativeOn',
+  'directives',
+  'scopedSlots',
+  'slot',
+  'key',
+  'ref',
+  'refInFor'
+]
+
+if (isVue3) {
+  const { extend: originalExtend } = Vue
+  const KNOWN_COMPONENTS = ['router-link', 'transition']
+  const originalVModelDynamicCreated = Vue.vModelDynamic.created
+  const originalVModelDynamicBeforeUpdate = Vue.vModelDynamic.beforeUpdate
+
+  // See https://github.com/vuejs/vue-next/pull/4121 for details
+  Vue.vModelDynamic.created = function(el, binding, vnode) {
+    originalVModelDynamicCreated.call(this, el, binding, vnode)
+    if (!el._assign) {
+      el._assign = () => {}
+    }
+  }
+  Vue.vModelDynamic.beforeUpdate = function(el, binding, vnode) {
+    originalVModelDynamicBeforeUpdate.call(this, el, binding, vnode)
+    if (!el._assign) {
+      el._assign = () => {}
+    }
+  }
+  Vue.extend = function(definition) {
+    if (typeof definition === 'object' && definition.render && !definition.__alreadyPatched) {
+      const originalRender = definition.render
+      definition.__alreadyPatched = true
+      definition.render = function(h) {
+        const patchedH = function(tag, dataObjOrChildren, ...rest) {
+          const isTag = typeof tag === 'string' && !KNOWN_COMPONENTS.includes(tag)
+          const isSecondArgumentDataObject =
+            dataObjOrChildren &&
+            typeof dataObjOrChildren === 'object' &&
+            !Array.isArray(dataObjOrChildren)
+
+          if (!isSecondArgumentDataObject) {
+            return h(tag, dataObjOrChildren, ...rest)
+          }
+
+          const { attrs, props, ...restData } = dataObjOrChildren
+          const normalizedData = {
+            ...restData,
+            attrs,
+            props: isTag ? {} : props
+          }
+          if (tag === 'router-link' && !normalizedData.slots && !normalizedData.scopedSlots) {
+            // terrible workaround to fix router-link rendering with compat vue-router
+            normalizedData.scopedSlots = { $hasNormal: () => {} }
+          }
+          return h(tag, normalizedData, ...rest)
+        }
+
+        if (definition.functional) {
+          const ctx = arguments[1]
+          const patchedCtx = { ...ctx }
+          patchedCtx.data = {
+            attrs: { ...(ctx.data.attrs || {}) },
+            props: { ...(ctx.data.props || {}) }
+          }
+          Object.keys(ctx.data || {}).forEach(key => {
+            if (ALLOWED_FIELDS_IN_DATA.includes(key)) {
+              patchedCtx.data[key] = ctx.data[key]
+            } else if (key in ctx.props) {
+              patchedCtx.data.props[key] = ctx.data[key]
+            } else if (!key.startsWith('on')) {
+              patchedCtx.data.attrs[key] = ctx.data[key]
+            }
+          })
+
+          const IGNORED_CHILDREN_KEYS = ['_ctx']
+          const children = ctx.children?.default?.() || ctx.children
+
+          if (
+            children &&
+            Object.keys(patchedCtx.children).filter(k => !IGNORED_CHILDREN_KEYS.includes(k))
+              .length === 0
+          ) {
+            delete patchedCtx.children
+          } else {
+            patchedCtx.children = children
+          }
+
+          patchedCtx.data.on = ctx.listeners
+          return originalRender.call(this, patchedH, patchedCtx)
+        }
+
+        return originalRender.call(this, patchedH)
+      }
+    }
+    return originalExtend.call(this, definition)
+  }
+}
+
+const nextTick = Vue.nextTick
+
+export { COMPONENT_UID_KEY, Vue, mergeData, isVue3, nextTick }

--- a/src/vue.js
+++ b/src/vue.js
@@ -23,9 +23,104 @@ const ALLOWED_FIELDS_IN_DATA = [
   'refInFor'
 ]
 
+function gatherCompatConfig(definition) {
+  const compatConfig = { ...(definition.compatConfig || {}) }
+  const mixinsCompatConfigDefinitions = (definition.mixins || []).map(
+    mixin => mixin.options.compatConfig || {}
+  )
+  const extendsCompatDefinition = definition.extends
+    ? gatherCompatConfig(definition.extends.options)
+    : {}
+
+  return Object.assign({}, ...mixinsCompatConfigDefinitions, extendsCompatDefinition, compatConfig)
+}
+
+const KNOWN_COMPONENTS = ['router-link', 'transition']
+function defineComponentCompat(definition) {
+  definition.compatConfig = {
+    MODE: 3,
+
+    // required for all files
+    RENDER_FUNCTION: 'suppress-warning',
+    INSTANCE_ATTRS_CLASS_STYLE: 'suppress-warning',
+    ATTR_FALSE_VALUE: 'suppress-warning',
+    COMPONENT_FUNCTIONAL: 'suppress-warning',
+
+    // required for patched-compat function below to work
+    INSTANCE_LISTENERS: 'suppress-warning',
+
+    ...gatherCompatConfig(definition)
+  }
+
+  const originalRender = definition.render
+  definition.__alreadyPatched = true
+  if (originalRender) {
+    definition.render = function(h) {
+      const patchedH = function(tag, dataObjOrChildren, ...rest) {
+        const isTag = typeof tag === 'string' && !KNOWN_COMPONENTS.includes(tag)
+        const isSecondArgumentDataObject =
+          dataObjOrChildren &&
+          typeof dataObjOrChildren === 'object' &&
+          !Array.isArray(dataObjOrChildren)
+
+        if (!isSecondArgumentDataObject) {
+          return h(tag, dataObjOrChildren, ...rest)
+        }
+
+        const { attrs, props, ...restData } = dataObjOrChildren
+        const normalizedData = {
+          ...restData,
+          attrs,
+          props: isTag ? {} : props
+        }
+        if (tag === 'router-link' && !normalizedData.slots && !normalizedData.scopedSlots) {
+          // terrible workaround to fix router-link rendering with compat vue-router
+          normalizedData.scopedSlots = { $hasNormal: () => {} }
+        }
+        return h(tag, normalizedData, ...rest)
+      }
+
+      if (definition.functional) {
+        const ctx = arguments[1]
+        const patchedCtx = { ...ctx }
+        patchedCtx.data = {
+          attrs: { ...(ctx.data.attrs || {}) },
+          props: { ...(ctx.data.props || {}) }
+        }
+        Object.keys(ctx.data || {}).forEach(key => {
+          if (ALLOWED_FIELDS_IN_DATA.includes(key)) {
+            patchedCtx.data[key] = ctx.data[key]
+          } else if (key in ctx.props) {
+            patchedCtx.data.props[key] = ctx.data[key]
+          } else if (!key.startsWith('on')) {
+            patchedCtx.data.attrs[key] = ctx.data[key]
+          }
+        })
+
+        const IGNORED_CHILDREN_KEYS = ['_ctx']
+        const children = ctx.children?.default?.() || ctx.children
+
+        if (
+          children &&
+          Object.keys(patchedCtx.children).filter(k => !IGNORED_CHILDREN_KEYS.includes(k))
+            .length === 0
+        ) {
+          delete patchedCtx.children
+        } else {
+          patchedCtx.children = children
+        }
+
+        patchedCtx.data.on = ctx.listeners
+        return originalRender.call(this, patchedH, patchedCtx)
+      }
+
+      return originalRender.call(this, patchedH)
+    }
+  }
+  return Vue.extend(definition)
+}
+
 if (isVue3) {
-  const { extend: originalExtend } = Vue
-  const KNOWN_COMPONENTS = ['router-link', 'transition']
   const originalVModelDynamicCreated = Vue.vModelDynamic.created
   const originalVModelDynamicBeforeUpdate = Vue.vModelDynamic.beforeUpdate
 
@@ -42,111 +137,9 @@ if (isVue3) {
       el._assign = () => {}
     }
   }
-
-  function gatherCompatConfig(definition) {
-    const compatConfig = { ...(definition.compatConfig || {}) }
-    const mixinsCompatConfigDefinitions = (definition.mixins || []).map(
-      mixin => mixin.options.compatConfig || {}
-    )
-    const extendsCompatDefinition = definition.extends
-      ? gatherCompatConfig(definition.extends.options)
-      : {}
-
-    return Object.assign(
-      {},
-      ...mixinsCompatConfigDefinitions,
-      extendsCompatDefinition,
-      compatConfig
-    )
-  }
-
-  Vue.extend = function(definition) {
-    if (typeof definition === 'object' && !definition.__alreadyPatched) {
-      definition.compatConfig = {
-        MODE: 3,
-
-        // required for all files
-        RENDER_FUNCTION: 'suppress-warning',
-        INSTANCE_ATTRS_CLASS_STYLE: 'suppress-warning',
-        ATTR_FALSE_VALUE: 'suppress-warning',
-        COMPONENT_FUNCTIONAL: 'suppress-warning',
-
-        // required for patched-compat function below to work
-        INSTANCE_LISTENERS: 'suppress-warning',
-
-        ...gatherCompatConfig(definition)
-      }
-
-      const originalRender = definition.render
-      definition.__alreadyPatched = true
-      if (originalRender) {
-        definition.render = function(h) {
-          const patchedH = function(tag, dataObjOrChildren, ...rest) {
-            const isTag = typeof tag === 'string' && !KNOWN_COMPONENTS.includes(tag)
-            const isSecondArgumentDataObject =
-              dataObjOrChildren &&
-              typeof dataObjOrChildren === 'object' &&
-              !Array.isArray(dataObjOrChildren)
-
-            if (!isSecondArgumentDataObject) {
-              return h(tag, dataObjOrChildren, ...rest)
-            }
-
-            const { attrs, props, ...restData } = dataObjOrChildren
-            const normalizedData = {
-              ...restData,
-              attrs,
-              props: isTag ? {} : props
-            }
-            if (tag === 'router-link' && !normalizedData.slots && !normalizedData.scopedSlots) {
-              // terrible workaround to fix router-link rendering with compat vue-router
-              normalizedData.scopedSlots = { $hasNormal: () => {} }
-            }
-            return h(tag, normalizedData, ...rest)
-          }
-
-          if (definition.functional) {
-            const ctx = arguments[1]
-            const patchedCtx = { ...ctx }
-            patchedCtx.data = {
-              attrs: { ...(ctx.data.attrs || {}) },
-              props: { ...(ctx.data.props || {}) }
-            }
-            Object.keys(ctx.data || {}).forEach(key => {
-              if (ALLOWED_FIELDS_IN_DATA.includes(key)) {
-                patchedCtx.data[key] = ctx.data[key]
-              } else if (key in ctx.props) {
-                patchedCtx.data.props[key] = ctx.data[key]
-              } else if (!key.startsWith('on')) {
-                patchedCtx.data.attrs[key] = ctx.data[key]
-              }
-            })
-
-            const IGNORED_CHILDREN_KEYS = ['_ctx']
-            const children = ctx.children?.default?.() || ctx.children
-
-            if (
-              children &&
-              Object.keys(patchedCtx.children).filter(k => !IGNORED_CHILDREN_KEYS.includes(k))
-                .length === 0
-            ) {
-              delete patchedCtx.children
-            } else {
-              patchedCtx.children = children
-            }
-
-            patchedCtx.data.on = ctx.listeners
-            return originalRender.call(this, patchedH, patchedCtx)
-          }
-
-          return originalRender.call(this, patchedH)
-        }
-      }
-    }
-    return originalExtend.call(this, definition)
-  }
 }
 
 const nextTick = Vue.nextTick
+const defineComponent = isVue3 ? defineComponentCompat : Vue.extend.bind(Vue)
 
-export { COMPONENT_UID_KEY, Vue, mergeData, isVue3, nextTick }
+export { COMPONENT_UID_KEY, Vue, mergeData, isVue3, nextTick, defineComponent }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,6 +1,18 @@
 import '@testing-library/jest-dom'
-import { config as vtuConfig } from '@vue/test-utils'
+import Vue from 'vue'
+import * as VTU from '@vue/test-utils'
+import { installCompat as installVTUCompat, fullCompatConfig } from 'vue-test-utils-compat'
+
+const useVue2 = 'USE_VUE2' in process.env
+if (!useVue2) {
+  Vue.configureCompat({
+    MODE: 2
+  })
+
+  const compatH = new Vue({}).$createElement
+  installVTUCompat(VTU, fullCompatConfig, compatH)
+}
 
 // Don't stub `<transition>` and `<transition-group>` components
-vtuConfig.stubs.transition = false
-vtuConfig.stubs['transition-group'] = false
+VTU.config.stubs.transition = false
+VTU.config.stubs['transition-group'] = false

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -6,10 +6,46 @@ import { installCompat as installVTUCompat, fullCompatConfig } from 'vue-test-ut
 const useVue2 = 'USE_VUE2' in process.env
 if (!useVue2) {
   Vue.configureCompat({
-    MODE: 2
+    MODE: 2,
+    ATTR_FALSE_VALUE: 'suppress-warning',
+    COMPONENT_FUNCTIONAL: 'suppress-warning',
+    COMPONENT_V_MODEL: 'suppress-warning',
+    CONFIG_OPTION_MERGE_STRATS: 'suppress-warning',
+    CONFIG_WHITESPACE: 'suppress-warning',
+    CUSTOM_DIR: 'suppress-warning',
+    GLOBAL_EXTEND: 'suppress-warning',
+    GLOBAL_MOUNT: 'suppress-warning',
+    GLOBAL_PRIVATE_UTIL: 'suppress-warning',
+    GLOBAL_PROTOTYPE: 'suppress-warning',
+    GLOBAL_SET: 'suppress-warning',
+    INSTANCE_ATTRS_CLASS_STYLE: 'suppress-warning',
+    INSTANCE_CHILDREN: 'suppress-warning',
+    INSTANCE_DELETE: 'suppress-warning',
+    INSTANCE_DESTROY: 'suppress-warning',
+    INSTANCE_EVENT_EMITTER: 'suppress-warning',
+    INSTANCE_EVENT_HOOKS: 'suppress-warning',
+    INSTANCE_LISTENERS: 'suppress-warning',
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning',
+    INSTANCE_SET: 'suppress-warning',
+    OPTIONS_BEFORE_DESTROY: 'suppress-warning',
+    OPTIONS_DATA_MERGE: 'suppress-warning',
+    OPTIONS_DESTROYED: 'suppress-warning',
+    RENDER_FUNCTION: 'suppress-warning',
+    V_FOR_REF: 'suppress-warning',
+    WATCH_ARRAY: 'suppress-warning'
   })
 
-  const compatH = new Vue({}).$createElement
+  let compatH
+  Vue.config.compilerOptions.whitespace = 'condense'
+  Vue.createApp({
+    compatConfig: {
+      MODE: 3,
+      RENDER_FUNCTION: 'suppress-warning'
+    },
+    render(h) {
+      compatH = h
+    }
+  }).mount(document.createElement('div'))
   installVTUCompat(VTU, fullCompatConfig, compatH)
 }
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,39 +1,69 @@
 import '@testing-library/jest-dom'
 import Vue from 'vue'
+import VueRouter from 'vue-router'
 import * as VTU from '@vue/test-utils'
 import { installCompat as installVTUCompat, fullCompatConfig } from 'vue-test-utils-compat'
 
 const useVue2 = 'USE_VUE2' in process.env
 if (!useVue2) {
   Vue.configureCompat({
-    MODE: 2,
-    ATTR_FALSE_VALUE: 'suppress-warning',
-    COMPONENT_FUNCTIONAL: 'suppress-warning',
-    COMPONENT_V_MODEL: 'suppress-warning',
+    MODE: 3,
+    // required by Vue-router
     CONFIG_OPTION_MERGE_STRATS: 'suppress-warning',
-    CONFIG_WHITESPACE: 'suppress-warning',
-    CUSTOM_DIR: 'suppress-warning',
-    GLOBAL_EXTEND: 'suppress-warning',
-    GLOBAL_MOUNT: 'suppress-warning',
     GLOBAL_PRIVATE_UTIL: 'suppress-warning',
     GLOBAL_PROTOTYPE: 'suppress-warning',
-    GLOBAL_SET: 'suppress-warning',
-    INSTANCE_ATTRS_CLASS_STYLE: 'suppress-warning',
-    INSTANCE_CHILDREN: 'suppress-warning',
-    INSTANCE_DELETE: 'suppress-warning',
-    INSTANCE_DESTROY: 'suppress-warning',
-    INSTANCE_EVENT_EMITTER: 'suppress-warning',
+
+    // required due to global mixin on vue-router
     INSTANCE_EVENT_HOOKS: 'suppress-warning',
-    INSTANCE_LISTENERS: 'suppress-warning',
-    INSTANCE_SCOPED_SLOTS: 'suppress-warning',
-    INSTANCE_SET: 'suppress-warning',
-    OPTIONS_BEFORE_DESTROY: 'suppress-warning',
-    OPTIONS_DATA_MERGE: 'suppress-warning',
     OPTIONS_DESTROYED: 'suppress-warning',
-    RENDER_FUNCTION: 'suppress-warning',
-    V_FOR_REF: 'suppress-warning',
-    WATCH_ARRAY: 'suppress-warning'
+    INSTANCE_EVENT_EMITTER: 'suppress-warning',
+
+    // required by portal-vue
+    GLOBAL_SET: 'suppress-warning',
+
+    // globals
+    GLOBAL_EXTEND: 'suppress-warning',
+    GLOBAL_MOUNT: 'suppress-warning'
   })
+
+  Vue.use(VueRouter)
+
+  Vue.component('RouterLink').compatConfig = {
+    MODE: 2,
+    RENDER_FUNCTION: 'suppress-warning',
+    INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+  }
+
+  Vue.component('RouterView').compatConfig = {
+    MODE: 2,
+    RENDER_FUNCTION: 'suppress-warning',
+    COMPONENT_FUNCTIONAL: 'suppress-warning'
+  }
+
+  const PortalVue = require('portal-vue')
+  PortalVue.Portal = PortalVue.Portal.extend({
+    compatConfig: {
+      MODE: 2,
+      RENDER_FUNCTION: 'suppress-warning',
+      INSTANCE_SCOPED_SLOTS: 'suppress-warning',
+      OPTIONS_BEFORE_DESTROY: 'suppress-warning'
+    }
+  })
+  PortalVue.PortalTarget = PortalVue.PortalTarget.extend({
+    compatConfig: {
+      MODE: 2,
+      RENDER_FUNCTION: 'suppress-warning',
+      WATCH_ARRAY: 'suppress-warning',
+      OPTIONS_BEFORE_DESTROY: 'suppress-warning',
+      INSTANCE_SCOPED_SLOTS: 'suppress-warning'
+    }
+  })
+
+  PortalVue.Wormhole.$.type.compatConfig = {
+    MODE: 3,
+    INSTANCE_SET: 'suppress-warning',
+    INSTANCE_DELETE: 'suppress-warning'
+  }
 
   let compatH
   Vue.config.compilerOptions.whitespace = 'condense'

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,13 +1,17 @@
 // --- Utils for testing ---
 
 export const wrapWithMethods = (Component, methods) => ({
+  compatConfig: {
+    MODE: 3,
+    INSTANCE_LISTENERS: false,
+    INSTANCE_SCOPED_SLOTS: false
+  },
   inheritAttrs: false,
   components: { wrappedComponent: Component },
   methods,
   template: `
-    <wrapped-component v-bind="$attrs" v-on="$listeners">
-      <slot v-for="(_, name) in $slots" :name="name" :slot="name" />
-      <template v-for="(_, name) in $scopedSlots" :slot="name" slot-scope="slotData"><slot :name="name" v-bind="slotData" /></template>
+    <wrapped-component v-bind="$attrs">
+      <template v-for="(_, name) in $slots" :slot="name" slot-scope="slotData"><slot :name="name" v-bind="slotData" /></template>
     </wrapped-component>
   `
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
   integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
@@ -42,7 +42,49 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
   integrity sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
 
-"@babel/core@^7.1.0", "@babel/core@^7.14.0", "@babel/core@^7.16.5", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.7.5":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.10.tgz#b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd"
+  integrity sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.10"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.5"
+    "@babel/parser" "^7.12.10"
+    "@babel/template" "^7.12.7"
+    "@babel/traverse" "^7.12.10"
+    "@babel/types" "^7.12.10"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.0.tgz#47299ff3ec8d111b493f1a9d04bf88c04e728d88"
+  integrity sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.14.0"
+    "@babel/helper-compilation-targets" "^7.13.16"
+    "@babel/helper-module-transforms" "^7.14.0"
+    "@babel/helpers" "^7.14.0"
+    "@babel/parser" "^7.14.0"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.14.0"
+    "@babel/types" "^7.14.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/core@^7.16.5":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.5.tgz#924aa9e1ae56e1e55f7184c8bf073a50d8677f5c"
   integrity sha512-wUcenlLzuWMZ9Zt8S0KmFwGlH6QKRh3vsm/dhDA3CHkiTA45YuG1XkHRcNRl73EFPXDp/d5kVOU0/y7x2w6OaQ==
@@ -61,6 +103,15 @@
     gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
     semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.12.10", "@babel/generator@^7.12.11", "@babel/generator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.0.tgz#d40f3d1d5075e62d3500bccb67f3daa8a95265b2"
+  integrity sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==
+  dependencies:
+    "@babel/types" "^7.16.0"
+    jsesc "^2.5.1"
     source-map "^0.5.0"
 
 "@babel/generator@^7.16.5":
@@ -159,6 +210,15 @@
   dependencies:
     "@babel/types" "^7.13.0"
 
+"@babel/helper-function-name@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz#1fd7738aee5dcf53c3ecff24f1da9c511ec47b42"
+  integrity sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.12.10"
+    "@babel/template" "^7.12.7"
+    "@babel/types" "^7.12.11"
+
 "@babel/helper-function-name@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
@@ -185,6 +245,13 @@
     "@babel/helper-get-function-arity" "^7.16.0"
     "@babel/template" "^7.16.0"
     "@babel/types" "^7.16.0"
+
+"@babel/helper-get-function-arity@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz#b158817a3165b5faa2047825dfa61970ddcc16cf"
+  integrity sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==
+  dependencies:
+    "@babel/types" "^7.12.10"
 
 "@babel/helper-get-function-arity@^7.12.13":
   version "7.12.13"
@@ -222,14 +289,64 @@
   dependencies:
     "@babel/types" "^7.13.12"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.13.12", "@babel/helper-module-imports@^7.16.0":
+"@babel/helper-member-expression-to-functions@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz#29287040efd197c77636ef75188e81da8bccd5a4"
+  integrity sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
+  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
+  dependencies:
+    "@babel/types" "^7.13.12"
+
+"@babel/helper-module-imports@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
+  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
+  dependencies:
+    "@babel/types" "^7.12.5"
+
+"@babel/helper-module-imports@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz#90538e60b672ecf1b448f5f4f5433d37e79a3ec3"
   integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.14.0", "@babel/helper-module-transforms@^7.14.2", "@babel/helper-module-transforms@^7.16.5":
+"@babel/helper-module-transforms@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
+  integrity sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/helper-replace-supers" "^7.12.1"
+    "@babel/helper-simple-access" "^7.12.1"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/helper-validator-identifier" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    lodash "^4.17.19"
+
+"@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz#8fcf78be220156f22633ee204ea81f73f826a8ad"
+  integrity sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.13.12"
+    "@babel/helper-replace-supers" "^7.13.12"
+    "@babel/helper-simple-access" "^7.13.12"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/helper-validator-identifier" "^7.14.0"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.14.0"
+    "@babel/types" "^7.14.0"
+
+"@babel/helper-module-transforms@^7.14.2", "@babel/helper-module-transforms@^7.16.5":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.5.tgz#530ebf6ea87b500f60840578515adda2af470a29"
   integrity sha512-CkvMxgV4ZyyioElFwcuWnDCcNIeyqTkCm9BxXZi73RR1ozqlpboqsbGUNvRTflgZtFbbJ1v5Emvm+lkjMYY/LQ==
@@ -250,7 +367,19 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.16.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+"@babel/helper-optimise-call-expression@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz#cecdb145d70c54096b1564f8e9f10cd7d193b338"
+  integrity sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
+  integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+
+"@babel/helper-plugin-utils@^7.16.5":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz#afe37a45f39fce44a3d50a7958129ea5b1a5c074"
   integrity sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==
@@ -264,6 +393,16 @@
     "@babel/helper-wrap-function" "^7.13.0"
     "@babel/types" "^7.13.0"
 
+"@babel/helper-replace-supers@^7.12.1":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz#73055e8d3cf9bcba8ddb55cad93fedc860f68f17"
+  integrity sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.16.0"
+    "@babel/helper-optimise-call-expression" "^7.16.0"
+    "@babel/traverse" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-replace-supers@^7.12.13", "@babel/helper-replace-supers@^7.13.12":
   version "7.13.12"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz#6442f4c1ad912502481a564a7386de0c77ff3804"
@@ -273,6 +412,13 @@
     "@babel/helper-optimise-call-expression" "^7.12.13"
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.12"
+
+"@babel/helper-simple-access@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
+  integrity sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
+  dependencies:
+    "@babel/types" "^7.12.1"
 
 "@babel/helper-simple-access@^7.13.12":
   version "7.13.12"
@@ -295,6 +441,13 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
+"@babel/helper-split-export-declaration@^7.11.0", "@babel/helper-split-export-declaration@^7.12.11", "@babel/helper-split-export-declaration@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz#29672f43663e936df370aaeb22beddb3baec7438"
+  integrity sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-split-export-declaration@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
@@ -302,14 +455,12 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
-"@babel/helper-split-export-declaration@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz#29672f43663e936df370aaeb22beddb3baec7438"
-  integrity sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
-  dependencies:
-    "@babel/types" "^7.16.0"
+"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
-"@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.0":
+"@babel/helper-validator-identifier@^7.14.0":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
   integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
@@ -339,6 +490,15 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
+"@babel/helpers@^7.12.5":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.16.0.tgz#875519c979c232f41adfbd43a3b0398c2e388183"
+  integrity sha512-dVRM0StFMdKlkt7cVcGgwD8UMaBfWJHl3A83Yfs8GQ3MO0LHIIIMvK7Fa0RGOGUQ10qikLaX6D7o5htcQWgTMQ==
+  dependencies:
+    "@babel/template" "^7.16.0"
+    "@babel/traverse" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
 "@babel/helpers@^7.16.5":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.16.5.tgz#29a052d4b827846dd76ece16f565b9634c554ebd"
@@ -366,10 +526,20 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.16.0", "@babel/parser@^7.16.5", "@babel/parser@^7.7.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.16.5", "@babel/parser@^7.7.0":
   version "7.16.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.6.tgz#8f194828193e8fa79166f34a4b4e52f3e769a314"
   integrity sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==
+
+"@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
+  integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
+
+"@babel/parser@^7.15.0", "@babel/parser@^7.16.0":
+  version "7.16.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.2.tgz#3723cd5c8d8773eef96ce57ea1d9b7faaccd12ac"
+  integrity sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -1012,7 +1182,25 @@
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.14.1.tgz#2c5f6908f03108583eea75bdcc94eb29e720fbac"
   integrity sha512-HFkwJyIv91mP38447ERwnVgw9yhx2/evs+r0+1hdAXf1Q1fBypPwtY8YOqsPniqoYCEVbBIqYELt0tNrOAg/Iw==
 
-"@babel/template@^7.12.13", "@babel/template@^7.16.0", "@babel/template@^7.3.3":
+"@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
+  integrity sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.12.7"
+    "@babel/types" "^7.12.7"
+
+"@babel/template@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
+  integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/parser" "^7.12.13"
+    "@babel/types" "^7.12.13"
+
+"@babel/template@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
   integrity sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
@@ -1021,7 +1209,51 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.13.15", "@babel/traverse@^7.16.5", "@babel/traverse@^7.7.0":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.10", "@babel/traverse@^7.7.0":
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.12.tgz#d0cd87892704edd8da002d674bc811ce64743376"
+  integrity sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==
+  dependencies:
+    "@babel/code-frame" "^7.12.11"
+    "@babel/generator" "^7.12.11"
+    "@babel/helper-function-name" "^7.12.11"
+    "@babel/helper-split-export-declaration" "^7.12.11"
+    "@babel/parser" "^7.12.11"
+    "@babel/types" "^7.12.12"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
+"@babel/traverse@^7.13.0", "@babel/traverse@^7.13.15":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.0.tgz#cea0dc8ae7e2b1dec65f512f39f3483e8cc95aef"
+  integrity sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.14.0"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.14.0"
+    "@babel/types" "^7.14.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.0.tgz#965df6c6bfc0a958c1e739284d3c9fa4a6e3c45b"
+  integrity sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    "@babel/generator" "^7.16.0"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-hoist-variables" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/parser" "^7.16.0"
+    "@babel/types" "^7.16.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.16.5":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.5.tgz#d7d400a8229c714a59b87624fc67b0f1fbd4b2b3"
   integrity sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==
@@ -1037,7 +1269,24 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.16", "@babel/types@^7.14.2", "@babel/types@^7.16.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
+  integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.16", "@babel/types@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.2.tgz#4208ae003107ef8a057ea8333e56eb64d2f6a2c3"
+  integrity sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
   integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
@@ -2141,16 +2390,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/strip-bom@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"
-  integrity sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=
-
-"@types/strip-json-comments@0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
-  integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
-
 "@types/tapable@^1", "@types/tapable@^1.0.5":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
@@ -2373,6 +2612,29 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.2.1"
     camelcase "^5.0.0"
 
+"@vue/compat@^3.2.24":
+  version "3.2.24"
+  resolved "https://registry.yarnpkg.com/@vue/compat/-/compat-3.2.24.tgz#6b10efb2773ccc8a59e625b4082bdc7cf2012549"
+  integrity sha512-fhnNc+SJ/hbhKZexVHVK+vZ0VstHm32VXgFEoiV1WWYNGRFJB5X7jbO/1a09IQgURiHwP0Km9jQQzN7/7sSbag==
+
+"@vue/compiler-core@3.2.24":
+  version "3.2.24"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.24.tgz#cadcda0e026e7f1cd453ce87160be51a5f313fe0"
+  integrity sha512-A0SxB2HAggKzP57LDin5gfgWOTwFyGCtQ5MTMNBADnfQYALWnYuC8kMI0DhRSplGTWRvn9Z2DAnG8f35BnojuA==
+  dependencies:
+    "@babel/parser" "^7.15.0"
+    "@vue/shared" "3.2.24"
+    estree-walker "^2.0.2"
+    source-map "^0.6.1"
+
+"@vue/compiler-dom@^3.2.24":
+  version "3.2.24"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.24.tgz#32235cb444660245be5cc58f4beb76747400505c"
+  integrity sha512-KQEm8r0JFsrNNIfbD28pcwMvHpcJcwjVR1XWFcD0yyQ8eREd7IXhT7J6j7iNCSE/TIo78NOvkwbyX+lnIm836w==
+  dependencies:
+    "@vue/compiler-core" "3.2.24"
+    "@vue/shared" "3.2.24"
+
 "@vue/component-compiler-utils@^3.1.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.2.0.tgz#8f85182ceed28e9b3c75313de669f83166d11e5d"
@@ -2388,6 +2650,16 @@
     vue-template-es2015-compiler "^1.9.0"
   optionalDependencies:
     prettier "^1.18.2"
+
+"@vue/shared@3.2.24":
+  version "3.2.24"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.24.tgz#d74615e856013b17fb60b19b09d712729ad5e090"
+  integrity sha512-BUgRiZCkCrqDps5aQ9av05xcge3rn092ztKIh17tHkeEFgP4zfXMQWBA2zfdoCdCEdBL26xtOv+FZYiOp9RUDA==
+
+"@vue/test-utils-vue3@npm:@vue/test-utils@^2.0.0":
+  version "2.0.0-rc.16"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.16.tgz#59380f02870f856ac002a29c02681d3f3fcbafeb"
+  integrity sha512-TubikDVkI2LuRKRPSLv3lYpbpvvucT2DIcGqfBVpvYs4W19u0EBTJEdmfwmSuLY7H1TyAr9Stur3PI1sWWvTGQ==
 
 "@vue/test-utils@^1.3.0":
   version "1.3.0"
@@ -3103,15 +3375,6 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-babel-code-frame@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
-
 babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
@@ -3152,13 +3415,6 @@ babel-loader@^8.2.2:
     loader-utils "^1.4.0"
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
-
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
-  dependencies:
-    babel-runtime "^6.22.0"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -3236,24 +3492,6 @@ babel-plugin-polyfill-regenerator@^0.3.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.0"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
-  version "6.26.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
-  integrity sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==
-  dependencies:
-    babel-plugin-transform-strict-mode "^6.24.1"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-types "^6.26.0"
-
-babel-plugin-transform-strict-mode@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
-  integrity sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -3279,55 +3517,6 @@ babel-preset-jest@^26.6.2:
   dependencies:
     babel-plugin-jest-hoist "^26.6.2"
     babel-preset-current-node-syntax "^1.0.0"
-
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-template@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    lodash "^4.17.4"
-
-babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.24.1, babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
-babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 bail@^1.0.0:
   version "1.0.5"
@@ -4189,11 +4378,6 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clone@2.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -4712,7 +4896,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.12.1.tgz#934da8b9b7221e2a2443dc71dfa5bd77a7ea00b8"
   integrity sha512-1cch+qads4JnDSWsvc7d6nzlKAippwjUlf6vykkTLW53VSV+NkE6muGBToAjEA8pG90cSfcud3JgVmW2ds5TaQ==
 
-core-js@^2.4.0, core-js@^2.6.5:
+core-js@^2.6.5:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
@@ -4966,16 +5150,6 @@ css.escape@^1.5.1:
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
-  dependencies:
-    inherits "^2.0.3"
-    source-map "^0.6.1"
-    source-map-resolve "^0.5.2"
-    urix "^0.1.0"
-
 css@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
@@ -5164,15 +5338,7 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
-deasync@^0.1.15:
-  version "0.1.21"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.21.tgz#bb11eabd4466c0d8776f0d82deb8a6126460d30f"
-  integrity sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==
-  dependencies:
-    bindings "^1.5.0"
-    node-addon-api "^1.7.1"
-
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -6046,6 +6212,11 @@ estree-walker@^0.6.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -6230,13 +6401,6 @@ extract-css-chunks-webpack-plugin@^4.9.0:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-extract-from-css@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/extract-from-css/-/extract-from-css-0.4.4.tgz#1ea7df2e7c7c6eb9922fa08e8adaea486f6f8f92"
-  integrity sha1-HqffLnx8brmSL6COitrqSG9vj5I=
-  dependencies:
-    css "^2.1.0"
-
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -6376,14 +6540,6 @@ finalhandler@1.1.2:
     parseurl "~1.3.3"
     statuses "~1.5.0"
     unpipe "~1.0.0"
-
-find-babel-config@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
-  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
-  dependencies:
-    json5 "^0.5.1"
-    path-exists "^3.0.0"
 
 find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
@@ -6658,7 +6814,7 @@ genfun@^4.0.1:
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-4.0.1.tgz#ed10041f2e4a7f1b0a38466d17a5c3e27df1dfc1"
   integrity sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=
 
-gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -6927,12 +7083,19 @@ globals@^13.6.0:
   dependencies:
     type-fest "^0.20.2"
 
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+globby@^11.0.0, globby@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
-globby@^11.0.0, globby@^11.0.1, globby@^11.0.3:
+globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
@@ -7701,13 +7864,6 @@ interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
-
-invariant@^2.2.2:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 ip@^1.1.4, ip@^1.1.5:
   version "1.1.5"
@@ -8652,7 +8808,7 @@ jiti@^1.9.2:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.9.2.tgz#2ee44830883dbb1b2e222adc053c3052d0bf3b61"
   integrity sha512-wymUBR/YGGVNVRAxX52yvFoZdUAYKEGjk0sYrz6gXLCvMblnRvJAmDUnMvQiH4tUHDBtbKHnZ4GT3R+m3Hc39A==
 
-js-beautify@^1.6.12, js-beautify@^1.6.14:
+js-beautify@^1.6.12:
   version "1.13.13"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.13.13.tgz#756907d1728f329f2b84c42efd56ad17514620bf"
   integrity sha512-oH+nc0U5mOAqX8M5JO1J0Pw/7Q35sAdOsM5W3i87pir9Ntx6P/5Gx1xLNoK+MGyvHk4rqqRCE4Oq58H6xl2W7A==
@@ -8663,15 +8819,10 @@ js-beautify@^1.6.12, js-beautify@^1.6.14:
     mkdirp "^1.0.4"
     nopt "^5.0.0"
 
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
 js-yaml@4.0.0:
   version "4.0.0"
@@ -8769,11 +8920,6 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
 json5@^1.0.1:
   version "1.0.1"
@@ -9132,7 +9278,12 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.15.0, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0:
+lodash@^4.15.0, lodash@^4.17.12, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.5:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9166,13 +9317,6 @@ longest-streak@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
-
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -9950,19 +10094,6 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
-
-node-addon-api@^1.7.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
-  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
-
-node-cache@^4.1.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.1.tgz#efd8474dee4edec4138cdded580f5516500f7334"
-  integrity sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==
-  dependencies:
-    clone "2.x"
-    lodash "^4.17.15"
 
 node-dir@^0.1.17:
   version "0.1.17"
@@ -12079,11 +12210,6 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
@@ -12685,7 +12811,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -13030,7 +13156,7 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
   integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
+source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
@@ -13464,15 +13590,15 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 style-resources-loader@^1.4.1:
   version "1.4.1"
@@ -13798,11 +13924,6 @@ to-buffer@^1.1.1:
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
   integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
 
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
-
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -13918,16 +14039,6 @@ tsconfig-paths@^3.11.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
-
-tsconfig@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-7.0.0.tgz#84538875a4dc216e5c4a5432b3a4dec3d54e91b7"
-  integrity sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==
-  dependencies:
-    "@types/strip-bom" "^3.0.0"
-    "@types/strip-json-comments" "0.0.30"
-    strip-bom "^3.0.0"
-    strip-json-comments "^2.0.0"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
@@ -14541,23 +14652,6 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-vue-jest@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-3.0.7.tgz#a6d29758a5cb4d750f5d1242212be39be4296a33"
-  integrity sha512-PIOxFM+wsBMry26ZpfBvUQ/DGH2hvp5khDQ1n51g3bN0TwFwTy4J85XVfxTRMukqHji/GnAoGUnlZ5Ao73K62w==
-  dependencies:
-    babel-plugin-transform-es2015-modules-commonjs "^6.26.0"
-    chalk "^2.1.0"
-    deasync "^0.1.15"
-    extract-from-css "^0.4.4"
-    find-babel-config "^1.1.0"
-    js-beautify "^1.6.14"
-    node-cache "^4.1.1"
-    object-assign "^4.1.1"
-    source-map "^0.5.6"
-    tsconfig "^7.0.0"
-    vue-template-es2015-compiler "^1.6.0"
-
 vue-loader@^15.9.7:
   version "15.9.7"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.7.tgz#15b05775c3e0c38407679393c2ce6df673b01044"
@@ -14616,10 +14710,15 @@ vue-template-compiler@^2.6.12:
     de-indent "^1.0.2"
     he "^1.1.0"
 
-vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
+vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+
+vue-test-utils-compat@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/vue-test-utils-compat/-/vue-test-utils-compat-0.0.3.tgz#d3efb08b049e97fc4577bdb1a93e417f546c2651"
+  integrity sha512-2zFkkcoirkp2FTrO7y2y4fZ9ZJ3WaoPoxwAZ7MmptlUhLchxbcay1KJ8t9qdJS1PHnu6aF98mD0Dn0jMQGoDGQ==
 
 vue@^2.6.12:
   version "2.6.12"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/200997/142714127-fc70a03d-f727-4c88-a627-90917963ff67.png)

# :question: What is it?
Version of Bootstrap-Vue which works for Vue 2 and Vue 3 (using `@vue/compat`)
Helps people with #5196 

[Demo using Vue 2](https://bootstrap-vue-3.netlify.app/vue2/)
[Demo using Vue 3](https://bootstrap-vue-3.netlify.app/vue3/)

Additionally, it passes all (well, almost all, tiny fraction of tests are disabled because they are irrelevant for vue 3) tests in the test suite (it would be literally impossible to do this migration without a test suite)

This package uses **vue 3 by default**. If you want to run tests, build, etc. using **vue 2** pass `USE_VUE2=1` environment variable

# :exclamation: How is this possible?

The heart of this PR consists of two parts:
* new [vue-test-utils-compat package](https://github.com/xanf/vue-test-utils-compat) which allows us to run old test suite using new Vue (it's like `@vue/compat` but for tests
* Additional [compatibility layer](https://github.com/xanf/bootstrap-vue/blob/vue3-compat-build/src/vue.js#L39-L121) for Vue3 crafted specifically for `bootstrap-vue`

# :wrench: How could I run it?

If you want just to play around - you can clone https://github.com/xanf/bootstrap-vue3-demo which has all required setup. If you want to try it on your own project, there is some setup required.

I'm skipping setup of `@vue/compat`, it is described in [migration guide](https://v3.vuejs.org/guide/migration/migration-build.html#preparations)

You will need to monkey patch your Vue 3 a bit somewhere early in your app: 
```js
  const originalVModelDynamicCreated = Vue.vModelDynamic.created;
  const originalVModelDynamicBeforeUpdate = Vue.vModelDynamic.beforeUpdate;
  Vue.vModelDynamic.created = function (el, binding, vnode) {
    originalVModelDynamicCreated.call(this, el, binding, vnode);
    if (!el._assign) {
      el._assign = () => {};
    }
  };
  Vue.vModelDynamic.beforeUpdate = function (el, binding, vnode) {
    originalVModelDynamicBeforeUpdate.call(this, el, binding, vnode);
    if (!el._assign) {
      el._assign = () => {};
    }
  };
```

See https://github.com/vuejs/vue-next/pull/4121 for details

If your intention is to run your app in `{ MODE: 2 }` (default @vue/compat) you're done. 
If you want to have `{ MODE: 3 }` (so all compats are disabled by default), additional setup is needed:

* if https://github.com/vuejs/vue-next/pull/4974 is not yet merged - you need to build `@vue/compat` build with this fix included. https://github.com/xanf/bootstrap-vue3-demo already has patch inside `patches` folder for that, installed by [patch-package](https://www.npmjs.com/package/patch-package)
* Certain compat flags required to be enabled globally ATM and can't be disabled in this release (which maintains Vue 2 and Vue 3 compatibility): 
  * `GLOBAL_EXTEND`, `GLOBAL_MOUNT` - for using `new Vue` inside `bootstrap-vue`
  * `COMPONENT_FUNCTIONAL`, `RENDER_FUNCTION` 
  * `CUSTOM_DIR` (anywhere where you use bootstrap-vue directive)

If you use `portal-vue` (which is still used for tooltips, etc.) you will need:
  * `GLOBAL_SET`

If you use old (for Vue 2) version of vue-router you will need:
  * `CONFIG_OPTION_MERGE_STRATS`
  * `GLOBAL_PRIVATE_UTIL`
  * `GLOBAL_PROTOTYPE`
  * `INSTANCE_EVENT_HOOKS`
  * `OPTIONS_DESTROYED`
  * `INSTANCE_EVENT_EMITTER`

# :bomb: What might not work

* Docs. I've tried to make `Nuxt` run using newer Nuxt 3, bridge, etc. but it was very problematic. So I wrote a script, which extracted demos from docs and generated https://github.com/xanf/bootstrap-vue3-demo with all demos
* Build. It might or might not work, I didn't have an opportunity to test it yet


# :arrow_upper_right: What's next?
Let's treat this one as "bridge" version
Based on this branch I will create another one, which will be focused solely on full vue 3 compatibility (without using @vue/compat). While this will definitely take time, right now I do not see any major obstacles in gradual migration

# :hugs: That's cool, how could I say "thank you"?
You're welcome, it's all about opensource. However, there are certain things, where your help will be appreciated:

* Help me spread the word about [vue-test-utils-compat](https://github.com/xanf/vue-test-utils-compat). You can [retweet me](https://twitter.com/xanf_ua/status/1461914150897164292) or just drop a link to your friend who could be interested
* Check deployed versions of https://github.com/xanf/bootstrap-vue3-demo (links inside) and report about any issues you find out in Vue 3 version (it is very time consuming to test all possible scenarios)


### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [x] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [x] Other: major update

**Does this PR introduce a breaking change?** (check one)

- [x] No (I know it's hard to believe)
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc.). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates
- [ ] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (required for new features and enhancements)
- [x] Existing test suites are passing
- [x] CodeCov for patch has met target (all changes/updates have been tested)
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
