### PR TITLE
fix(scss): invalid max-height CSS value, and SCSS selector typo

### DIFF
--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -12,7 +12,7 @@
   font-weight: 400;
   line-height: 1;
   max-width: 100%;
-  max-height: auto;
+  max-height: 100%;
   text-align: center;
   overflow: visible;
   position: relative;
@@ -82,7 +82,7 @@
   .b-avatar-img img {
     width: 100%;
     height: 100%;
-    max-height: auto;
+    max-height: 100%;
     border-radius: inherit;
     // This is not supported in IE11 and Edge <16
     // https://caniuse.com/object-fit

--- a/src/components/form-spinbutton/_spinbutton.scss
+++ b/src/components/form-spinbutton/_spinbutton.scss
@@ -43,7 +43,7 @@
   }
 
   &:not(.d-inline-flex):not(.flex-column) {
-    output: {
+    output {
       width: 100%;
     }
   }


### PR DESCRIPTION
### Describe the PR

We operate a site that must adhere to strict W3C Accessibility Standards.

When running one of our pages through the W3C Markup Validation Service to test Priority A compliance, our external auditor received the following CSS errors that could affect our accreditation:

- CSS: ```max-height: auto``` is not a ```max-height``` value. (appears twice)
- CSS: ```output-width```: Property ```output-width``` doesn't exist.

I've replaced ```max-height: auto``` with ```max-height: 100%``` and removed an incorrectly placed colon in the SCSS, as this spawns the invalid ```output-width``` property when it's transpiled into CSS.

A workaround for us currently is to host the SCSS files in our project, using XCOPY to copy the SCSS files from this repo, making the fixes there. This isn't ideal.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [ ] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [x] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc.). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [ ] Includes documentation updates
- [ ] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [ ] Includes any needed TypeScript declaration file updates
- [ ] New/updated tests are included and passing (required for new features and enhancements)
- [x] Existing test suites are passing
- [ ] CodeCov for patch has met target (all changes/updates have been tested)
- [x] The changes have not impacted the functionality of other components or directives
- [ ] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
