### PR TITLE
fix(b-tooltip): Updated tooltip to work under shadowDOM

### DIFF
--- a/src/components/tooltip/helpers/bv-tooltip.js
+++ b/src/components/tooltip/helpers/bv-tooltip.js
@@ -29,8 +29,10 @@ import {
   contains,
   getAttr,
   getById,
+  getShadowRootOrRoot,
   hasAttr,
   hasClass,
+  isConnectedToDOM,
   isDisabled,
   isElement,
   isVisible,
@@ -262,7 +264,7 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
 
     this.$nextTick(() => {
       const target = this.getTarget()
-      if (target && contains(document.body, target)) {
+      if (target && (target.isConnected || isConnectedToDOM(target))) {
         // Copy the parent's scoped style attribute
         this.scopeId = getScopeId(this.$parent)
         // Set up all trigger handlers and listeners
@@ -420,7 +422,7 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
       const target = this.getTarget()
       if (
         !target ||
-        !contains(document.body, target) ||
+        !isConnectedToDOM(target) ||
         !isVisible(target) ||
         this.dropdownOpen() ||
         ((isUndefinedOrNull(this.title) || this.title === '') &&
@@ -567,8 +569,9 @@ export const BVTooltip = /*#__PURE__*/ Vue.extend({
     getContainer() {
       // Handle case where container may be a component ref
       const container = this.container ? this.container.$el || this.container : false
-      const body = document.body
       const target = this.getTarget()
+      const body = getShadowRootOrRoot(target)
+
       // If we are in a modal, we append to the modal, If we
       // are in a sidebar, we append to the sidebar, else append
       // to body, unless a container is specified

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -83,7 +83,7 @@ export const isActiveElement = el => isElement(el) && el === getActiveElement()
 
 // Determine if an HTML element is visible - Faster than CSS check
 export const isVisible = el => {
-  if (!isElement(el) || !el.parentNode || !contains(DOCUMENT.body, el)) {
+  if (!isElement(el) || !el.parentNode || !isConnectedToDOM(el)) {
     // Note this can fail for shadow dom elements since they
     // are not a direct descendant of document.body
     return false
@@ -98,6 +98,23 @@ export const isVisible = el => {
   // Except when we override the getBCR prototype in some tests
   const bcr = getBCR(el)
   return !!(bcr && bcr.height > 0 && bcr.width > 0)
+}
+
+// used to grab either the shadow root in a web component or the main document body
+export const getShadowRootOrRoot = el => {
+  if (el.getRootNode == null) {
+    return DOCUMENT.body
+  }
+  const root = el.getRootNode()
+  if (root.nodeType === 9) {
+    return root.body
+  }
+  return root
+}
+
+export const isConnectedToDOM = el => {
+  // If node.isConnected undefined then fallback to IE11 compliant check
+  return el.isConnected == null ? contains(DOCUMENT.body, el) : el.isConnected
 }
 
 // Determine if an element is disabled


### PR DESCRIPTION
### Describe the PR
Our company heavily uses web components to implement the micro-frontend architecture. Bootstrap-vue is heavily used in our application and we have thus far had to not use tooltips/popovers due to the shadow dom issue. After researching it internally for a while we realized a small adjustment to how the element is checked for DOM attachment and visibility would fix this issue. The "node.isConnected" property is widely supported by browsers and is ShadowDOM aware. The utility methods were created though due to specifically IE11 not supporting that property allowing us to be backward compatible. Wanted to contribute that back to the wider community.

Added to dom utility methods
- isConnectedToDOM() checks if a target element is in the DOM and will check both Shadow and Regular DOM
- getShadowRootOrRoot() will return the target's root either the Shadow Root or DOCUMENT.body

Updated isVisibile() dom util to use new isConnectedToDOM() function

Updated the dom.spec.js unit tests for the two new dom utilities
Fixed the dom.spec.js to get the select() and selectAll() tests working

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [ ] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc.). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates
- [ ] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [x] New/updated tests are included and passing (required for new features and enhancements)
- [x] Existing test suites are passing
- [ ] CodeCov for patch has met target (all changes/updates have been tested)
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
