### PR TITLE
fix(b-button): add aria-disabled attribute when explicitly set

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -84,6 +84,8 @@ const computeAttrs = (props, data) => {
   const nonStandardTag = isNonStandardTag(props)
   const hashLink = link && props.href === '#'
   const role = data.attrs && data.attrs.role ? data.attrs.role : null
+  const ariaDisabled =
+    data.attrs && data.attrs['aria-disabled'] ? data.attrs['aria-disabled'] : null
   let tabindex = data.attrs ? data.attrs.tabindex : null
   if (nonStandardTag || hashLink) {
     tabindex = '0'
@@ -98,7 +100,7 @@ const computeAttrs = (props, data) => {
     // Except when link has `href` of `#`
     role: nonStandardTag || hashLink ? 'button' : role,
     // We set the `aria-disabled` state for non-standard tags
-    'aria-disabled': nonStandardTag ? String(props.disabled) : null,
+    'aria-disabled': nonStandardTag ? String(props.disabled) : ariaDisabled,
     // For toggles, we need to set the pressed state for ARIA
     'aria-pressed': toggle ? String(props.pressed) : null,
     // `autocomplete="off"` is needed in toggle mode to prevent some browsers

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -176,6 +176,18 @@ describe('button', () => {
     wrapper.destroy()
   })
 
+  it('button has aria-disabled attribute when explicitly set', () => {
+    const wrapper = mount(BButton, {
+      attrs: {
+        'aria-disabled': 'true'
+      }
+    })
+
+    expect(wrapper.attributes('aria-disabled')).toBe('true')
+
+    wrapper.destroy()
+  })
+
   it('link has attribute aria-disabled when disabled set', async () => {
     const wrapper = mount(BButton, {
       propsData: {


### PR DESCRIPTION
### Describe the PR

Discussed in https://github.com/bootstrap-vue/bootstrap-vue/discussions/6678

Currently it is not possible to explicitly set `aria-disabled` attribute on `b-button`, this PR fixes that bug.

### PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fixes a boo-boo in the code) - `fix(...)`, requires a patch version update
- [ ] Feature (adds a new feature to BootstrapVue) - `feat(...)`, requires a minor version update
- [ ] Enhancement (augments an existing feature) - `feat(...)`, requires a minor version update
- [ ] ARIA accessibility (fixes or improves ARIA accessibility) - `fix(...)`, requires a patch or minor version update
- [ ] Documentation update (improves documentation or typo fixes) - `chore(docs)`, requires a patch version update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe since breaking changes require a minor version update)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [-] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc.). **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type (patch or minor).**

**If new features/enhancement/fixes are added or changed:**

- [-] Includes documentation updates
- [-] Includes component package.json meta section updates (prop, slot and event changes/updates)
- [-] Includes any needed TypeScript declaration file updates
- [x] New/updated tests are included and passing (required for new features and enhancements)
- [x] Existing test suites are passing
- [ ] CodeCov for patch has met target (all changes/updates have been tested)
- [ ] The changes have not impacted the functionality of other components or directives
- [x] ARIA Accessibility has been taken into consideration (Does it affect screen reader users or keyboard only users? Clickable items should be in the tab index, etc.)

**If adding a new feature, or changing the functionality of an existing feature, the PR's
description above includes:**

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
